### PR TITLE
fix(hub): forget() erasure covers ledger deltas + published blob versions (#734, #750)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-forget-residue.md
+++ b/docs/superpowers/plans/2026-07-17-forget-residue.md
@@ -1,0 +1,471 @@
+# Forget-Residue Arc (#734 + #750) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the two remaining `forget()` erasure gaps: a forgotten record's plaintext `_ledger_deltas` rows survive the crypto-shred (#734), and its published blob versions (`_blob_versions_*` rows + version-held content) survive `shredAllForRecord` (#750).
+
+**Architecture:** Both fixes extend existing, review-hardened purge machinery — no new crypto. #734 calls the #729-built `LedgerStore.purgeRecordDeltas(collection, id)` from `vault.forget()`'s per-ref loop (chain-safe by construction: `verify()` never re-reads delta rows). #750 folds published-version refCount holds into `shredAllForRecord`'s existing per-eTag `holds` map so each eTag is released exactly once with its combined hold count, then deletes the readable version rows.
+
+**Tech Stack:** TypeScript ESM, vitest, `crypto.subtle` only (no new deps).
+
+## Global Constraints
+
+- `packages/hub/src/kernel/vault.ts` kernel-surface ceiling is **3959** (`scripts/check-architecture.mjs` `KERNEL_SURFACE_BUDGET`), file currently at **3958** — Task 1 must be net-negative on vault.ts (the compressed hoist funds it); Task 3 ratchets the ceiling down to the final actual per the checker's ratchet-to-actual convention.
+- `blob-set.ts` has no line ceiling.
+- Never add Claude attribution to commits/PRs.
+- Hub stays portable: no Node built-ins in `hub/src/**`.
+- Branch: `fix/734-750-forget-residue` off `main`.
+- Run everything from repo root (`/Users/vicio/lanna-db/noy-db`).
+
+---
+
+### Task 1: #734 — forget() purges `_ledger_deltas`
+
+**Files:**
+- Modify: `packages/hub/src/kernel/vault.ts` (forget(): ~2281-2500)
+- Modify: `packages/hub/src/with-audit/forget/strategy.ts` (ForgetResult, after `sealedResidue` ~line 147)
+- Test (create): `packages/hub/__tests__/forget-ledger-deltas.test.ts`
+
+**Interfaces:**
+- Consumes: `LedgerStore.purgeRecordDeltas(collection: string, id: string): Promise<number>` (`with-commit/history/ledger/store.ts:387`), `Vault.getLedgerOrNull()` (private, `vault.ts:2217`), `vault.ledger()` / `ledger.entries()` / `ledger.verify()` (test-side, see `__tests__/ledger-purge.test.ts:94-129`).
+- Produces: `ForgetResult.ledgerDeltasPurged: number` and `ForgetResult.ledgerDeltaResidue: readonly string[]` — Task 3's changeset references these names.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/hub/__tests__/forget-ledger-deltas.test.ts`. Copy the inline `memory()` adapter VERBATIM from `packages/hub/__tests__/ledger-purge.test.ts:27-79` (same imports block, lines 17-25 of that file, PLUS `import { withForgetCascade } from '../src/with-audit/forget/index.js'`; the `withTiers` import is not needed — drop it):
+
+```ts
+/**
+ * #734 — vault.forget() purges the forgotten record's plaintext
+ * `_ledger_deltas` rows (the erasure twin of #729's elevate-side purge).
+ *
+ * Coverage:
+ *   - forget() deletes the subject record's delta rows, keeps the
+ *     tamper-chain valid, leaves a sibling record's deltas intact, and
+ *     reports the count in ForgetResult.ledgerDeltasPurged
+ *   - forget() without a history strategy fails FAST — nothing shredded
+ */
+
+interface Doc { id: string; body: string; buyerId: string }
+
+describe('vault.forget() purges _ledger_deltas (#734)', () => {
+  it('deletes the forgotten record’s delta rows, keeps verify() ok, leaves siblings intact', async () => {
+    const adapter = memory()
+    const db = await createNoydb({
+      store: adapter,
+      user: 'alice', historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { docs: 'buyerId' } }),
+      secret: 'test-passphrase-1234',
+    })
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs')
+    const ledger = company.ledger()
+
+    // 'a' (subject B-1) updated twice → delta rows; 'b' (B-2) too — must survive.
+    await docs.put('a', { id: 'a', body: 'a-v1', buyerId: 'B-1' })
+    await docs.put('a', { id: 'a', body: 'a-v2', buyerId: 'B-1' })
+    await docs.put('b', { id: 'b', body: 'b-v1', buyerId: 'B-2' })
+    await docs.put('b', { id: 'b', body: 'b-v2', buyerId: 'B-2' })
+
+    const entries = await ledger.entries()
+    const aDeltaEntry = entries.find((e) => e.collection === 'docs' && e.id === 'a' && e.deltaHash !== undefined)
+    const bDeltaEntry = entries.find((e) => e.collection === 'docs' && e.id === 'b' && e.deltaHash !== undefined)
+    expect(aDeltaEntry).toBeDefined()
+    expect(bDeltaEntry).toBeDefined()
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(aDeltaEntry!.index))).not.toBeNull()
+
+    const result = await company.forget('B-1')
+
+    // THE FIX: a's plaintext delta rows are gone; b's survive; chain stays valid.
+    expect(result.ledgerDeltasPurged).toBeGreaterThan(0)
+    expect(result.ledgerDeltaResidue).toEqual([])
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(aDeltaEntry!.index))).toBeNull()
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(bDeltaEntry!.index))).not.toBeNull()
+    expect((await ledger.verify()).ok).toBe(true)
+    // The summary forget entry + a's entry metadata (audit trail) survive.
+    expect((await ledger.entries()).some((e) => e.op === 'forget')).toBe(true)
+    expect((await ledger.entries()).some((e) => e.id === 'a')).toBe(true)
+    db.close()
+  })
+
+  it('fails FAST without a history strategy — nothing shredded', async () => {
+    const adapter = memory()
+    const db = await createNoydb({
+      store: adapter,
+      user: 'alice',
+      forgetStrategy: withForgetCascade({ subjects: { docs: 'buyerId' } }),
+      secret: 'test-passphrase-1234',
+    })
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs')
+    await docs.put('a', { id: 'a', body: 'a-v1', buyerId: 'B-1' })
+
+    await expect(company.forget('B-1')).rejects.toThrow(/requires the history strategy/)
+    // Fail-fast: the record was NOT tombstoned first.
+    expect(await docs.get('a')).not.toBeNull()
+    db.close()
+  })
+})
+```
+
+Note: if `company.forget('B-1')` in test 2 throws `ForgetStrategyNotConfiguredError` instead, the subject declaration is wrong — fix the test setup, not the assertion. If the fail-fast test's `docs.get('a')` returns null even after the fix, check that the hoisted throw sits BEFORE `lookupSubject`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run packages/hub/__tests__/forget-ledger-deltas.test.ts`
+Expected: Test 1 FAILS — `result.ledgerDeltasPurged` is `undefined` (property doesn't exist) and/or the `aDeltaEntry` row is still present after forget. Test 2 FAILS — `docs.get('a')` is null (old order shreds before throwing).
+
+- [ ] **Step 3: Implement**
+
+**(a) `packages/hub/src/with-audit/forget/strategy.ts`** — in `interface ForgetResult`, immediately after the `sealedResidue` member:
+
+```ts
+  /** Count of `_ledger_deltas` rows hard-deleted across the shredded records (#734) — the
+   * erasure twin of #729's elevate-side purge. Entry metadata (that the record was mutated,
+   * at which version/timestamp/actor) is retained; only the plaintext delta content is removed. */
+  readonly ledgerDeltasPurged: number
+  /** `collection:id` refs whose `_ledger_deltas` purge failed — plaintext delta residue still
+   * readable under the retained ledger DEK. Non-empty means erasure is INCOMPLETE. */
+  readonly ledgerDeltaResidue: readonly string[]
+```
+
+**(b) `packages/hub/src/kernel/vault.ts`** — four edits inside `forget()`:
+
+1. Directly after the `ForgetStrategyNotConfiguredError` guard (currently lines 2282-2284), BEFORE `lookupSubject`, insert the ledger resolution (hoisted from below, compressed — this is the fail-fast move AND the line funding):
+
+```ts
+    // #734: resolve the ledger BEFORE any shred — the loop purges each record's
+    // plaintext deltas and the summary entry appends after, so a missing history
+    // strategy must abort with NOTHING erased (was: shred-then-throw).
+    const ledger = this.getLedgerOrNull()
+    if (!ledger) throw new Error('vault.forget() requires the history strategy for the erasure-proof ledger entry. Pass `historyStrategy: withHistory()` from "@noy-db/hub/history" to createNoydb().')
+```
+
+2. At the OLD site (currently lines 2445-2453), delete the `const ledger = ...` + `if (!ledger) { throw ... }` block entirely, keeping only `const subjectHash = await sha256Hex(subjectId)`. (Net across edits 1+2: −3 lines.)
+
+3. Accumulators — extend the two existing joined declaration lines (currently 2295-2296), adding to the END of each (no new lines):
+
+```ts
+    let sealedFieldsShredded = 0; let sealedCekEnvelopesPurged = 0; let ledgerDeltasPurged = 0
+    const sealedCekResidue: string[] = []; const sealedResidue: string[] = []; const indexResidue: string[] = []; const ledgerDeltaResidue: string[] = []
+```
+
+4. In the per-ref loop, immediately AFTER the `tombstoneHistory` call block (currently ends line 2387), insert:
+
+```ts
+      // #734: purge the record's plaintext `_ledger_deltas` rows — the erasure twin
+      // of #729's elevate purge. Chain-safe: verify() never re-reads delta rows; the
+      // summary `forget` entry appended below is the retained proof of erasure.
+      try { ledgerDeltasPurged += await ledger.purgeRecordDeltas(ref.collection, ref.id) } catch { ledgerDeltaResidue.push(`${ref.collection}:${ref.id}`) }
+```
+
+5. Summary-entry `reason` JSON (the `JSON.stringify({...})` currently at 2461-2475): extend the `sealedResidueCount` line in place:
+
+```ts
+        sealedResidueCount: sealedResidue.length, ledgerDeltasPurged, ledgerDeltaResidueCount: ledgerDeltaResidue.length,
+```
+
+6. Return object (currently 2479-2499): extend the existing joined final line in place:
+
+```ts
+      lookupReferencesCascaded: fanoutStats.lookupReferencesCascaded, lookupReferencesNullified: fanoutStats.lookupReferencesNullified, lookupReferencesResidue: fanoutStats.lookupReferencesResidue, scopedPurgeResidue, ledgerDeltasPurged, ledgerDeltaResidue, // #650 Task 5 (+ review Important fix: residue) + #633 + #734
+    }
+```
+
+Net vault.ts budget: +5 (edit 1) −8 (edit 2) +4 (edit 4) = **−0 to −1 net** (verify with `wc -l`; must be ≤ 3959).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run packages/hub/__tests__/forget-ledger-deltas.test.ts`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Run the neighboring forget/ledger suites (regression)**
+
+Run: `pnpm vitest run packages/hub/__tests__/forget.test.ts packages/hub/__tests__/ledger-purge.test.ts packages/hub/__tests__/forget-sealed-erasure.test.ts packages/hub/__tests__/satellites-forget.test.ts`
+Expected: PASS. If any test asserted the old shred-then-throw ordering (forget without history shredding records before erroring), update that test to the new fail-fast contract and say so in the commit message.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/kernel/vault.ts packages/hub/src/with-audit/forget/strategy.ts packages/hub/__tests__/forget-ledger-deltas.test.ts
+git commit -m "fix(hub): forget() purges the record's plaintext _ledger_deltas rows (#734)"
+```
+
+---
+
+### Task 2: #750 — shredAllForRecord shreds published blob versions
+
+**Files:**
+- Modify: `packages/hub/src/with-shape/blobs/blob-set.ts` (`shredAllForRecord`, lines ~516-560, + one new private method below it)
+- Test: `packages/hub/__tests__/blob-set.test.ts` (append a new `describe` block)
+
+**Interfaces:**
+- Consumes: `this.releaseRef(eTag, n, reclaimLegacy): Promise<'shredded' | 'retainedShared' | 'residue'>` (line 460), `this.loadSlots(tier?)` (282), `this.ownerTier()` (259), `this.versionsCollection` (269), `openEnvelopeJson`, `dekKey`, `VersionRecord` (fields used: `eTag`) — all already imported/in-file.
+- Produces: unchanged public signature `shredAllForRecord(ownerTier?: number): Promise<{ shredded: string[]; retainedShared: string[]; residue: string[] }>`; new private `collectVersionHolds(ownerTier: number | undefined, holds: Map<string, number>, residue: string[]): Promise<string[]>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/hub/__tests__/blob-set.test.ts` (inside the top-level describe, after the published-versions tests; reuse the file's existing `store`, `VAULT`, `SECRET`, `textBytes` helpers — check `beforeEach` for how `store` is reset):
+
+```ts
+  // ─── #750: forget shreds published versions ────────────────────────
+
+  it('#750: shredAllForRecord shreds version-held content and deletes the version rows', async () => {
+    const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<{ x: number }>('docs')
+    await col.put('d-001', { x: 1 })
+
+    const blobs = col.blob('d-001')
+    await blobs.put('file.txt', textBytes('original content'))
+    await blobs.publish('file.txt', 'v1')
+    // Overwrite the slot: the v1 content is now held ONLY by the published version.
+    await blobs.put('file.txt', textBytes('amended content'))
+
+    const result = await blobs.shredAllForRecord()
+    expect(result.residue).toEqual([])
+
+    // Version rows for the record are gone…
+    const versionKeys = await store.list(VAULT, `${BLOB_VERSIONS_PREFIX}docs`)
+    expect(versionKeys.filter((k) => k.startsWith('d-001::'))).toEqual([])
+    // …and BOTH contents (slot-held and version-held) are crypto-shredded.
+    expect(await store.list(VAULT, BLOB_INDEX_COLLECTION)).toEqual([])
+    expect(await store.list(VAULT, BLOB_CHUNKS_COLLECTION)).toEqual([])
+    db.close()
+  })
+
+  it('#750: version content shared with another record is retained for the co-owner', async () => {
+    const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<{ x: number }>('docs')
+    await col.put('d-001', { x: 1 })
+    await col.put('d-002', { x: 2 })
+
+    const a = col.blob('d-001')
+    await a.put('file.txt', textBytes('shared bytes'))
+    await a.publish('file.txt', 'v1')
+    const b = col.blob('d-002')
+    await b.put('copy.txt', textBytes('shared bytes')) // dedup: same eTag, refCount 3
+
+    const result = await a.shredAllForRecord()
+    // d-001's two holds (slot + version) released in ONE outcome: retainedShared.
+    expect(result.retainedShared).toHaveLength(1)
+    expect(result.shredded).toEqual([])
+    // Co-owner still reads.
+    expect(new TextDecoder().decode((await b.get('copy.txt'))!)).toBe('shared bytes')
+    db.close()
+  })
+
+  it('#750: versions are shredded even when the slot map is empty (version outlived its slot)', async () => {
+    const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<{ x: number }>('docs')
+    await col.put('d-001', { x: 1 })
+
+    const blobs = col.blob('d-001')
+    await blobs.put('file.txt', textBytes('published then unlinked'))
+    await blobs.publish('file.txt', 'v1')
+    await blobs.delete('file.txt') // slot gone; the version keeps its hold
+
+    const result = await blobs.shredAllForRecord()
+    expect(result.shredded).toHaveLength(1)
+    expect(await store.list(VAULT, `${BLOB_VERSIONS_PREFIX}docs`)).toEqual([])
+    expect(await store.list(VAULT, BLOB_CHUNKS_COLLECTION)).toEqual([])
+    db.close()
+  })
+
+  it('#750: an unreadable version row is reported as residue and left in place', async () => {
+    const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<{ x: number }>('docs')
+    await col.put('d-001', { x: 1 })
+
+    const blobs = col.blob('d-001')
+    await blobs.put('file.txt', textBytes('content'))
+    await blobs.publish('file.txt', 'v1')
+
+    // Corrupt the version row at rest.
+    const versionsColl = `${BLOB_VERSIONS_PREFIX}docs`
+    const [key] = (await store.list(VAULT, versionsColl)).filter((k) => k.startsWith('d-001::'))
+    const envelope = (await store.get(VAULT, versionsColl, key!))!
+    await store.put(VAULT, versionsColl, key!, { ...envelope, _data: 'corrupted' }, envelope._v)
+
+    const result = await blobs.shredAllForRecord()
+    expect(result.residue).toEqual([`docs:d-001:${key}`])
+    // The row is NOT deleted (deleting blind would orphan its refCount hold).
+    expect(await store.get(VAULT, versionsColl, key!)).not.toBeNull()
+    db.close()
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run packages/hub/__tests__/blob-set.test.ts -t '#750'`
+Expected: 4 FAILURES — version rows survive, `_blob_index`/`_blob_chunks` non-empty, residue empty where corruption expected.
+
+- [ ] **Step 3: Implement**
+
+In `packages/hub/src/with-shape/blobs/blob-set.ts`, replace the body of `shredAllForRecord` (lines ~516-560) with the version-aware version. Keep the existing doc comments on the method and its slot-map catch (they are review artifacts — extend, don't delete):
+
+```ts
+  async shredAllForRecord(ownerTier?: number): Promise<{
+    shredded: string[]
+    retainedShared: string[]
+    residue: string[]
+  }> {
+    const shredded: string[] = []
+    const retainedShared: string[] = []
+    const residue: string[] = []
+    let slots: Record<string, SlotRecord> = {}
+    try {
+      slots = (await this.loadSlots(ownerTier)).slots
+    } catch {
+      // [keep the existing #724 re-review comment here]
+      // #750: an unreadable slot map no longer aborts the cascade — published
+      // versions are independently-keyed rows and must still be shredded below.
+      residue.push(`${this.collection}:${this.recordId}:_blob_slots`)
+    }
+
+    // Reference count from THIS record per eTag — slot holds and published-
+    // version holds (#750) merged, so a shared eTag releases ALL of this
+    // record's holds in ONE releaseRef call and reports ONE outcome.
+    const holds = new Map<string, number>()
+    for (const name of Object.keys(slots)) {
+      const eTag = slots[name]!.eTag
+      holds.set(eTag, (holds.get(eTag) ?? 0) + 1)
+    }
+    const versionKeys = await this.collectVersionHolds(ownerTier, holds, residue)
+
+    for (const [eTag, n] of holds) {
+      // Forget erasure reclaims legacy orphans too (the record is being erased),
+      // so reclaimLegacy = true — but only erasable blobs count as a crypto-shred.
+      const outcome = await this.releaseRef(eTag, n, true)
+      if (outcome === 'shredded') shredded.push(eTag)
+      else if (outcome === 'retainedShared') retainedShared.push(eTag)
+      else residue.push(eTag)
+    }
+
+    // Sever the subject's links: the slot map + the readable version rows (#750).
+    if (Object.keys(slots).length > 0) await this.store.delete(this.vault, this.slotsCollection, this.recordId)
+    for (const key of versionKeys) await this.store.delete(this.vault, this.versionsCollection, key)
+    return { shredded, retainedShared, residue }
+  }
+
+  /**
+   * #750: enumerate this record's published-version rows (`{recordId}::*` in
+   * `_blob_versions_{collection}` — the same raw prefix scan as
+   * `rehomeVersionRecords`) and fold each version's independent refCount hold
+   * into `holds`. Returns the READABLE version keys — safe to delete once
+   * their holds are released. An unreadable row is pushed onto `residue` and
+   * NOT returned: deleting it blind would orphan its refCount hold and strand
+   * the content undecryptable-but-undeleted forever, so it stays in place for
+   * out-of-band repair (mirrors the unreadable-slot-map posture above).
+   */
+  private async collectVersionHolds(
+    ownerTier: number | undefined,
+    holds: Map<string, number>,
+    residue: string[],
+  ): Promise<string[]> {
+    const prefix = `${this.recordId}::`
+    const keys = (await this.store.list(this.vault, this.versionsCollection)).filter((k) => k.startsWith(prefix))
+    if (keys.length === 0) return []
+    const readable: string[] = []
+    const dek = this.encrypted ? await this.getDEK(dekKey(this.collection, ownerTier ?? await this.ownerTier())) : null
+    for (const key of keys) {
+      const envelope = await this.store.get(this.vault, this.versionsCollection, key)
+      if (!envelope) continue
+      try {
+        const record = this.encrypted
+          ? JSON.parse(await openEnvelopeJson(envelope, dek!)) as VersionRecord
+          : JSON.parse(envelope._data) as VersionRecord
+        holds.set(record.eTag, (holds.get(record.eTag) ?? 0) + 1)
+        readable.push(key)
+      } catch {
+        residue.push(`${this.collection}:${this.recordId}:${key}`)
+      }
+    }
+    return readable
+  }
+```
+
+Behavioral notes to preserve:
+- The zero-slots early return is GONE by design: a record can hold versions with an empty/absent slot map (test 3). `store.delete` on an absent slot row is a void no-op, but the `if` guard keeps parity with the old behavior of not touching the row when there were no slots.
+- Every ref now pays one extra `store.list` on `_blob_versions_{collection}` per forget — accepted (correctness over micro-perf; flagged for the reviewer).
+- Do NOT reorder: holds must be fully collected (slots + versions) BEFORE any `releaseRef`, or a shared eTag double-reports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run packages/hub/__tests__/blob-set.test.ts`
+Expected: PASS — the 4 new tests AND every pre-existing test in the file (slot-only shred behavior unchanged).
+
+- [ ] **Step 5: Run the blob + forget regression suites**
+
+Run: `pnpm vitest run packages/hub/__tests__/per-blob-cek.test.ts packages/hub/__tests__/forget.test.ts packages/hub/__tests__/blob-legalhold-retention.test.ts packages/hub/__tests__/tier-composition-guard.test.ts packages/hub/__tests__/blob-compaction.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/with-shape/blobs/blob-set.ts packages/hub/__tests__/blob-set.test.ts
+git commit -m "fix(hub): shredAllForRecord shreds published blob versions — forget() erasure covers _blob_versions_* (#750)"
+```
+
+---
+
+### Task 3: Guards, ceiling ratchet, changeset
+
+**Files:**
+- Modify: `scripts/check-architecture.mjs` (vault.ts ceiling, line ~1012)
+- Create: `.changeset/forget-residue.md`
+
+**Interfaces:**
+- Consumes: Task 1's `ledgerDeltasPurged`/`ledgerDeltaResidue` names, Task 2's version-shred behavior (for the changeset text).
+
+- [ ] **Step 1: Full verification**
+
+Run, from repo root:
+```bash
+pnpm --filter @noy-db/hub test
+pnpm --filter @noy-db/hub typecheck
+pnpm --filter @noy-db/hub lint
+pnpm check:architecture
+```
+Expected: all PASS. If `kernel-surface` fails on vault.ts, Task 1's line budget was overrun — compress (join declaration lines) rather than bumping the ceiling.
+
+- [ ] **Step 2: Ratchet the vault.ts ceiling to actual**
+
+`wc -l packages/hub/src/kernel/vault.ts` → if the actual is BELOW 3959, lower `'packages/hub/src/kernel/vault.ts'` in `KERNEL_SURFACE_BUDGET` to the actual count, with a one-line comment following the file's existing convention:
+
+```js
+  // Lowered 3959→<actual> (2026-07-17, #734): the ledger-check hoist (fail-fast,
+  // compressed) more than funded the in-loop delta purge — ratchet-to-actual.
+  'packages/hub/src/kernel/vault.ts': <actual>,
+```
+Re-run `pnpm check:architecture` → PASS.
+
+- [ ] **Step 3: Changeset**
+
+Create `.changeset/forget-residue.md`:
+
+```md
+---
+"@noy-db/hub": patch
+---
+
+`vault.forget()` erasure now covers two residue classes it previously left at rest (#734, #750). (1) The forgotten record's plaintext `_ledger_deltas` rows are purged via the #729 primitive — chain-safe (`verify()` recomputes the tamper-chain from the retained entries, never the delta rows), with the count reported as `ForgetResult.ledgerDeltasPurged` and failures surfaced in `ForgetResult.ledgerDeltaResidue` rather than swallowed. As part of this, forget() without a history strategy now fails FAST with nothing shredded (was: shred everything, then throw on the summary-entry step). (2) `shredAllForRecord` now enumerates the record's published blob versions (`_blob_versions_*`): each version's independent refCount hold is released (crypto-shredding version-held content at refCount 0, retaining shared content for co-owners) and the version rows are deleted; an unreadable version row is reported as blob residue and left in place rather than blind-deleted (which would orphan its refCount hold).
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/check-architecture.mjs .changeset/forget-residue.md
+git commit -m "chore(hub): ratchet vault.ts ceiling + changeset for the forget-residue arc (#734, #750)"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: #734 (in-loop purge + result candor + fail-fast hoist) → Task 1; #750 (version holds + row deletion + unreadable-row residue + empty-slot-map path) → Task 2; ceiling + changeset → Task 3. Both issues' "Fix" sections are implemented as written.
+- Type consistency: `ledgerDeltasPurged`/`ledgerDeltaResidue` names match across strategy.ts, vault.ts, test, changeset. `collectVersionHolds` signature matches its call site.
+- Known intentional behavior changes (call out in PR body): fail-fast forget without history; unreadable slot map no longer skips the version pass; zero-slot records now pay a `_blob_versions` list() per forget ref.

--- a/packages/hub/__tests__/blob-set.test.ts
+++ b/packages/hub/__tests__/blob-set.test.ts
@@ -509,6 +509,95 @@ describe('BlobSet', () => {
 
     db.close()
   })
+
+  // ─── #750: forget shreds published versions ────────────────────────
+
+  it('#750: shredAllForRecord shreds version-held content and deletes the version rows', async () => {
+    const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<{ x: number }>('docs', { perRecordKeys: true })
+    await col.put('d-001', { x: 1 })
+
+    const blobs = col.blob('d-001')
+    await blobs.put('file.txt', textBytes('original content'))
+    await blobs.publish('file.txt', 'v1')
+    // Overwrite the slot: the v1 content is now held ONLY by the published version.
+    await blobs.put('file.txt', textBytes('amended content'))
+
+    const result = await blobs.shredAllForRecord()
+    expect(result.residue).toEqual([])
+
+    // Version rows for the record are gone…
+    const versionKeys = await store.list(VAULT, `${BLOB_VERSIONS_PREFIX}docs`)
+    expect(versionKeys.filter((k) => k.startsWith('d-001::'))).toEqual([])
+    // …and BOTH contents (slot-held and version-held) are crypto-shredded.
+    expect(await store.list(VAULT, BLOB_INDEX_COLLECTION)).toEqual([])
+    expect(await store.list(VAULT, BLOB_CHUNKS_COLLECTION)).toEqual([])
+    db.close()
+  })
+
+  it('#750: version content shared with another record is retained for the co-owner', async () => {
+    const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<{ x: number }>('docs', { perRecordKeys: true })
+    await col.put('d-001', { x: 1 })
+    await col.put('d-002', { x: 2 })
+
+    const a = col.blob('d-001')
+    await a.put('file.txt', textBytes('shared bytes'))
+    await a.publish('file.txt', 'v1')
+    const b = col.blob('d-002')
+    await b.put('copy.txt', textBytes('shared bytes')) // dedup: same eTag, refCount 3
+
+    const result = await a.shredAllForRecord()
+    // d-001's two holds (slot + version) released in ONE outcome: retainedShared.
+    expect(result.retainedShared).toHaveLength(1)
+    expect(result.shredded).toEqual([])
+    // Co-owner still reads.
+    expect(new TextDecoder().decode((await b.get('copy.txt'))!)).toBe('shared bytes')
+    db.close()
+  })
+
+  it('#750: versions are shredded even when the slot map is empty (version outlived its slot)', async () => {
+    const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<{ x: number }>('docs', { perRecordKeys: true })
+    await col.put('d-001', { x: 1 })
+
+    const blobs = col.blob('d-001')
+    await blobs.put('file.txt', textBytes('published then unlinked'))
+    await blobs.publish('file.txt', 'v1')
+    await blobs.delete('file.txt') // slot gone; the version keeps its hold
+
+    const result = await blobs.shredAllForRecord()
+    expect(result.shredded).toHaveLength(1)
+    expect(await store.list(VAULT, `${BLOB_VERSIONS_PREFIX}docs`)).toEqual([])
+    expect(await store.list(VAULT, BLOB_CHUNKS_COLLECTION)).toEqual([])
+    db.close()
+  })
+
+  it('#750: an unreadable version row is reported as residue and left in place', async () => {
+    const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<{ x: number }>('docs', { perRecordKeys: true })
+    await col.put('d-001', { x: 1 })
+
+    const blobs = col.blob('d-001')
+    await blobs.put('file.txt', textBytes('content'))
+    await blobs.publish('file.txt', 'v1')
+
+    // Corrupt the version row at rest.
+    const versionsColl = `${BLOB_VERSIONS_PREFIX}docs`
+    const [key] = (await store.list(VAULT, versionsColl)).filter((k) => k.startsWith('d-001::'))
+    const envelope = (await store.get(VAULT, versionsColl, key!))!
+    await store.put(VAULT, versionsColl, key!, { ...envelope, _data: 'corrupted' }, envelope._v)
+
+    const result = await blobs.shredAllForRecord()
+    expect(result.residue).toEqual([`docs:d-001:${key}`])
+    // The row is NOT deleted (deleting blind would orphan its refCount hold).
+    expect(await store.get(VAULT, versionsColl, key!)).not.toBeNull()
+    db.close()
+  })
 })
 
 // ─── wrapBundleStore Tests ───────────────────────────────────────────

--- a/packages/hub/__tests__/forget-ledger-deltas.test.ts
+++ b/packages/hub/__tests__/forget-ledger-deltas.test.ts
@@ -1,0 +1,129 @@
+/**
+ * #734 — vault.forget() purges the forgotten record's plaintext
+ * `_ledger_deltas` rows (the erasure twin of #729's elevate-side purge).
+ *
+ * Coverage:
+ *   - forget() deletes the subject record's delta rows, keeps the
+ *     tamper-chain valid, leaves a sibling record's deltas intact, and
+ *     reports the count in ForgetResult.ledgerDeltasPurged
+ *   - forget() without a history strategy fails FAST — nothing shredded
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+import { ConflictError } from '../src/kernel/errors.js'
+import { paddedIndex } from '../src/with-commit/history/ledger/entry.js'
+import { withForgetCascade } from '../src/with-audit/forget/index.js'
+
+// Inline memory adapter (same shape as other ledger test files).
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) {
+        for (const [name, coll] of existing) {
+          if (name.startsWith('_')) comp.set(name, coll)
+        }
+      }
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Doc { id: string; body: string; buyerId: string }
+
+describe('vault.forget() purges _ledger_deltas (#734)', () => {
+  it('deletes the forgotten record’s delta rows, keeps verify() ok, leaves siblings intact', async () => {
+    const adapter = memory()
+    const db = await createNoydb({
+      store: adapter,
+      user: 'alice', historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { docs: 'buyerId' } }),
+      secret: 'test-passphrase-1234',
+    })
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs')
+    const ledger = company.ledger()
+
+    // 'a' (subject B-1) updated twice → delta rows; 'b' (B-2) too — must survive.
+    await docs.put('a', { id: 'a', body: 'a-v1', buyerId: 'B-1' })
+    await docs.put('a', { id: 'a', body: 'a-v2', buyerId: 'B-1' })
+    await docs.put('b', { id: 'b', body: 'b-v1', buyerId: 'B-2' })
+    await docs.put('b', { id: 'b', body: 'b-v2', buyerId: 'B-2' })
+
+    const entries = await ledger.entries()
+    const aDeltaEntry = entries.find((e) => e.collection === 'docs' && e.id === 'a' && e.deltaHash !== undefined)
+    const bDeltaEntry = entries.find((e) => e.collection === 'docs' && e.id === 'b' && e.deltaHash !== undefined)
+    expect(aDeltaEntry).toBeDefined()
+    expect(bDeltaEntry).toBeDefined()
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(aDeltaEntry!.index))).not.toBeNull()
+
+    const result = await company.forget('B-1')
+
+    // THE FIX: a's plaintext delta rows are gone; b's survive; chain stays valid.
+    expect(result.ledgerDeltasPurged).toBeGreaterThan(0)
+    expect(result.ledgerDeltaResidue).toEqual([])
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(aDeltaEntry!.index))).toBeNull()
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(bDeltaEntry!.index))).not.toBeNull()
+    expect((await ledger.verify()).ok).toBe(true)
+    // The summary forget entry + a's entry metadata (audit trail) survive.
+    expect((await ledger.entries()).some((e) => e.op === 'forget')).toBe(true)
+    expect((await ledger.entries()).some((e) => e.id === 'a')).toBe(true)
+    db.close()
+  })
+
+  it('fails FAST without a history strategy — nothing shredded', async () => {
+    const adapter = memory()
+    const db = await createNoydb({
+      store: adapter,
+      user: 'alice',
+      forgetStrategy: withForgetCascade({ subjects: { docs: 'buyerId' } }),
+      secret: 'test-passphrase-1234',
+    })
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs')
+    await docs.put('a', { id: 'a', body: 'a-v1', buyerId: 'B-1' })
+
+    await expect(company.forget('B-1')).rejects.toThrow(/requires the history strategy/)
+    // Fail-fast: the record was NOT tombstoned first.
+    expect(await docs.get('a')).not.toBeNull()
+    db.close()
+  })
+})

--- a/packages/hub/__tests__/forget.test.ts
+++ b/packages/hub/__tests__/forget.test.ts
@@ -30,6 +30,7 @@ import { ConflictError, ForgetStrategyNotConfiguredError } from '../src/kernel/e
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
 import { withHistory } from '../src/with-commit/history/index.js'
 import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import { withBlobs } from '../src/via/blob/index.js'
 import { withIndexing } from '../src/with-lookup/indexing/index.js'
 import { withCrdt } from '../src/with-commit/crdt/index.js'
 import { withSync } from '../src/with-party/sync/index.js'
@@ -248,6 +249,38 @@ describe('forget — group 5: blob residue reported', () => {
     } as EncryptedEnvelope)
 
     const result = await vault.forget('buyer-1')
+    expect(result.blobResidueCollections).toContain('invoices')
+  })
+
+  it('#750: reports residue for a published blob version that outlives its deleted slot, blob service off', async () => {
+    const store = memory()
+    // Session 1: blob service ON — publish a version, then delete the slot.
+    // The version keeps an independent refCount hold (see blob-set.test.ts
+    // #750) and its row survives under `_blob_versions_invoices`.
+    const db1 = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+      blobStrategy: withBlobs(),
+    })
+    const vault1 = await db1.openVault('v')
+    const invoices1 = vault1.collection<Invoice>('invoices', { perRecordKeys: true })
+    await invoices1.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 100 })
+    const blobs = invoices1.blob('i-1')
+    await blobs.put('file.txt', new TextEncoder().encode('content'))
+    await blobs.publish('file.txt', 'v1')
+    await blobs.delete('file.txt')
+    db1.close()
+
+    // Session 2: blob service OFF — forget() falls back to the raw
+    // _blob_slots_/_blob_versions_ peek (the blobsEnabled === false path).
+    const db2 = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+    })
+    const vault2 = await db2.openVault('v')
+    const result = await vault2.forget('buyer-1')
     expect(result.blobResidueCollections).toContain('invoices')
   })
 })

--- a/packages/hub/__tests__/via/forget-fanout.test.ts
+++ b/packages/hub/__tests__/via/forget-fanout.test.ts
@@ -216,7 +216,8 @@ describe('forget() fanout to derived residue (#622)', () => {
     expect(Object.keys(result).sort()).toEqual([
       'blobResidueCollections', 'blobsRetainedShared', 'blobsShredded', 'collections',
       'derivedAggregatesRecomputed', 'derivedRecordsErased', 'derivedResidueFrozen',
-      'historyVersionsShredded', 'indexPostingsPurged', 'indexResidue', 'ledgerEntry',
+      'historyVersionsShredded', 'indexPostingsPurged', 'indexResidue', 'ledgerDeltaResidue',
+      'ledgerDeltasPurged', 'ledgerEntry',
       'lookupReferencesCascaded', 'lookupReferencesNullified', 'lookupReferencesResidue',
       'recordsShredded', 'scopedPurgeResidue', 'sealedCekEnvelopesPurged', 'sealedCekResidue', 'sealedFieldsShredded',
       'sealedResidue', 'subject', 'unmigratedRecords',

--- a/packages/hub/__tests__/via/lookup-forget-ref.test.ts
+++ b/packages/hub/__tests__/via/lookup-forget-ref.test.ts
@@ -223,7 +223,8 @@ describe('forget() × lookup ref semantics (#650 Task 5, fixes #648)', () => {
     expect(Object.keys(result).sort()).toEqual([
       'blobResidueCollections', 'blobsRetainedShared', 'blobsShredded', 'collections',
       'derivedAggregatesRecomputed', 'derivedRecordsErased', 'derivedResidueFrozen',
-      'historyVersionsShredded', 'indexPostingsPurged', 'indexResidue', 'ledgerEntry',
+      'historyVersionsShredded', 'indexPostingsPurged', 'indexResidue', 'ledgerDeltaResidue',
+      'ledgerDeltasPurged', 'ledgerEntry',
       'lookupReferencesCascaded', 'lookupReferencesNullified', 'lookupReferencesResidue',
       'recordsShredded', 'scopedPurgeResidue', 'sealedCekEnvelopesPurged', 'sealedCekResidue', 'sealedFieldsShredded',
       'sealedResidue', 'subject', 'unmigratedRecords',

--- a/packages/hub/__tests__/via/lookup-restrict-unresolvable.test.ts
+++ b/packages/hub/__tests__/via/lookup-restrict-unresolvable.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect } from 'vitest'
 import { createNoydb } from '../../src/kernel/noydb.js'
 import { withForgetCascade } from '../../src/with-audit/forget/index.js'
+import { withHistory } from '../../src/with-commit/history/index.js'
 import { lookup } from '../../src/via/lookup/descriptor.js'
 import { DictKeyInUseError, RestrictRefUnresolvableError, ConflictError } from '../../src/kernel/errors.js'
 import type { Noydb } from '../../src/kernel/noydb.js'
@@ -88,6 +89,7 @@ describe('restrict direction: unresolvable compare-key fails closed (#654)', () 
     const db = await createNoydb({
       store: memory(), user: 'a', secret: 'lookup-restrict-unresolvable-forget-2026',
       forgetStrategy: withForgetCascade({ subjects: { countries: 'subjectId' } }),
+      historyStrategy: withHistory(),
     })
     const vault = await db.openVault('v')
     const countries = vault.collection<CountryRow>('countries', {})

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -2283,6 +2283,10 @@ export class Vault {
       throw new ForgetStrategyNotConfiguredError()
     }
 
+    // #734: resolve the ledger BEFORE any shred — the loop purges each record's
+    // plaintext deltas and the summary entry appends after, so a missing history
+    // strategy must abort with NOTHING erased (was: shred-then-throw).
+    const ledger = this.getLedgerOrNull(); if (!ledger) throw new Error('vault.forget() requires the history strategy for the erasure-proof ledger entry. Pass `historyStrategy: withHistory()` from "@noy-db/hub/history" to createNoydb().')
     const refs = await lookupSubject(this.adapter, this.name, this.getDEK, this.encrypted, subjectId)
     // Satellite fan-out (#591, with-shape/satellites/forget.ts) — a satellite
     // is never itself in the subject index, so synthesize its ref or it survives.
@@ -2292,8 +2296,8 @@ export class Vault {
     const collections = new Set<string>(); const unmigratedRecords: string[] = []
     const blobResidueCollections = new Set<string>()
     let blobsShredded = 0; let blobsRetainedShared = 0; let indexPostingsPurged = 0
-    let sealedFieldsShredded = 0; let sealedCekEnvelopesPurged = 0
-    const sealedCekResidue: string[] = []; const sealedResidue: string[] = []; const indexResidue: string[] = []
+    let sealedFieldsShredded = 0; let sealedCekEnvelopesPurged = 0; let ledgerDeltasPurged = 0
+    const sealedCekResidue: string[] = []; const sealedResidue: string[] = []; const indexResidue: string[] = []; const ledgerDeltaResidue: string[] = []
     const blobsEnabled = this.blobStrategy !== undefined
     const actor = this.keyring.userId
     const fanoutStats: ForgetFanoutStats = { recordsErased: 0, aggregatesRecomputed: 0, residueFrozen: [], lookupReferencesCascaded: 0, lookupReferencesNullified: 0, lookupReferencesResidue: [] }
@@ -2386,6 +2390,10 @@ export class Vault {
         this.adapter, this.name, ref.collection, ref.id, actor, this.encrypted,
       )
 
+      // #734: purge the record's plaintext `_ledger_deltas` rows — the erasure twin
+      // of #729's elevate purge. Chain-safe: verify() never re-reads delta rows; the
+      // summary `forget` entry appended below is the retained proof of erasure.
+      try { ledgerDeltasPurged += await ledger.purgeRecordDeltas(ref.collection, ref.id) } catch { ledgerDeltaResidue.push(`${ref.collection}:${ref.id}`) }
       // Purge the record's persisted `_idx` side-cars: they live under
       // the retained collection DEK, so crypto-shred alone leaves the indexed
       // field VALUES readable. Content-free delete; failures → indexResidue.
@@ -2443,14 +2451,6 @@ export class Vault {
     // ONE summary ledger entry for the whole subject. payloadHash =
     // sha256Hex(subjectId) so the ledger proves erasure without the subject.
     const subjectHash = await sha256Hex(subjectId)
-    const ledger = this.getLedgerOrNull()
-    if (!ledger) {
-      throw new Error(
-        'vault.forget() requires the history strategy for the erasure-proof ' +
-        'ledger entry. Pass `historyStrategy: withHistory()` from ' +
-        '"@noy-db/hub/history" to createNoydb().',
-      )
-    }
     const ledgerEntry = await ledger.append({
       op: 'forget',
       collection: '',
@@ -2471,7 +2471,7 @@ export class Vault {
         sealedFieldsShredded,
         sealedCekEnvelopesPurged,
         sealedCekResidueCount: sealedCekResidue.length,
-        sealedResidueCount: sealedResidue.length,
+        sealedResidueCount: sealedResidue.length, ledgerDeltasPurged, ledgerDeltaResidueCount: ledgerDeltaResidue.length,
       }),
     })
 
@@ -2495,7 +2495,7 @@ export class Vault {
       derivedRecordsErased: fanoutStats.recordsErased,
       derivedAggregatesRecomputed: fanoutStats.aggregatesRecomputed,
       derivedResidueFrozen: fanoutStats.residueFrozen,
-      lookupReferencesCascaded: fanoutStats.lookupReferencesCascaded, lookupReferencesNullified: fanoutStats.lookupReferencesNullified, lookupReferencesResidue: fanoutStats.lookupReferencesResidue, scopedPurgeResidue, // #650 Task 5 (+ review Important fix: residue) + #633
+      lookupReferencesCascaded: fanoutStats.lookupReferencesCascaded, lookupReferencesNullified: fanoutStats.lookupReferencesNullified, lookupReferencesResidue: fanoutStats.lookupReferencesResidue, scopedPurgeResidue, ledgerDeltasPurged, ledgerDeltaResidue, // #650 Task 5 (+ review Important fix: residue) + #633 + #734
     }
   }
 

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -2425,8 +2425,8 @@ export class Vault {
         if (r.residue.length > 0) blobResidueCollections.add(ref.collection)
       } else {
         try {
-          const slotIds = await this.adapter.list(this.name, `_blob_slots_${ref.collection}`)
-          if (slotIds.includes(ref.id)) blobResidueCollections.add(ref.collection)
+          const [slotIds, verKeys] = await Promise.all([this.adapter.list(this.name, `_blob_slots_${ref.collection}`), this.adapter.list(this.name, `_blob_versions_${ref.collection}`)]) // #750: version rows are residue too when the blob service is off
+          if (slotIds.includes(ref.id) || verKeys.some((k) => k.startsWith(`${ref.id}::`))) blobResidueCollections.add(ref.collection)
         } catch {
           // No blob-slots collection for this collection — nothing to report.
         }

--- a/packages/hub/src/with-audit/forget/strategy.ts
+++ b/packages/hub/src/with-audit/forget/strategy.ts
@@ -146,6 +146,13 @@ export interface ForgetResult {
   /** `collection:id:field` sealed slots that were DEK-derived (legacy, written before per-record CEKs) and thus NOT crypto-shredded
    * by dropping `_cek` — the collection DEK is retained, so synced/backup copies stay decryptable (#M-1). */
   readonly sealedResidue: readonly string[]
+  /** Count of `_ledger_deltas` rows hard-deleted across the shredded records (#734) — the
+   * erasure twin of #729's elevate-side purge. Entry metadata (that the record was mutated,
+   * at which version/timestamp/actor) is retained; only the plaintext delta content is removed. */
+  readonly ledgerDeltasPurged: number
+  /** `collection:id` refs whose `_ledger_deltas` purge failed — plaintext delta residue still
+   * readable under the retained ledger DEK. Non-empty means erasure is INCOMPLETE. */
+  readonly ledgerDeltaResidue: readonly string[]
   /** The single `op:'forget'` ledger entry appended for this erasure. */
   readonly ledgerEntry: LedgerEntry
   /** #622 — record-grain derived artifacts (MV rows, per-record derived copies) erased

--- a/packages/hub/src/with-shape/blobs/blob-set.ts
+++ b/packages/hub/src/with-shape/blobs/blob-set.ts
@@ -512,6 +512,16 @@ export class BlobSet {
    * that must never be swallowed as "no blobs to shred": it is pushed onto
    * `residue` so `forget()` surfaces it via `blobResidueCollections` rather
    * than silently reporting a clean erasure while un-shredded blobs remain.
+   *
+   * #750: published versions (`_blob_versions_{collection}/{recordId}::*`)
+   * take an INDEPENDENT refCount hold on a `BlobObject`, separate from the
+   * slot map (see `publish()`) — the slot loop above never sees them. Left
+   * untouched, that hold (and the version-held content, if the slot was
+   * later overwritten) survives `forget()` — a GDPR-erasure hole. So this
+   * method now also enumerates the record's version rows via
+   * `collectVersionHolds`, folds each version's hold into the SAME `holds`
+   * map (a shared eTag reports ONE outcome, not two), and deletes the
+   * readable version rows once their holds are released.
    */
   async shredAllForRecord(ownerTier?: number): Promise<{
     shredded: string[]
@@ -521,7 +531,7 @@ export class BlobSet {
     const shredded: string[] = []
     const retainedShared: string[] = []
     const residue: string[] = []
-    let slots: Record<string, SlotRecord>
+    let slots: Record<string, SlotRecord> = {}
     try {
       slots = (await this.loadSlots(ownerTier)).slots
     } catch {
@@ -532,18 +542,21 @@ export class BlobSet {
       // exist and we can't read them" — must surface as residue (mirrors
       // the sibling `_vec`/classified-sealed-dek residue push in
       // `vault.ts`'s forget loop), never silently report a clean erasure.
+      //
+      // #750: an unreadable slot map no longer aborts the cascade — published
+      // versions are independently-keyed rows and must still be shredded below.
       residue.push(`${this.collection}:${this.recordId}:_blob_slots`)
-      return { shredded, retainedShared, residue }
     }
-    const slotNames = Object.keys(slots)
-    if (slotNames.length === 0) return { shredded, retainedShared, residue }
 
-    // Reference count from THIS record per eTag.
+    // Reference count from THIS record per eTag — slot holds and published-
+    // version holds (#750) merged, so a shared eTag releases ALL of this
+    // record's holds in ONE releaseRef call and reports ONE outcome.
     const holds = new Map<string, number>()
-    for (const name of slotNames) {
+    for (const name of Object.keys(slots)) {
       const eTag = slots[name]!.eTag
       holds.set(eTag, (holds.get(eTag) ?? 0) + 1)
     }
+    const versionKeys = await this.collectVersionHolds(ownerTier, holds, residue)
 
     for (const [eTag, n] of holds) {
       // Forget erasure reclaims legacy orphans too (the record is being erased),
@@ -554,9 +567,46 @@ export class BlobSet {
       else residue.push(eTag)
     }
 
-    // Sever the subject's link: drop the record's slot map.
-    await this.store.delete(this.vault, this.slotsCollection, this.recordId)
+    // Sever the subject's links: the slot map + the readable version rows (#750).
+    if (Object.keys(slots).length > 0) await this.store.delete(this.vault, this.slotsCollection, this.recordId)
+    for (const key of versionKeys) await this.store.delete(this.vault, this.versionsCollection, key)
     return { shredded, retainedShared, residue }
+  }
+
+  /**
+   * #750: enumerate this record's published-version rows (`{recordId}::*` in
+   * `_blob_versions_{collection}` — the same raw prefix scan as
+   * `rehomeVersionRecords`) and fold each version's independent refCount hold
+   * into `holds`. Returns the READABLE version keys — safe to delete once
+   * their holds are released. An unreadable row is pushed onto `residue` and
+   * NOT returned: deleting it blind would orphan its refCount hold and strand
+   * the content undecryptable-but-undeleted forever, so it stays in place for
+   * out-of-band repair (mirrors the unreadable-slot-map posture above).
+   */
+  private async collectVersionHolds(
+    ownerTier: number | undefined,
+    holds: Map<string, number>,
+    residue: string[],
+  ): Promise<string[]> {
+    const prefix = `${this.recordId}::`
+    const keys = (await this.store.list(this.vault, this.versionsCollection)).filter((k) => k.startsWith(prefix))
+    if (keys.length === 0) return []
+    const readable: string[] = []
+    const dek = this.encrypted ? await this.getDEK(dekKey(this.collection, ownerTier ?? await this.ownerTier())) : null
+    for (const key of keys) {
+      const envelope = await this.store.get(this.vault, this.versionsCollection, key)
+      if (!envelope) continue
+      try {
+        const record = this.encrypted
+          ? JSON.parse(await openEnvelopeJson(envelope, dek!)) as VersionRecord
+          : JSON.parse(envelope._data) as VersionRecord
+        holds.set(record.eTag, (holds.get(record.eTag) ?? 0) + 1)
+        readable.push(key)
+      } catch {
+        residue.push(`${this.collection}:${this.recordId}:${key}`)
+      }
+    }
+    return readable
   }
 
   /**

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -1782,7 +1782,12 @@ const PRE_EXISTING_BODY_ACCESS = new Map([
   // (`openEnvelopeJson`/`writeBlobContent`) for every actual decrypt/write —
   // these are the two bare discriminant reads the loop needs to route
   // correctly. Up 2. 34→36.
-  ['packages/hub/src/with-shape/blobs/blob-set.ts', 36],
+  // #750: `collectVersionHolds` reads a raw version-record envelope's
+  // `_data` in the unencrypted branch — mirrors `rehomeVersionRecords`'s
+  // identical dual-branch read directly above it (the encrypted branch
+  // goes through the `openEnvelopeJson` barrel; only the plaintext-mode
+  // fallback is a bare `_data` read). Up 1. 36→37.
+  ['packages/hub/src/with-shape/blobs/blob-set.ts', 37],
   // #629 Task 4: DictionaryHandle's encrypt/decrypt now goes through the
   // reservedEnvelopes('_dict_') capability instead of building `_iv`/`_data`
   // literals inline — down from 5 (the plaintext branch's `_iv: ''`/`_data:`


### PR DESCRIPTION
Closes #734. Closes #750. Milestone-34 Batch A (forget-residue arc); plan: `docs/superpowers/plans/2026-07-17-forget-residue.md`.

## What

Two residue classes `vault.forget()` previously left at rest:

- **#734 — `_ledger_deltas`:** the forgotten record's plaintext reverse-JSON-Patch deltas survived the crypto-shred under the retained vault-wide ledger DEK (and rode into every `dump()`). forget() now calls the #729 primitive `LedgerStore.purgeRecordDeltas` per ref — chain-safe by construction (`verify()` recomputes the tamper-chain from the retained `_ledger` entries, never the delta rows). New candor fields: `ForgetResult.ledgerDeltasPurged` + `ledgerDeltaResidue`; the summary `forget` entry (proof of erasure) is unchanged.
- **#750 — published blob versions:** `shredAllForRecord` walked only the slot map; `_blob_versions_{coll}/{id}::*` rows and version-held content survived. Version refCount holds now fold into the same per-eTag holds map (one `releaseRef` per eTag with combined count → shared content correctly retained for co-owners), readable version rows are deleted, and an unreadable version row is reported as residue and left in place (blind deletion would orphan its refCount hold and strand the content forever). The blobs-disabled fallback also detects version residue now (final-review fix).

## Intentional behavior changes

1. forget() without a history strategy **fails fast with nothing shredded** (was: shred everything, then throw on the summary-entry step). Per-collection `ledger: false` is unaffected (vault-level ledger still resolves; purge is a 0-count no-op).
2. An unreadable slot map no longer aborts the blob cascade — residue is reported and the version pass still runs.
3. Every forgotten ref now pays one `list()` on `_blob_versions_{collection}` (correctness over micro-perf).

## Review trail

Per-task reviews + fable whole-branch review ("with fixes" → fix wave applied + re-reviewed). Follow-ups filed from the whole-branch review: #752 (`::` in record ids makes version-key prefix scans cross records — write-time guard), #753 (`shredAllForRecord` crash-idempotency + two deferred test-debt items). Deferred minors: VersionRecord-decode dedup (3rd copy in blob-set.ts, grandfather 36→37 accounted), forget() JSDoc residue-channel enumeration, residue-key format.

## Verification

Full hub suite 4204+ green (incl. 3 pre-existing test files updated for the new ForgetResult fields / fail-fast contract — reviewed faithful, no weakened assertions); typecheck/lint/`check:architecture` clean; vault.ts at 3958/3959 kernel-surface ceiling (net-zero). Changeset `forget-residue.md` (hub patch) created local-only per repo convention.