### PR TITLE
fix(hub): derived outputs follow the source's tier — recompute on tier move (#722)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-derived-outputs-tier.md
+++ b/docs/superpowers/plans/2026-07-17-derived-outputs-tier.md
@@ -1,0 +1,129 @@
+# Arc 9 — Derived Outputs Follow Tier Implementation Plan (#722)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Checkbox (`- [ ]`) steps.
+
+**Goal:** On a tier move, recompute the source record's derived outputs (MV rows, rollup contributions, `withDerivation` outputs) from the tier-aware cache — so an elevated source's plaintext no longer sits in tier-0 output collections; demote restores. Reuses the forget-fanout recompute. Owner chose RECOMPUTE (drop the contribution), reversible.
+
+**Architecture:** Spec — `docs/superpowers/specs/2026-07-17-derived-outputs-tier-design.md`. New `TiersContext.syncDerived` hook reusing `dispatchMaterializedViewsOnDelete`/`dispatchRollupsOnDelete`/`dispatchArrayDerivationsOnDelete` (remove, on elevate) and the local-write dispatchers (add, on demote). Recompute is tier-safe because the source scan reads the elevated-excluding cache.
+
+**Tech Stack:** TypeScript ESM, vitest. Branch `fix/722-derived-outputs-tier` off main b2b164e3.
+
+## Global Constraints
+
+- NEVER add Claude/Anthropic attribution; never reference the private pilot client — grep the diff.
+- Ceilings exact (checker = `wc -l` + 1): `collection.ts` **4549**, `vault.ts` 3959, `noydb.ts` 2396. The one `syncDerived` wiring line needs a mechanical shrink-join. Never edit ceiling values or check-architecture ratchets. `vault.ts`/`noydb.ts` untouched.
+- TDD: RED before implementing. Run from `packages/hub/`: `pnpm vitest run <path>`.
+- No new deps; no timing assertions. **Reuse the forget-fanout dispatchers — do NOT write a new recompute engine.**
+
+---
+
+### Task 1: `syncDerived` hook + recompute-as-remove on elevate
+
+**Files:**
+- Modify: `packages/hub/src/with-audit/tiers/index.ts` (`TiersContext.syncDerived` + call in `elevate`/`putAtTier(>0)`)
+- Modify: `packages/hub/src/kernel/collection.ts` (one wiring line; net-zero via shrink-join)
+- Create: `packages/hub/__tests__/tiers-derived.test.ts`
+
+**Interfaces:**
+- Produces: `TiersContext.syncDerived(id: string, record: T | null, elevated: boolean): Promise<void>` — `elevated` (landing tier > 0) → remove the source's derived outputs (reuse the onDelete fanout); else → add (Task 2). No-op fast when the collection has no MV/derivation source.
+- Consumes (all existing): `dispatchMaterializedViewsOnDelete(id)` (`collection.ts:2935`), `dispatchRollupsOnDelete(id, priorRecord)` (`~:2287`), `dispatchArrayDerivationsOnDelete(id, internal)` (`~:2888`); `this.materializedViewSource`/`this.derivationSource` (undefined → no derivations).
+- STUDY FIRST: `forgetDerivedFanout` (`kernel/via/dispatch.ts:305-361`) — it fans out per edge kind (`'mv'`/`'rollup'`/`'derivation'`) over `vault.graph.derivedArtifactsOf(collection)` and calls exactly those dispatchers. The elevate-remove path mirrors it (minus the `'ref'` cascade). Reuse its shape; the rollup path needs the pre-move record (the tier op already decodes it) as `priorRecord`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/hub/__tests__/tiers-derived.test.ts`. **No repo test combines tiers with MV/rollup/derivation — build the fixtures from scratch.** Grep working derivation tests (`grep -rln "withMaterializedView\|materializedViews:\|withRollup\|withDerivation" __tests__/`) for the real config of EACH kind, then make the SOURCE collection `tiers: [0,1]` + `perRecordKeys: true`. Cover the remove direction:
+
+```ts
+/**
+ * #722 — derived outputs must follow the source's tier. Elevating a source
+ * record must remove its contribution from every derived output (MV rows,
+ * rollup/aggregate values, derivation outputs) — those output rows live in
+ * tier-0 output collections and held the source's tier-0-era plaintext.
+ * Reuses the forget-fanout recompute; recompute reads the elevated-excluding
+ * cache so it drops the now-invisible source.
+ */
+describe('#722 elevate removes the source from derived outputs', () => {
+  it('record-grain MV: the elevated source’s output row vanishes; the output collection holds no source plaintext', async () => {
+    // source coll tiers:[0,1]+perRecordKeys feeding a record-grain MV (e.g. a filtered projection);
+    // put source 'a' and 'b'; assert the MV output collection has rows for both (with source fields);
+    await src.elevate('a', 1)
+    // assert: the MV output row derived from 'a' is GONE; 'b' remains; the output collection contains no 'a' plaintext.
+  })
+
+  it('aggregate MV: elevating a contributor drops it from the group aggregate', async () => {
+    // groupBy(dept).sum(salary); put two source records in the same group; assert the aggregate;
+    // elevate one; assert the aggregate DROPPED that contribution (owner-accepted inference channel).
+  })
+
+  it('rollup: elevating a child drops its contribution from the parent rollup field', async () => { /* … */ })
+
+  it('record/array withDerivation: the elevated source’s derived output is removed', async () => { /* … */ })
+
+  it('a sibling non-elevated source’s derived outputs are untouched', async () => { /* … */ })
+
+  it('a collection with NO derivations is unaffected (syncDerived is a fast no-op)', async () => { /* … */ })
+})
+```
+Fill each in fully against the REAL derivation APIs (grep first — do NOT invent). The assertion (the elevated source's plaintext/contribution is gone from the output collection; siblings intact) is what matters. If a RED doesn't reproduce (e.g. the output row didn't exist pre-elevate, or already excluded the source), STOP → BLOCKED with output — that would refute the leak premise for that kind.
+
+- [ ] **Step 2: RED** — post-elevate the output row / aggregate contribution / derivation output still reflects the elevated source.
+
+- [ ] **Step 3: Implement**
+
+(a) `TiersContext.syncDerived(id, record, elevated)` (spec doc comment). (b) Wire in `collection.ts` `tiersContext()` (beside `syncLedger`) to a helper that, for `elevated`, runs the remove-dispatchers for the source id (mirror `forgetDerivedFanout`'s per-edge dispatch, using the graph edges of THIS collection); guard `this.materializedViewSource !== undefined || this.derivationSource !== undefined` → else no-op. (c) `elevate` → `await ctx.syncDerived(id, <pre-move decoded record>, true)`; `putAtTier(tier > 0)` → same with `true`. Place after the live `adapter.put`. collection.ts must end at exactly **4548** — one shrink-join.
+
+- [ ] **Step 4: GREEN + regression** — the new file + the MV/rollup/derivation suites + `__tests__/hierarchical-tiers.test.ts`; `node scripts/check-architecture.mjs`; typecheck; lint.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/with-audit/tiers/index.ts packages/hub/src/kernel/collection.ts packages/hub/__tests__/tiers-derived.test.ts
+git commit -m "fix(hub): elevate removes the source from derived outputs (MV/rollup/derivation) (#722)"
+```
+
+---
+
+### Task 2: recompute-as-add on demote (reversibility) + the full matrix
+
+**Files:**
+- Modify: `packages/hub/src/with-audit/tiers/index.ts` (`syncDerived` add-branch + calls in `demote`/`putAtTier(0)`)
+- Modify: `packages/hub/__tests__/tiers-derived.test.ts` (append)
+
+**Interfaces:**
+- Consumes: the local-write dispatchers `dispatchMaterializedViews(id, record)` / `dispatchDerivations(id, record, version)` / the rollup add path (`collection.ts:3866-3876`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('#722 demote restores the source to derived outputs (reversible)', () => {
+  it('record-grain MV: demote re-creates the output row', async () => {
+    // elevate 'a' (row gone), then demote 'a' to 0; assert the MV output row for 'a' is BACK with its fields.
+  })
+  it('aggregate MV: demote restores the contribution to the group aggregate', async () => { /* … */ })
+  it('rollup + derivation: demote restores the contribution/output', async () => { /* … */ })
+  it('putAtTier(0) over an elevated record restores its derived outputs', async () => { /* … */ })
+  it('elevate → demote → elevate round-trips cleanly (outputs match the current tier each time)', async () => { /* … */ })
+})
+```
+
+- [ ] **Step 2: RED** — after demote, the output row/contribution is NOT restored (elevate removed it, demote doesn't re-add).
+
+- [ ] **Step 3: Implement** the add-branch of `syncDerived` (`elevated === false` → run the local-write dispatchers with the record). Wire `demote(→0)` → `await ctx.syncDerived(id, <decoded record>, false)`; `demote(→ intermediate >0)` → `true` (still removed); `putAtTier(0)` → `false`. Reuse demote's existing record decode (no double-decrypt). collection.ts untouched this task (Task 1 wired the callback).
+
+- [ ] **Step 4: GREEN + regression** — the new file + MV/rollup/derivation suites + `__tests__/hierarchical-tiers.test.ts` + the merged tier suites (`tier0-read-paths`, `history-at-rest`, `ledger-purge`, `tiers-search`, `tiers-indexing`); then the FULL hub suite from root; `node scripts/check-architecture.mjs`; typecheck; lint. Adjudicate any pre-existing test that changes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/with-audit/tiers/index.ts packages/hub/__tests__/tiers-derived.test.ts
+git commit -m "fix(hub): demote restores the source to derived outputs — reversible (#722)"
+```
+
+---
+
+### Final: full suite + whole-branch review + changeset + PR
+
+- [ ] `pnpm --filter @noy-db/hub test` + typecheck + lint + `pnpm check:architecture` — green.
+- [ ] Whole-branch review (fable — prove NO derived output retains an elevated source's plaintext/contribution on any path/kind; prove recompute doesn't RE-EMBED elevated plaintext (the source scan reads the elevated-excluding cache — verify); prove reversibility (demote restores) and round-trip stability; sweep for a derivation kind or dispatch edge the arc missed; confirm the aggregate-drop inference channel is the only new observable and is documented).
+- [ ] Local changeset: `@noy-db/hub` patch — elevating a record now removes its contribution from materialized-view rows, rollups, and derivation outputs (they held the source's plaintext at tier 0); demote restores. Document the aggregate-drop inference channel (an aggregate/rollup value changes observably when a contributor is elevated) as a known, accepted property (#722).
+- [ ] PR → main: `Closes #722`.

--- a/docs/superpowers/specs/2026-07-17-derived-outputs-tier-design.md
+++ b/docs/superpowers/specs/2026-07-17-derived-outputs-tier-design.md
@@ -1,0 +1,51 @@
+# Arc 9 — derived outputs follow their source's tier (#722)
+
+**Issue:** [#722](https://github.com/vLannaAi/noy-db/issues/722) · recon: task a80b4684. **Owner decision (2026-07-17): RECOMPUTE** (drop the elevated source's contribution), uniform for record- and aggregate-grain.
+**Predecessors:** the tier campaign through #729 + the Arc-7 guard. This is the third of three "full support" handlers.
+
+## The problem (recon reshaped #722's framing)
+
+Materialized-view rows, rollup contributions, and `withDerivation` outputs are computed from a source record and written to an **output collection** via a plain `put` — at **tier 0**, under the output collection's tier-0 DEK (`materialized-views/executor.ts:203-209`, `304-309`). `elevate()` rewraps only the *source* envelope; the derived row is a separate tier-0 record still holding the source's tier-0-era plaintext. So **elevating the source doesn't move the derived output** — any tier-0 caller reads the source-derived plaintext out of the output collection. No tier op recomputes (they `adapter.put` directly, never `_onRecordMutated('local-write')`, `tiers/index.ts`). `with-formula/` has zero tier awareness (grep-clean).
+
+**Corrections to #722's framing (from recon):**
+1. **The fix is RECOMPUTE, not purge** — `_materializedFrom` (`materialized-views/types.ts:28-46`) carries no source-record id, so output rows can't be targeted from a source id. `forget()`'s `forgetDerivedFanout` (#622, `via/dispatch.ts:305`) is already recompute-based — the analogue transplants.
+2. **Scope is wider than "MV + rollup"** — record/array `withDerivation` outputs (`derivations/executor.ts:157-189`) leak identically and are a distinct forget edge. This arc covers ALL record-grain derived artifacts.
+3. **Recompute is safe because the source scan is tier-aware:** MV/rollup recompute reads through the cache/`get()` which already exclude `_tier > 0` records (#701/#709/#712). So a recompute *after* elevate naturally omits the now-elevated source — it does not re-embed its plaintext (unlike the naive #721 search rebuild would have).
+
+## Decision: recompute derived outputs on every tier move
+
+**A derived output must reflect the source record's tier-0 visibility** — present when the source is at tier 0, absent (or contribution-dropped) when elevated. Because recompute reads the tier-aware cache, this is expressible as: *on any tier move, recompute the record's derived outputs from the current cache.* Unlike the ledger (#729, irreversible purge), this is **reversible** — the source's plaintext survives the elevate/demote rewrap round-trip, so demote re-adds it.
+
+| Move | Source tier-0 visibility | Derived output |
+|---|---|---|
+| `elevate`, `putAtTier(>0)` | source leaves tier 0 | **recompute-as-remove**: record-grain rows vanish; aggregate/rollup drops the contribution; derivation outputs removed |
+| `demote(→0)`, `putAtTier(0)` | source rejoins tier 0 | **recompute-as-add**: rows/contributions restored |
+| `demote(→ intermediate >0)` | still elevated | recompute-as-remove (still absent) |
+
+**Aggregate inference channel (owner-accepted):** for aggregate MV / rollups, recompute changes the aggregate value, so a tier-0 observer can infer "a record with ~this contribution was elevated" from the drop. Accepted as marginal (`_tier` changes are already store-visible metadata) — but **documented** in the changeset as a known property.
+
+## Design
+
+**Reuse the forget-fanout machinery** — no new engine. The remove path is exactly what `forgetDerivedFanout` runs per edge:
+- MV: `dispatchMaterializedViewsOnDelete(id)` (`collection.ts:2935`) → `executor.refresh` (recompute from cache + diff, `onEmpty:'delete'`) — direction-agnostic (makes the MV match the current tier-aware cache).
+- rollups: `dispatchRollupsOnDelete(id, priorRecord)` (`collection.ts:2287`) → recompute without the contribution.
+- array/record derivations: `dispatchArrayDerivationsOnDelete(id, internal)` (`collection.ts:2888`).
+The add path (demote) is the normal `dispatchMaterializedViews`/`dispatchDerivations`/`dispatchRollups` local-write dispatchers (`collection.ts:3866-3876`).
+
+**The hook.** `TiersContext.syncDerived(id, record, tierIsElevated): Promise<void>` (doc-commented, sixth `sync*` beside `syncLedger`), wired in `collection.ts` `tiersContext()` to a helper that:
+- `tierIsElevated` (landing tier > 0) → run the remove-dispatchers for `id` (reuse the onDelete fanout; `priorRecord` from the pre-move decode the tier op already has, for the rollup path);
+- else (landing at tier 0) → run the add-dispatchers with the record.
+Guarded by `this.materializedViewSource !== undefined || this.derivationSource !== undefined` (no-op when the collection has no derivations). Called by `elevate`/`demote`/`putAtTier` after the live `adapter.put`, in the same after-put block as the other sync hooks (ordering-independent w.r.t. them — it operates on OTHER collections' output rows, not this collection's cache/indexes).
+
+**Why this composes with the merged campaign.** The derived-output rows live in *output* collections whose reads are already tier-gated; the leak was that the *content* was source-derived plaintext at tier 0. Recompute removes/updates that content. It reuses the same tier-aware cache the read gates established, so no new tier logic enters `with-formula/`.
+
+## Constraints
+
+- Ceiling: `collection.ts` **4548** exact — the one `syncDerived` wiring line needs a mechanical shrink-join. `tiers/index.ts` / `with-formula/` have no ceiling. `vault.ts`/`noydb.ts` untouched.
+- Zero-knowledge: recompute reads through the enclave/cache path (already sanctioned); it resolves no tier DEK directly and writes output rows via the normal `put` (tier 0, as before — the point is they no longer contain elevated plaintext).
+- Reuse the forget-fanout dispatchers — do NOT write a new recompute engine.
+- **Coverage gap:** no test combines tiers with MV/rollup/derivation. Tests must cover: record-grain MV (elevate → the source's output row vanishes; the output collection holds no source plaintext; demote → row restored), aggregate MV (elevate → the group aggregate drops the elevated contribution; demote → restored), rollup (same), array/record derivation (output removed/restored), a sibling non-elevated source's outputs untouched, and a collection with NO derivations is unaffected (fast no-op).
+
+## Tests reference
+
+Grep existing MV/rollup/derivation tests (`__tests__/*materializ*`, `*rollup*`, `*deriv*`) for the real `withMaterializedView`/`withRollup`/`withDerivation` config + how to read an output collection + trigger a refresh, and `__tests__/hierarchical-tiers.test.ts` for tiers. Build a tiered SOURCE collection feeding each derivation kind; assert the OUTPUT collection's content before/after elevate + demote.

--- a/packages/hub/__tests__/tiers-derived.test.ts
+++ b/packages/hub/__tests__/tiers-derived.test.ts
@@ -249,3 +249,208 @@ describe('#722 elevate removes the source from derived outputs', () => {
     expect(await docs.getAtTier('d1')).toEqual({ id: 'd1', title: 'Public' })
   })
 })
+
+/**
+ * #722 Task 2 — demote (and putAtTier(0)) must RESTORE what elevate removed:
+ * the source's plaintext survives the elevate/demote rewrap round-trip, so
+ * its contribution can be re-added to every derived output. Reuses the
+ * ordinary local-write add-dispatchers (`dispatchDerivations`/
+ * `dispatchMaterializedViews`) — the same ones a plain `put()` fires.
+ */
+describe('#722 demote restores the source to derived outputs (reversible)', () => {
+  it('record-grain MV: demote re-creates the output row', async () => {
+    interface Invoice extends Record<string, unknown> { id: string; clientId: string; amount: number; status: 'open' | 'paid' }
+    const openInvoicesMV = withMaterializedView<Invoice>({
+      name: 'open-invoices',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      query: (db) => { (db as any).collection('invoices', { tiers: [0, 1], perRecordKeys: true }); return db.collection<Invoice>('invoices').query().where('status', '==', 'open') },
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-mv-demote-passphrase-2026',
+      tiersStrategy: withTiers(),
+      materializedViewStrategies: [openInvoicesMV],
+    })
+    const vault = await db.openVault('demo')
+    const invoices = vault.collection<Invoice>('invoices', { tiers: [0, 1], perRecordKeys: true })
+    const openMV = vault.collection<Invoice>('open-invoices')
+
+    await invoices.put('inv-a', { id: 'inv-a', clientId: 'acme', amount: 100, status: 'open' })
+    await invoices.elevate('inv-a', 1)
+    expect(await openMV.get('inv-a')).toBeNull()
+
+    await invoices.demote('inv-a', 0)
+
+    expect((await openMV.get('inv-a'))?.amount).toBe(100)
+    expect((await openMV.get('inv-a'))?.status).toBe('open')
+  })
+
+  it('aggregate MV: demote restores the contribution to the group aggregate', async () => {
+    interface Compensation extends Record<string, unknown> { id: string; clientId: string; taxAmount: number }
+    interface ClientTotalRow extends Record<string, unknown> { clientId: string; taxTotal: number }
+    const mv = withMaterializedView<ClientTotalRow>({
+      name: 'client-totals',
+      sources: ['compensations'],
+      query: (db) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(db as any).collection('compensations', { tiers: [0, 1], perRecordKeys: true })
+        return db.collection<Compensation>('compensations')
+          .query()
+          .groupBy('clientId')
+          .aggregate({ taxTotal: sum('taxAmount') }) as GroupedAggregation<ClientTotalRow>
+      },
+      rowKey: (r) => r.clientId,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-aggregate-demote-passphrase-2026',
+      tiersStrategy: withTiers(),
+      aggregateStrategy: withAggregate(),
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('demo')
+    const compensations = vault.collection<Compensation>('compensations', { tiers: [0, 1], perRecordKeys: true })
+    const totals = vault.collection<ClientTotalRow>('client-totals')
+
+    await compensations.put('c1', { id: 'c1', clientId: 'acme', taxAmount: 100 })
+    await compensations.put('c2', { id: 'c2', clientId: 'acme', taxAmount: 50 })
+    await compensations.elevate('c1', 1)
+    expect((await totals.get('acme'))?.taxTotal).toBe(50)
+
+    await compensations.demote('c1', 0)
+
+    expect((await totals.get('acme'))?.taxTotal).toBe(150)
+  })
+
+  it('rollup + derivation: demote restores the contribution/output', async () => {
+    interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number }
+    interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const rollupDb = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-rollup-demote-passphrase-2026',
+      tiersStrategy: withTiers(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const rollupVault = await rollupDb.openVault('firm')
+    const buyers = rollupVault.collection<Buyer>('buyers')
+    const sales = rollupVault.collection<Sale>('sales', { tiers: [0, 1], perRecordKeys: true })
+
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    await sales.elevate('s1', 1)
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200)
+
+    await sales.demote('s1', 0)
+
+    expect((await buyers.get('b1'))?.totalSpent).toBe(300)
+
+    interface Worker extends Record<string, unknown> { id: string; clientId: string; period: string; baseSalary: number }
+    interface ActivePeriod extends Record<string, unknown> { id: string; workerId: string; period: string }
+    const derivationStrategy = withDerivation<Worker, { activeInPeriod: ActivePeriod[] }>({
+      source: 'workers',
+      deterministic: true,
+      outputs: {
+        activeInPeriod: {
+          shape: 'array',
+          collection: 'workerActiveInPeriod',
+          key: (o) => `${o.workerId as string}|${o.period as string}`,
+        },
+      },
+      derive: (worker) => ({
+        activeInPeriod: [{ id: `${worker.id}|${worker.period}`, workerId: worker.id, period: worker.period }],
+      }),
+      lifecycle: 'eager',
+    })
+    const derivationDb = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-array-demote-passphrase-2026',
+      tiersStrategy: withTiers(),
+      derivationStrategies: [derivationStrategy],
+    })
+    const derivationVault = await derivationDb.openVault('acme')
+    const workers = derivationVault.collection<Worker>('workers', { tiers: [0, 1], perRecordKeys: true })
+    const activePeriods = derivationVault.collection<ActivePeriod>('workerActiveInPeriod')
+
+    await workers.put('w1', { id: 'w1', clientId: 'cl-A', period: '2026-03', baseSalary: 30000 })
+    await workers.elevate('w1', 1)
+    expect(await activePeriods.get('w1|2026-03')).toBeNull()
+
+    await workers.demote('w1', 0)
+
+    expect(await activePeriods.get('w1|2026-03')).not.toBeNull()
+  })
+
+  it('putAtTier(0) over an elevated record restores its derived outputs', async () => {
+    interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number }
+    interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-putattier0-passphrase-2026',
+      tiersStrategy: withTiers(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const vault = await db.openVault('firm')
+    const buyers = vault.collection<Buyer>('buyers')
+    const sales = vault.collection<Sale>('sales', { tiers: [0, 1], perRecordKeys: true })
+
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    await sales.elevate('s1', 1)
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200)
+
+    await sales.putAtTier('s1', { id: 's1', buyerId: 'b1', total: 100 }, 0)
+
+    expect((await buyers.get('b1'))?.totalSpent).toBe(300)
+  })
+
+  it('elevate → demote → elevate round-trips cleanly (outputs match the current tier each time)', async () => {
+    interface Invoice extends Record<string, unknown> { id: string; clientId: string; amount: number; status: 'open' | 'paid' }
+    const openInvoicesMV = withMaterializedView<Invoice>({
+      name: 'open-invoices',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      query: (db) => { (db as any).collection('invoices', { tiers: [0, 1], perRecordKeys: true }); return db.collection<Invoice>('invoices').query().where('status', '==', 'open') },
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-roundtrip-passphrase-2026',
+      tiersStrategy: withTiers(),
+      materializedViewStrategies: [openInvoicesMV],
+    })
+    const vault = await db.openVault('demo')
+    const invoices = vault.collection<Invoice>('invoices', { tiers: [0, 1], perRecordKeys: true })
+    const openMV = vault.collection<Invoice>('open-invoices')
+
+    await invoices.put('inv-a', { id: 'inv-a', clientId: 'acme', amount: 100, status: 'open' })
+    expect((await openMV.get('inv-a'))?.amount).toBe(100)
+
+    await invoices.elevate('inv-a', 1)
+    expect(await openMV.get('inv-a')).toBeNull()
+
+    await invoices.demote('inv-a', 0)
+    expect((await openMV.get('inv-a'))?.amount).toBe(100)
+
+    await invoices.elevate('inv-a', 1)
+    expect(await openMV.get('inv-a')).toBeNull()
+  })
+})

--- a/packages/hub/__tests__/tiers-derived.test.ts
+++ b/packages/hub/__tests__/tiers-derived.test.ts
@@ -536,3 +536,147 @@ describe('#722 review fix: syncDerived pre-move decode is gated by hasDerivedOut
     expect((await buyers.get('b1'))?.totalSpent).toBe(0)
   })
 })
+
+/**
+ * Whole-branch review (Arc 9, #722): the pre-move decode the three tier ops
+ * added to feed `syncDerived`'s remove path (`ctx.codec.decryptRecord(...,
+ * { sealedAsHandles: true })`) is TIER-UNAWARE — it resolves the CEK via the
+ * cekCache or falls back to `ctx.codec`'s DEFAULT (tier-0/collection) DEK,
+ * never `envelope._tier`. That only "works" when the SAME op's own
+ * `rewrapBodyToDek` call already primed the cekCache with THIS record's CEK
+ * (the ordinary put()-then-elevate(0→1) shape every existing test uses). A
+ * `putAtTier`-origin record (body encrypted directly under its tier DEK, no
+ * `_cek` ever minted) or a non-`perRecordKeys` collection has nothing to
+ * prime the cache with, and a from-tier>0 read throws `TamperedError`
+ * instead of a `TierNotGrantedError`/similar expected failure — a CRITICAL
+ * regression: the throw lands AFTER `adapter.put`, so the tier move itself
+ * already landed (half-applied op).
+ */
+describe('#722 whole-branch review: pre-move decode must be tier-aware (not just cekCache-primed)', () => {
+  it('putAtTier-origin record: elevate() from a from-tier>0 read does not throw (no _cek was ever minted to prime the cache)', async () => {
+    interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number }
+    interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-review-putattier-elevate-passphrase-2026',
+      tiersStrategy: withTiers(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const vault = await db.openVault('firm')
+    const buyers = vault.collection<Buyer>('buyers')
+    const sales = vault.collection<Sale>('sales', { tiers: [0, 1, 2], perRecordKeys: true })
+
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    // s1 is born directly at tier 1 — putAtTier mints no `_cek`, so nothing
+    // primes the cekCache for the elevate() below.
+    await sales.putAtTier('s1', { id: 's1', buyerId: 'b1', total: 100 }, 1)
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200) // s1 never contributed (born above tier 0)
+
+    await expect(sales.elevate('s1', 2)).resolves.toBeUndefined()
+
+    // s1 stays excluded — no crash, no double-count, no corruption of the
+    // sibling's contribution.
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200)
+  })
+
+  it('non-perRecordKeys collection: elevate() from a from-tier>0 read does not throw (no `_cek` exists at all)', async () => {
+    interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number }
+    interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-review-nonperrecord-elevate-passphrase-2026',
+      tiersStrategy: withTiers(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const vault = await db.openVault('firm')
+    const buyers = vault.collection<Buyer>('buyers')
+    // NON-perRecordKeys: body always decrypts directly under the tier DEK,
+    // never a per-record CEK.
+    const sales = vault.collection<Sale>('sales', { tiers: [0, 1, 2] })
+
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    await sales.putAtTier('s1', { id: 's1', buyerId: 'b1', total: 100 }, 1)
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200)
+
+    await expect(sales.elevate('s1', 2)).resolves.toBeUndefined()
+
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200)
+  })
+
+  it('putAtTier over an existing tier-1 record does not throw', async () => {
+    interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number }
+    interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-review-putattier-over-existing-passphrase-2026',
+      tiersStrategy: withTiers(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const vault = await db.openVault('firm')
+    const buyers = vault.collection<Buyer>('buyers')
+    const sales = vault.collection<Sale>('sales', { tiers: [0, 1, 2], perRecordKeys: true })
+
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    // Establish s1 at tier 1 directly (no `_cek`).
+    await sales.putAtTier('s1', { id: 's1', buyerId: 'b1', total: 100 }, 1)
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200)
+
+    // putAtTier's OWN pre-write decode of the pre-existing tier-1 envelope
+    // is the buggy site under test here.
+    await expect(sales.putAtTier('s1', { id: 's1', buyerId: 'b1', total: 150 }, 2)).resolves.toBeUndefined()
+
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200)
+  })
+
+  it('demote() to an intermediate tier > 0 does not throw', async () => {
+    interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number }
+    interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-review-demote-intermediate-passphrase-2026',
+      tiersStrategy: withTiers(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const vault = await db.openVault('firm')
+    const buyers = vault.collection<Buyer>('buyers')
+    // NON-perRecordKeys, so the record's body carries no `_cek` at any tier.
+    const sales = vault.collection<Sale>('sales', { tiers: [0, 1, 2] })
+
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    // Born directly at tier 2 (first write — no pre-write decode needed here).
+    await sales.putAtTier('s1', { id: 's1', buyerId: 'b1', total: 100 }, 2)
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200)
+
+    // demote() to an INTERMEDIATE tier (still > 0) is the buggy site: it
+    // must decrypt the fromTier(=2) envelope, not the collection's
+    // default (tier-0) DEK.
+    await expect(sales.demote('s1', 1)).resolves.toBeUndefined()
+
+    // s1 stays elevated (tier 1 > 0) — still excluded from the rollup.
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200)
+  })
+})

--- a/packages/hub/__tests__/tiers-derived.test.ts
+++ b/packages/hub/__tests__/tiers-derived.test.ts
@@ -1,0 +1,251 @@
+/**
+ * #722 — derived outputs must follow the source's tier. Elevating a source
+ * record must remove its contribution from every derived output (MV rows,
+ * rollup/aggregate values, derivation outputs) — those output rows live in
+ * tier-0 output collections and held the source's tier-0-era plaintext.
+ * Reuses the forget-fanout recompute; recompute reads the elevated-excluding
+ * cache so it drops the now-invisible source.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView, withRollup, withDerivation, ConflictError, type GroupedAggregation } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withAggregate } from '../src/with-lookup/aggregate/index.js'
+import { sum } from '../src/with-lookup/aggregate/reducers.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+describe('#722 elevate removes the source from derived outputs', () => {
+  it('record-grain MV: the elevated source’s output row vanishes; the output collection holds no source plaintext', async () => {
+    interface Invoice extends Record<string, unknown> { id: string; clientId: string; amount: number; status: 'open' | 'paid' }
+    const openInvoicesMV = withMaterializedView<Invoice>({
+      name: 'open-invoices',
+      // The MV's query callback runs at REGISTRATION time (inside
+      // `openVault`) and its `db.collection(name)` call is what FIRST
+      // constructs + caches the source collection — a later
+      // `vault.collection('invoices', { tiers: ... })` call is a no-op
+      // (first-construction wins). So the tiered options must be supplied
+      // HERE, on this first construction; the untyped call below is
+      // side-effect-only (cache warm), the typed call just re-reads it.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      query: (db) => { (db as any).collection('invoices', { tiers: [0, 1], perRecordKeys: true }); return db.collection<Invoice>('invoices').query().where('status', '==', 'open') },
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-mv-passphrase-2026',
+      tiersStrategy: withTiers(),
+      materializedViewStrategies: [openInvoicesMV],
+    })
+    const vault = await db.openVault('demo')
+    const invoices = vault.collection<Invoice>('invoices', { tiers: [0, 1], perRecordKeys: true })
+    const openMV = vault.collection<Invoice>('open-invoices')
+
+    await invoices.put('inv-a', { id: 'inv-a', clientId: 'acme', amount: 100, status: 'open' })
+    await invoices.put('inv-b', { id: 'inv-b', clientId: 'acme', amount: 50, status: 'open' })
+
+    expect((await openMV.get('inv-a'))?.amount).toBe(100)
+    expect((await openMV.get('inv-b'))?.amount).toBe(50)
+
+    await invoices.elevate('inv-a', 1)
+
+    expect(await openMV.get('inv-a')).toBeNull()
+    expect((await openMV.get('inv-b'))?.amount).toBe(50)
+
+    // No source plaintext remains — the output row itself is gone.
+    const store = (db as unknown as { options: { store: NoydbStore } }).options.store
+    expect(await store.get('demo', 'open-invoices', 'inv-a')).toBeNull()
+  })
+
+  it('aggregate MV: elevating a contributor drops it from the group aggregate', async () => {
+    interface Compensation extends Record<string, unknown> { id: string; clientId: string; taxAmount: number }
+    interface ClientTotalRow extends Record<string, unknown> { clientId: string; taxTotal: number }
+    const mv = withMaterializedView<ClientTotalRow>({
+      name: 'client-totals',
+      sources: ['compensations'],
+      // See the record-grain MV test above: tiered options must be supplied
+      // on the FIRST `collection()` call the query callback makes (which
+      // happens at registration time, before the test can reach it).
+      query: (db) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(db as any).collection('compensations', { tiers: [0, 1], perRecordKeys: true })
+        return db.collection<Compensation>('compensations')
+          .query()
+          .groupBy('clientId')
+          .aggregate({ taxTotal: sum('taxAmount') }) as GroupedAggregation<ClientTotalRow>
+      },
+      rowKey: (r) => r.clientId,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-aggregate-passphrase-2026',
+      tiersStrategy: withTiers(),
+      aggregateStrategy: withAggregate(),
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('demo')
+    const compensations = vault.collection<Compensation>('compensations', { tiers: [0, 1], perRecordKeys: true })
+    const totals = vault.collection<ClientTotalRow>('client-totals')
+
+    await compensations.put('c1', { id: 'c1', clientId: 'acme', taxAmount: 100 })
+    await compensations.put('c2', { id: 'c2', clientId: 'acme', taxAmount: 50 })
+    expect((await totals.get('acme'))?.taxTotal).toBe(150)
+
+    await compensations.elevate('c1', 1)
+
+    // The aggregate drops the elevated contributor's amount (owner-accepted
+    // inference channel — see the arc's design doc).
+    expect((await totals.get('acme'))?.taxTotal).toBe(50)
+  })
+
+  it('rollup: elevating a child drops its contribution from the parent rollup field', async () => {
+    interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number }
+    interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-rollup-passphrase-2026',
+      tiersStrategy: withTiers(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const vault = await db.openVault('firm')
+    const buyers = vault.collection<Buyer>('buyers')
+    const sales = vault.collection<Sale>('sales', { tiers: [0, 1], perRecordKeys: true })
+
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(300)
+
+    await sales.elevate('s1', 1)
+
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200)
+  })
+
+  it('record/array withDerivation: the elevated source’s derived output is removed', async () => {
+    interface Worker extends Record<string, unknown> { id: string; clientId: string; period: string; baseSalary: number }
+    interface ActivePeriod extends Record<string, unknown> { id: string; workerId: string; period: string }
+    const strategy = withDerivation<Worker, { activeInPeriod: ActivePeriod[] }>({
+      source: 'workers',
+      deterministic: true,
+      outputs: {
+        activeInPeriod: {
+          shape: 'array',
+          collection: 'workerActiveInPeriod',
+          key: (o) => `${o.workerId as string}|${o.period as string}`,
+        },
+      },
+      derive: (worker) => ({
+        activeInPeriod: [{ id: `${worker.id}|${worker.period}`, workerId: worker.id, period: worker.period }],
+      }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-array-passphrase-2026',
+      tiersStrategy: withTiers(),
+      derivationStrategies: [strategy],
+    })
+    const vault = await db.openVault('acme')
+    const workers = vault.collection<Worker>('workers', { tiers: [0, 1], perRecordKeys: true })
+    const activePeriods = vault.collection<ActivePeriod>('workerActiveInPeriod')
+
+    await workers.put('w1', { id: 'w1', clientId: 'cl-A', period: '2026-03', baseSalary: 30000 })
+    expect(await activePeriods.get('w1|2026-03')).not.toBeNull()
+
+    await workers.elevate('w1', 1)
+
+    expect(await activePeriods.get('w1|2026-03')).toBeNull()
+  })
+
+  it('a sibling non-elevated source’s derived outputs are untouched', async () => {
+    interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number }
+    interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-sibling-passphrase-2026',
+      tiersStrategy: withTiers(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const vault = await db.openVault('firm')
+    const buyers = vault.collection<Buyer>('buyers')
+    const sales = vault.collection<Sale>('sales', { tiers: [0, 1], perRecordKeys: true })
+
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await buyers.put('b2', { id: 'b2', companyName: 'Beta' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b2', total: 75 })
+
+    await sales.elevate('s1', 1)
+
+    expect((await buyers.get('b1'))?.totalSpent).toBe(0)
+    expect((await buyers.get('b2'))?.totalSpent).toBe(75) // sibling untouched
+  })
+
+  it('a collection with NO derivations is unaffected (syncDerived is a fast no-op)', async () => {
+    interface Doc extends Record<string, unknown> { id: string; title: string }
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-noop-passphrase-2026',
+      tiersStrategy: withTiers(),
+    })
+    const vault = await db.openVault('demo')
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1], perRecordKeys: true })
+
+    await docs.put('d1', { id: 'd1', title: 'Public' })
+
+    await expect(docs.elevate('d1', 1)).resolves.toBeUndefined()
+    expect(await docs.getAtTier('d1')).toEqual({ id: 'd1', title: 'Public' })
+  })
+})

--- a/packages/hub/__tests__/tiers-derived.test.ts
+++ b/packages/hub/__tests__/tiers-derived.test.ts
@@ -6,7 +6,7 @@
  * Reuses the forget-fanout recompute; recompute reads the elevated-excluding
  * cache so it drops the now-invisible source.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { createNoydb, withMaterializedView, withRollup, withDerivation, ConflictError, type GroupedAggregation } from '../src/index.js'
 import { withTiers } from '../src/with-audit/tiers/index.js'
 import { withAggregate } from '../src/with-lookup/aggregate/index.js'
@@ -452,5 +452,87 @@ describe('#722 demote restores the source to derived outputs (reversible)', () =
 
     await invoices.elevate('inv-a', 1)
     expect(await openMV.get('inv-a')).toBeNull()
+  })
+})
+
+/**
+ * Review finding (Arc 9, #722): the tier ops decoded the record body to feed
+ * `syncDerived` UNCONDITIONALLY, even for collections with no MV/derivation
+ * source attached — the dispatchers self-guard, but only AFTER the expensive
+ * `decryptRecord` already ran. `elevate()` never decrypted the body before
+ * this arc (it only re-keyed the ciphertext). Fixed by gating the pre-move
+ * decode behind `TiersContext.hasDerivedOutputs`. This locks the guard by
+ * counting the underlying `crypto.subtle.decrypt` calls a rewrap makes:
+ * `rewrapBodyToDek` always makes exactly one (the body re-key, required
+ * regardless of derivations); a collection WITH a derivation/MV source makes
+ * exactly one MORE (the gated `syncDerived` decode) — a collection with NONE
+ * must not.
+ */
+describe('#722 review fix: syncDerived pre-move decode is gated by hasDerivedOutputs', () => {
+  it('elevate() on a vault with NO derivation/MV registries performs zero extra record-body decrypts vs an otherwise-identical elevate on a vault WITH one', async () => {
+    interface Doc extends Record<string, unknown> { id: string; title: string }
+    interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number }
+    interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+
+    // `hasDerivedOutputs` is computed per-collection from the VAULT's
+    // derivation/MV registry presence (`this.derivationSource !==
+    // undefined || this.materializedViewSource !== undefined` —
+    // `tiersContext()`), not from whether this specific collection is a
+    // registered source — so the two elevates must run against two
+    // SEPARATE vaults (one with no derivation strategy configured at all,
+    // one with) to observe the gate.
+    const plainDb = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-decode-guard-plain-passphrase-2026',
+      tiersStrategy: withTiers(),
+    })
+    const plainVault = await plainDb.openVault('demo')
+    const docs = plainVault.collection<Doc>('docs', { tiers: [0, 1], perRecordKeys: true })
+
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const derivedDb = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-derived-decode-guard-derived-passphrase-2026',
+      tiersStrategy: withTiers(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const derivedVault = await derivedDb.openVault('demo')
+    const buyers = derivedVault.collection<Buyer>('buyers')
+    // Same shape as `docs` (tiered, per-record-key) so its elevate() rewrap
+    // makes the SAME one decrypt call as `docs`'s, plus the gated decode.
+    const sales = derivedVault.collection<Sale>('sales', { tiers: [0, 1], perRecordKeys: true })
+
+    await docs.put('d1', { id: 'd1', title: 'Public' })
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+
+    const decryptSpy = vi.spyOn(crypto.subtle, 'decrypt')
+
+    const before1 = decryptSpy.mock.calls.length
+    await docs.elevate('d1', 1)
+    const noDerivationDecryptCalls = decryptSpy.mock.calls.length - before1
+
+    const before2 = decryptSpy.mock.calls.length
+    await sales.elevate('s1', 1)
+    const withDerivationDecryptCalls = decryptSpy.mock.calls.length - before2
+
+    decryptSpy.mockRestore()
+
+    // Both elevates perform the identical body rewrap (one decrypt). `sales`
+    // (its vault has a derivation registry) additionally pays the
+    // syncDerived pre-move decode; `docs` (its vault has none) must not —
+    // this is the whole point of the `hasDerivedOutputs` gate.
+    expect(noDerivationDecryptCalls).toBeGreaterThan(0) // sanity: the rewrap itself still decrypts
+    expect(withDerivationDecryptCalls - noDerivationDecryptCalls).toBe(1)
+
+    // Behavior is unchanged either way: both moves still land at tier 1 and
+    // the rollup on the derivation-vault side still reflects the removal.
+    expect(await docs.getAtTier('d1')).toEqual({ id: 'd1', title: 'Public' })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(0)
   })
 })

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -28,7 +28,7 @@ import {
 import { countLiveEnvelopes } from './lazy-count.js'
 import { liveRecordIsElevated, assertTierWritable } from './tier-visibility.js'
 import {
-  classifySealedShred as classifySealedShredImpl,
+  classifySealedShred as classifySealedShredImpl, syncDerivedOutputs,
   type TiersContext,
 } from '../with-audit/tiers/index.js'
 import type { TiersStrategy } from '../with-audit/tiers/strategy.js'
@@ -4496,9 +4496,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     if (patch.presentForJoin) this.presentForJoin = patch.presentForJoin
   }
   /**
-   * Bind the {@link TiersContext} the tier ops need. The `cekCache` is passed
-   * by reference (the SAME `Lru` the kernel's read/write path owns) so an
-   * elevate/demote CEK re-wrap stays synchronous with cache eviction.
+   * Bind the {@link TiersContext} the tier ops need — `cekCache` by reference
+   * (same `Lru` the read/write path owns) for a synchronous re-wrap; `syncDerived` closes over `this` for {@link syncDerivedOutputs} (#722).
    */
   private tiersContext(): TiersContext<T> {
     return {
@@ -4513,6 +4512,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       syncSearch: (id: string, rec: T | null, version?: number) => syncTierSearchImpl(this.searchContext(), id, rec, version),
       syncHistory: async (id: string, fromDek: EnclaveKey, toDek: EnclaveKey) => this.historyStrategy.rewrapHistory(this.adapter, this.vault, this.name, id, fromDek, toDek, await this.getDEK(this.name)),
       syncLedger: async (id: string) => { await this.ledger?.purgeRecordDeltas(this.name, id) },
+      syncDerived: (id: string, record: T | null, elevated: boolean) => syncDerivedOutputs(this, id, record, elevated),
       provenance: this.provenance,
       tiers: this.tiers,
       tierMode: this.tierMode,

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -4513,6 +4513,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       syncHistory: async (id: string, fromDek: EnclaveKey, toDek: EnclaveKey) => this.historyStrategy.rewrapHistory(this.adapter, this.vault, this.name, id, fromDek, toDek, await this.getDEK(this.name)),
       syncLedger: async (id: string) => { await this.ledger?.purgeRecordDeltas(this.name, id) },
       syncDerived: (id: string, record: T | null, elevated: boolean, version?: number) => syncDerivedOutputs(this, id, record, elevated, version),
+      hasDerivedOutputs: this.materializedViewSource !== undefined || this.derivationSource !== undefined,
       provenance: this.provenance,
       tiers: this.tiers,
       tierMode: this.tierMode,
@@ -4525,8 +4526,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    * Bind the {@link IndexingContext} the index-maintenance surface needs. The
    * eager `cache` Map and the index / unique-constraint / persisted mirrors are
    * passed by reference (the SAME instances the query path reads, never
-   * copied); the `persistedIndexesLoaded` flag and `ensure*` hydration stay
-   * collection-resident, reached via callbacks.
+   * copied); the `persistedIndexesLoaded` flag and `ensure*` hydration stay collection-resident, reached via callbacks.
    */
   private indexingContext(): IndexingContext<T> {
     return {

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -4512,7 +4512,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       syncSearch: (id: string, rec: T | null, version?: number) => syncTierSearchImpl(this.searchContext(), id, rec, version),
       syncHistory: async (id: string, fromDek: EnclaveKey, toDek: EnclaveKey) => this.historyStrategy.rewrapHistory(this.adapter, this.vault, this.name, id, fromDek, toDek, await this.getDEK(this.name)),
       syncLedger: async (id: string) => { await this.ledger?.purgeRecordDeltas(this.name, id) },
-      syncDerived: (id: string, record: T | null, elevated: boolean) => syncDerivedOutputs(this, id, record, elevated),
+      syncDerived: (id: string, record: T | null, elevated: boolean, version?: number) => syncDerivedOutputs(this, id, record, elevated, version),
       provenance: this.provenance,
       tiers: this.tiers,
       tierMode: this.tierMode,

--- a/packages/hub/src/kernel/enclave/record-keys/record-codec.ts
+++ b/packages/hub/src/kernel/enclave/record-keys/record-codec.ts
@@ -724,6 +724,49 @@ export class RecordCodec<T> {
   }
 
   /**
+   * Decrypt an envelope under an EXPLICIT `dek` instead of this codec's own
+   * `ctx.getDEK()` / cekCache resolution — for a from-tier>0 pre-move decode
+   * (`with-audit/tiers/index.ts`'s `putAtTier`/`elevate`/`demote` sites,
+   * #722 whole-branch review). Mirrors the manual unwrap-then-decrypt
+   * `getAtTier`'s own tier>0 leg performs there (same primitives, same
+   * `applySealedSlots` extraction point #635 built for exactly this caller).
+   *
+   * `decryptRecord` is tier-UNAWARE: `resolveEnvelopeCek` reads the cekCache
+   * or falls back to `ctx.getDEK()` — this codec's DEFAULT (tier-0/
+   * collection) DEK — never the envelope's OWN tier. That only happens to
+   * decrypt a from-tier>0 envelope correctly when some other call in the
+   * SAME op already primed the cekCache with this record's CEK (true for an
+   * ordinary put()-then-elevate(0→1); NOT true for a `putAtTier`-origin
+   * envelope, whose body is encrypted directly under its tier DEK with no
+   * `_cek` ever minted, or a non-`perRecordKeys` collection, which has no
+   * `_cek` at all) — those throw `TamperedError`. Decrypting under the
+   * caller-resolved `dek` is correct regardless of cache state or
+   * `perRecordKeys`.
+   *
+   * No CRDT resolution, no schema validation — same scope as `getAtTier`'s
+   * tier>0 branch (the established precedent for a tier-aware read), which
+   * skips both for the same reason: a tier>0 read is an internal/derived-
+   * output-recompute path, not the public per-record read surface schema
+   * validation guards.
+   */
+  async decryptRecordAtDek(envelope: EncryptedEnvelope, dek: EnclaveKey, id?: string): Promise<T | null> {
+    if (isTombstone(envelope, this.ctx.storeCiphertext) || isDeleteMarker(envelope)) return null
+    let plaintext: string
+    let cek: EnclaveKey | undefined
+    if (envelope._cek !== undefined) {
+      cek = await unwrapCek(envelope._cek, dek)
+      plaintext = await decrypt(envelope._iv, envelope._data, cek)
+    } else {
+      plaintext = await decrypt(envelope._iv, envelope._data, dek)
+    }
+    let record = JSON.parse(plaintext) as T
+    if (envelope._sealed !== undefined && this.ctx.storeCiphertext) {
+      record = await this.applySealedSlots(record, envelope._sealed, cek, { ...(id !== undefined ? { id } : {}), sealedAsHandles: true })
+    }
+    return record
+  }
+
+  /**
    * Decrypt an envelope into a record of type `T`.
    *
    * When a schema is attached, the decrypted value is validated before

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -156,6 +156,18 @@ export interface TiersContext<T> {
    * below checks its own source before doing any work.
    */
   syncDerived(id: string, record: T | null, elevated: boolean, version?: number): Promise<void>
+  /**
+   * `true` iff the collection has a materialized-view or derivation source
+   * attached. Gates the {@link syncDerived} pre-move decode on the remove
+   * direction (`elevate()`, `putAtTier(tier>0)`, `demote()`'s intermediate-
+   * tier branch): those sites decode the record SOLELY to feed
+   * `syncDerived(..., true)`, whose dispatchers no-op immediately when the
+   * collection has no MV/derivation source — so a no-derivation collection
+   * would otherwise pay a full record-body decrypt on every tier move for
+   * nothing (#722 perf regression). `false` short-circuits the decode to
+   * `null`, which `syncDerivedOutputs` already treats safely.
+   */
+  readonly hasDerivedOutputs: boolean
   /** Emit `_source`/`_sourceTs` provenance fields when a source is supplied. */
   readonly provenance: boolean
   /** Declared tiers, or null when the feature is off. */
@@ -308,8 +320,10 @@ export async function putAtTier<T>(
     await ctx.syncLedger(id)
     // #722: recompute this record's derived outputs now that it left tier 0
     // — same law as elevate() below. `existing` is the PRE-write envelope;
-    // decode it only here (the rollup edge is the only consumer).
-    await ctx.syncDerived(id, existing ? await ctx.codec.decryptRecord(existing, { id, sealedAsHandles: true }) : null, true)
+    // decode it only here (the rollup edge is the only consumer). Gated by
+    // `hasDerivedOutputs` — no-derivation collections skip this decrypt
+    // entirely (perf regression review finding, Arc 9 #722).
+    await ctx.syncDerived(id, ctx.hasDerivedOutputs && existing ? await ctx.codec.decryptRecord(existing, { id, sealedAsHandles: true }) : null, true)
   } else {
     const rec = await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
     await ctx.syncIndexes(id, rec, envelope._v)
@@ -516,8 +530,10 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   // #722: recompute this record's derived outputs now that it left tier 0 —
   // same law as putAtTier(tier>0) above. `envelope` is the PRE-move envelope
   // (captured before the rewrap), decoded only here (the rollup edge is the
-  // only consumer of the record content).
-  await ctx.syncDerived(id, await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true }), true)
+  // only consumer of the record content). Gated by `hasDerivedOutputs` — no-
+  // derivation collections skip this decrypt entirely (perf regression
+  // review finding, Arc 9 #722).
+  await ctx.syncDerived(id, ctx.hasDerivedOutputs ? await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true }) : null, true)
 
   ctx.emitCrossTierEvent({
     actor: ctx.keyring.userId,
@@ -620,7 +636,9 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
     // derived outputs stay recompute-as-removed, same law as elevate()
     // above. `envelope` is the PRE-move envelope captured at function
     // entry; decoded only here (the rollup edge is the only consumer).
-    await ctx.syncDerived(id, await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true }), true)
+    // Gated by `hasDerivedOutputs` — no-derivation collections skip this
+    // decrypt entirely (perf regression review finding, Arc 9 #722).
+    await ctx.syncDerived(id, ctx.hasDerivedOutputs ? await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true }) : null, true)
   }
 
   ctx.emitCrossTierEvent({

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -126,6 +126,29 @@ export interface TiersContext<T> {
    * ledger (`withHistory()` not enabled).
    */
   syncLedger(id: string): Promise<void>
+  /**
+   * Sync a record's derived outputs (materialized-view rows, rollup
+   * contributions, `withDerivation` outputs) after a tier move (#722).
+   * Those outputs are computed from this record and written to OTHER
+   * (output) collections via a plain `put` at tier 0 — `elevate()`'s live-
+   * body rewrap moves only the source envelope, so the output rows keep
+   * holding the source's tier-0-era plaintext, the same leak class
+   * `syncSearch`/`syncIndexes` closed for THIS collection's own artifacts.
+   * `elevated` (landing tier > 0) reuses the SAME onDelete fanout
+   * `forgetDerivedFanout` drives for `forget()` (`kernel/via/dispatch.ts`)
+   * — minus its `'ref'` cascade edge (elevate/demote never erase a
+   * *different* record) — to recompute this record's derived outputs as
+   * REMOVED. Recompute is tier-safe: the fanout's own source scan reads
+   * the elevated-excluding cache (#701/#709/#712), so it naturally omits
+   * the now-elevated record instead of re-embedding its plaintext. Landing
+   * back at tier 0 (`elevated === false`) is the reverse, restoring the
+   * contribution — Task 2 (#722). `record` is the PRE-move decoded source
+   * record — only the rollup edge needs it (to resolve which parent it
+   * rolls up into); `null` skips that edge. No-op fast when the collection
+   * has no MV/derivation source — each dispatcher below checks its own
+   * source before doing any work.
+   */
+  syncDerived(id: string, record: T | null, elevated: boolean): Promise<void>
   /** Emit `_source`/`_sourceTs` provenance fields when a source is supplied. */
   readonly provenance: boolean
   /** Declared tiers, or null when the feature is off. */
@@ -161,6 +184,40 @@ export function assertDeclaredTier<T>(ctx: TiersContext<T>, tier: number): void 
 
 function isElevatorOrOwner<T>(ctx: TiersContext<T>): boolean {
   return ctx.keyring.role === 'owner' || ctx.keyring.role === 'admin'
+}
+
+/**
+ * Structural surface {@link syncDerivedOutputs} needs from the owning
+ * collection — the SAME onDelete dispatchers `forgetDerivedFanout` already
+ * drives (`kernel/via/dispatch.ts`), reused as-is (#722). Narrower than
+ * `Collection<T>` (avoids an import cycle: collection.ts constructs
+ * `TiersContext` FROM `this`, which already satisfies this shape
+ * structurally — no cast needed at the `tiersContext()` call site).
+ */
+export interface DerivedOutputsHost<T> {
+  dispatchMaterializedViewsOnDelete(id: string): Promise<number>
+  dispatchArrayDerivationsOnDelete(id: string, eraseRecordShapeToo?: boolean): Promise<number>
+  dispatchRollupsOnDelete(id: string, deleted: T): Promise<unknown>
+}
+
+/**
+ * The {@link TiersContext.syncDerived} implementation collection.ts's
+ * `tiersContext()` binds `this` into (#722). See that field's doc comment
+ * for the design; `host` is `this` — every dispatcher below is a public
+ * Collection method, already self-guarding (no-op) when the collection has
+ * no materialized-view/derivation source, so no separate fast-path check is
+ * needed here.
+ */
+export async function syncDerivedOutputs<T>(
+  host: DerivedOutputsHost<T>,
+  id: string,
+  record: T | null,
+  elevated: boolean,
+): Promise<void> {
+  if (!elevated) return // Task 2 (#722): recompute-as-add on demote/putAtTier(0)
+  await host.dispatchMaterializedViewsOnDelete(id)
+  await host.dispatchArrayDerivationsOnDelete(id, true)
+  if (record !== null) await host.dispatchRollupsOnDelete(id, record)
 }
 
 /**
@@ -228,6 +285,10 @@ export async function putAtTier<T>(
     // #729: the record lands above tier 0 — purge its tier-0-era plaintext
     // ledger deltas (irreversible; a tier-0 putAtTier(0) has nothing to purge).
     await ctx.syncLedger(id)
+    // #722: recompute this record's derived outputs now that it left tier 0
+    // — same law as elevate() below. `existing` is the PRE-write envelope;
+    // decode it only here (the rollup edge is the only consumer).
+    await ctx.syncDerived(id, existing ? await ctx.codec.decryptRecord(existing, { id, sealedAsHandles: true }) : null, true)
   } else {
     const rec = await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
     await ctx.syncIndexes(id, rec, envelope._v)
@@ -427,6 +488,11 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   // #729: elevate always lands the record at tier > 0 — purge its
   // tier-0-era plaintext ledger deltas (irreversible; entry metadata stays).
   await ctx.syncLedger(id)
+  // #722: recompute this record's derived outputs now that it left tier 0 —
+  // same law as putAtTier(tier>0) above. `envelope` is the PRE-move envelope
+  // (captured before the rewrap), decoded only here (the rollup edge is the
+  // only consumer of the record content).
+  await ctx.syncDerived(id, await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true }), true)
 
   ctx.emitCrossTierEvent({
     actor: ctx.keyring.userId,

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -322,8 +322,19 @@ export async function putAtTier<T>(
     // — same law as elevate() below. `existing` is the PRE-write envelope;
     // decode it only here (the rollup edge is the only consumer). Gated by
     // `hasDerivedOutputs` — no-derivation collections skip this decrypt
-    // entirely (perf regression review finding, Arc 9 #722).
-    await ctx.syncDerived(id, ctx.hasDerivedOutputs && existing ? await ctx.codec.decryptRecord(existing, { id, sealedAsHandles: true }) : null, true)
+    // entirely (perf regression review finding, Arc 9 #722). Whole-branch
+    // review: `existing` may sit at ANY prior tier (including a
+    // `putAtTier`-origin tier>0 record with no `_cek` ever minted) — decode
+    // it under ITS OWN tier's DEK via `codec.decryptRecordAtDek`, not
+    // `ctx.codec.decryptRecord`'s tier-unaware default, which threw
+    // `TamperedError` here.
+    await ctx.syncDerived(
+      id,
+      ctx.hasDerivedOutputs && existing
+        ? await ctx.codec.decryptRecordAtDek(existing, await ctx.getDEK(dekKey(ctx.name, existing._tier ?? 0)), id)
+        : null,
+      true,
+    )
   } else {
     const rec = await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
     await ctx.syncIndexes(id, rec, envelope._v)
@@ -532,8 +543,12 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   // (captured before the rewrap), decoded only here (the rollup edge is the
   // only consumer of the record content). Gated by `hasDerivedOutputs` — no-
   // derivation collections skip this decrypt entirely (perf regression
-  // review finding, Arc 9 #722).
-  await ctx.syncDerived(id, ctx.hasDerivedOutputs ? await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true }) : null, true)
+  // review finding, Arc 9 #722). Whole-branch review: decode under `fromDek`
+  // via `codec.decryptRecordAtDek` — `fromTier` may be > 0 here (a prior
+  // elevate), and `ctx.codec.decryptRecord`'s tier-unaware CEK resolution
+  // threw `TamperedError` whenever this op's own rewrap hadn't just primed
+  // the cekCache (non-`perRecordKeys` collections; `_cek`-absent bodies).
+  await ctx.syncDerived(id, ctx.hasDerivedOutputs ? await ctx.codec.decryptRecordAtDek(envelope, fromDek, id) : null, true)
 
   ctx.emitCrossTierEvent({
     actor: ctx.keyring.userId,
@@ -638,7 +653,13 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
     // entry; decoded only here (the rollup edge is the only consumer).
     // Gated by `hasDerivedOutputs` — no-derivation collections skip this
     // decrypt entirely (perf regression review finding, Arc 9 #722).
-    await ctx.syncDerived(id, ctx.hasDerivedOutputs ? await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true }) : null, true)
+    // Whole-branch review: decode under `fromDek` via
+    // `codec.decryptRecordAtDek` — this branch's `fromTier` is always > 0 (a
+    // demote FROM tier `fromTier` TO an intermediate `toTier` > 0), so
+    // `ctx.codec.decryptRecord`'s tier-unaware CEK resolution threw
+    // `TamperedError` here exactly as it did in elevate() above
+    // (code-identical bug, same fix).
+    await ctx.syncDerived(id, ctx.hasDerivedOutputs ? await ctx.codec.decryptRecordAtDek(envelope, fromDek, id) : null, true)
   }
 
   ctx.emitCrossTierEvent({

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -141,14 +141,21 @@ export interface TiersContext<T> {
    * REMOVED. Recompute is tier-safe: the fanout's own source scan reads
    * the elevated-excluding cache (#701/#709/#712), so it naturally omits
    * the now-elevated record instead of re-embedding its plaintext. Landing
-   * back at tier 0 (`elevated === false`) is the reverse, restoring the
-   * contribution — Task 2 (#722). `record` is the PRE-move decoded source
-   * record — only the rollup edge needs it (to resolve which parent it
-   * rolls up into); `null` skips that edge. No-op fast when the collection
-   * has no MV/derivation source — each dispatcher below checks its own
-   * source before doing any work.
+   * back at tier 0 (`elevated === false`) is the reverse (Task 2, #722):
+   * `syncDerivedOutputs` instead runs the ordinary local-write add-
+   * dispatchers (`dispatchDerivations`/`dispatchMaterializedViews`, the
+   * same ones a plain `put()` fires) to restore the contribution —
+   * reversible, since the source's plaintext survives the elevate/demote
+   * rewrap round-trip. `record` is the decoded source record (PRE-move on
+   * the remove side, POST-move on the add side); only the rollup edge
+   * consumes it on remove, both add-dispatchers require it on add; `null`
+   * (tombstone/delete-marker) skips both. `version` stamps the add-
+   * dispatchers' `_derivedFrom.sourceVersion` metadata — reuses the version
+   * the tier op already has, no re-read; unused on the remove side. No-op
+   * fast when the collection has no MV/derivation source — each dispatcher
+   * below checks its own source before doing any work.
    */
-  syncDerived(id: string, record: T | null, elevated: boolean): Promise<void>
+  syncDerived(id: string, record: T | null, elevated: boolean, version?: number): Promise<void>
   /** Emit `_source`/`_sourceTs` provenance fields when a source is supplied. */
   readonly provenance: boolean
   /** Declared tiers, or null when the feature is off. */
@@ -198,6 +205,9 @@ export interface DerivedOutputsHost<T> {
   dispatchMaterializedViewsOnDelete(id: string): Promise<number>
   dispatchArrayDerivationsOnDelete(id: string, eraseRecordShapeToo?: boolean): Promise<number>
   dispatchRollupsOnDelete(id: string, deleted: T): Promise<unknown>
+  /** Task 2 (#722) add-direction: the same local-write dispatchers an ordinary `put()` fires. */
+  dispatchMaterializedViews(id: string, record: T): Promise<void>
+  dispatchDerivations(id: string, record: T, version: number): Promise<void>
 }
 
 /**
@@ -213,11 +223,22 @@ export async function syncDerivedOutputs<T>(
   id: string,
   record: T | null,
   elevated: boolean,
+  version?: number,
 ): Promise<void> {
-  if (!elevated) return // Task 2 (#722): recompute-as-add on demote/putAtTier(0)
-  await host.dispatchMaterializedViewsOnDelete(id)
-  await host.dispatchArrayDerivationsOnDelete(id, true)
-  if (record !== null) await host.dispatchRollupsOnDelete(id, record)
+  if (elevated) {
+    await host.dispatchMaterializedViewsOnDelete(id)
+    await host.dispatchArrayDerivationsOnDelete(id, true)
+    if (record !== null) await host.dispatchRollupsOnDelete(id, record)
+    return
+  }
+  // Task 2 (#722) recompute-as-add: the record rejoined tier 0 (demote(→0) /
+  // putAtTier(0)) — restore its contribution via the SAME local-write
+  // dispatchers an ordinary `put()` fires (`collection.ts`'s
+  // `_onRecordMutated('local-write')`), same order. `record === null` only
+  // when a caller demotes a tombstone/delete-marker to 0 — nothing to add.
+  if (record === null) return
+  await host.dispatchDerivations(id, record, version ?? 0)
+  await host.dispatchMaterializedViews(id, record)
 }
 
 /**
@@ -293,6 +314,10 @@ export async function putAtTier<T>(
     const rec = await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
     await ctx.syncIndexes(id, rec, envelope._v)
     ctx.syncCache(id, rec !== null ? { record: rec, version: envelope._v } : null)
+    // #722 Task 2: the record is written at tier 0 — restore its
+    // contribution to every derived output (reuse the decode above, no
+    // double-decrypt).
+    await ctx.syncDerived(id, rec, false, envelope._v)
   }
   // #721: search artifacts follow the same tier > 0 → purge / tier 0 →
   // re-embed law as syncIndexes above. No ordering dependency on syncCache —
@@ -583,11 +608,19 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
     // #721: reuse the decode above — no double-decrypt. The record is tier-0
     // again, so re-embed its _vec and invalidate _ftindex to include it.
     await ctx.syncSearch(id, rec, next._v)
+    // #722 Task 2: the record rejoined tier 0 — restore its contribution to
+    // every derived output (reuse the decode above, no double-decrypt).
+    await ctx.syncDerived(id, rec, false, next._v)
   } else {
     await ctx.syncIndexes(id, null)
     ctx.syncCache(id, null)
     // #721: still above tier 0 — purge _vec, invalidate _ftindex.
     await ctx.syncSearch(id, null)
+    // #722 Task 2: still elevated (an intermediate tier) — the source's
+    // derived outputs stay recompute-as-removed, same law as elevate()
+    // above. `envelope` is the PRE-move envelope captured at function
+    // entry; decoded only here (the rollup edge is the only consumer).
+    await ctx.syncDerived(id, await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true }), true)
   }
 
   ctx.emitCrossTierEvent({


### PR DESCRIPTION
Closes #722. Third and last of the three "full support" tier handlers (after #712 history, #729 ledger).

## The leak

Materialized-view rows, rollup contributions, and `withDerivation` outputs are computed from a source record and written to an **output collection** via a plain `put` — at **tier 0**, under the output collection's tier-0 DEK. `elevate()` rewraps only the *source* envelope; the derived row is a separate tier-0 record still holding the source's tier-0-era plaintext. So elevating a source did not move its derived output — any tier-0 caller could read the source-derived plaintext out of the output collection.

## The fix — recompute (owner decision), reversible

On any tier move, recompute the source record's derived outputs from the **tier-aware cache** (which already excludes `_tier > 0` records). New `TiersContext.syncDerived` hook reuses the forget-fanout dispatchers — no new recompute engine:

- **elevate / putAtTier(>0)** → recompute-as-remove: record-grain rows vanish, aggregate/rollup drops the contribution, derivation outputs removed.
- **demote(→0) / putAtTier(0)** → recompute-as-add: rows/contributions restored (reversible; source plaintext survives the rewrap round-trip).
- **demote(→ intermediate >0)** → still removed.

## Critical caught in whole-branch review (fixed, `d37c9a10`)

The pre-move decode fed `syncDerived` was tier-unaware (default tier-0 DEK) and threw `TamperedError` on tier>0-origin moves in derivation vaults (putAtTier-origin / non-perRecordKeys / cold-session), *after* the adapter.put — a half-applied move with the leak surviving. Fixed by decoding under the explicit from-tier DEK via the new enclave method `RecordCodec.decryptRecordAtDek()` (mirrors `getAtTier`'s vetted tier>0 leg). 4 red-team tests lock the previously-crashing shapes (RED reproduced independently at all three call sites). No ratchet edit — the crypto lives in the enclave.

## Known / accepted

- **Aggregate inference channel** (owner-accepted, documented in the changeset): an aggregate/rollup value changes observably when a contributor is elevated. Marginal — `_tier` is already store-visible metadata.
- Follow-ups filed: lazy/manual/frozen MV cold-session staleness (#736), vault-grained `hasDerivedOutputs` gate (#737). This arc covers **eager** derived outputs.

## Verification

- 4 new red-team tests in `tiers-derived.test.ts` (elevate-remove × 4 kinds, demote-restore, round-trip, no-derivations no-op) + the 4 critical-fix shape tests.
- Full hub suite: 507 files / 4165 tests green. `check:architecture` clean; `collection.ts` at 4548 (no ceiling bump); typecheck + lint clean.
