### PR TITLE
fix(hub): refuse '::' and boundary colons in blob key parts at the write surface (#752)

### DIFF
--- a/packages/hub/__tests__/blob-set.test.ts
+++ b/packages/hub/__tests__/blob-set.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, NoydbBundleStore } from '../src/kernel/types.js'
-import { ConflictError, BundleVersionConflictError } from '../src/kernel/errors.js'
+import { ConflictError, BundleVersionConflictError, ValidationError } from '../src/kernel/errors.js'
 import { createNoydb } from '../src/kernel/noydb.js'
 import { withBlobs } from '../src/via/blob/index.js'
 import { withTeam } from '../src/with-party/team/index.js'
@@ -597,6 +597,58 @@ describe('BlobSet', () => {
     // The row is NOT deleted (deleting blind would orphan its refCount hold).
     expect(await store.get(VAULT, versionsColl, key!)).not.toBeNull()
     db.close()
+  })
+
+  describe('#752 blob key-part guard', () => {
+    it('put rejects a record id containing \'::\'', async () => {
+      const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+      const vault = await db.openVault(VAULT)
+      const col = vault.collection<{ x: number }>('docs')
+      await col.put('a::x', { x: 1 })
+
+      await expect(col.blob('a::x').put('file.txt', textBytes('hi'))).rejects.toThrow(ValidationError)
+      db.close()
+    })
+
+    it('put rejects a slot name containing \'::\'', async () => {
+      const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+      const vault = await db.openVault(VAULT)
+      const col = vault.collection<{ x: number }>('docs')
+      await col.put('d-001', { x: 1 })
+
+      await expect(col.blob('d-001').put('bad::slot', textBytes('hi'))).rejects.toThrow(ValidationError)
+      db.close()
+    })
+
+    it('publish rejects a label containing \'::\'', async () => {
+      const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+      const vault = await db.openVault(VAULT)
+      const col = vault.collection<{ x: number }>('docs')
+      await col.put('d-001', { x: 1 })
+
+      const blobs = col.blob('d-001')
+      await blobs.put('file.txt', textBytes('hi'))
+
+      await expect(blobs.publish('file.txt', 'bad::label')).rejects.toThrow(ValidationError)
+      db.close()
+    })
+
+    it('sanity: normal id/slot/label still work (put + publish + getVersion round-trip)', async () => {
+      const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+      const vault = await db.openVault(VAULT)
+      const col = vault.collection<{ x: number }>('docs')
+      await col.put('d-001', { x: 1 })
+
+      const blobs = col.blob('d-001')
+      const bytes = textBytes('hello')
+      await blobs.put('file.txt', bytes)
+      await blobs.publish('file.txt', 'v1')
+
+      const v1 = await blobs.getVersion('file.txt', 'v1')
+      expect(v1).not.toBeNull()
+      expect(new TextDecoder().decode(v1!)).toBe('hello')
+      db.close()
+    })
   })
 })
 

--- a/packages/hub/__tests__/blob-set.test.ts
+++ b/packages/hub/__tests__/blob-set.test.ts
@@ -649,6 +649,42 @@ describe('BlobSet', () => {
       expect(new TextDecoder().decode(v1!)).toBe('hello')
       db.close()
     })
+
+    it('sanity: an interior colon in id/slot is still accepted (put + get round-trip)', async () => {
+      const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+      const vault = await db.openVault(VAULT)
+      const col = vault.collection<{ x: number }>('docs')
+      await col.put('invoice:2025', { x: 1 })
+
+      const blobs = col.blob('invoice:2025')
+      const bytes = textBytes('hello')
+      await blobs.put('file:v1.txt', bytes)
+
+      const got = await blobs.get('file:v1.txt')
+      expect(got).not.toBeNull()
+      expect(new TextDecoder().decode(got!)).toBe('hello')
+      db.close()
+    })
+
+    it('put rejects a record id with a trailing colon (boundary re-segmentation)', async () => {
+      const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+      const vault = await db.openVault(VAULT)
+      const col = vault.collection<{ x: number }>('docs')
+      await col.put('a:', { x: 1 })
+
+      await expect(col.blob('a:').put('file.txt', textBytes('hi'))).rejects.toThrow(ValidationError)
+      db.close()
+    })
+
+    it('put rejects a slot name with a leading colon (boundary re-segmentation)', async () => {
+      const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+      const vault = await db.openVault(VAULT)
+      const col = vault.collection<{ x: number }>('docs')
+      await col.put('d-001', { x: 1 })
+
+      await expect(col.blob('d-001').put(':x', textBytes('hi'))).rejects.toThrow(ValidationError)
+      db.close()
+    })
   })
 })
 

--- a/packages/hub/src/with-shape/blobs/blob-set.ts
+++ b/packages/hub/src/with-shape/blobs/blob-set.ts
@@ -25,7 +25,7 @@ import {
   sha256Hex,
   type EnclaveKey,
 } from '../../kernel/enclave/index.js'
-import { ConflictError, NotFoundError, UnsupportedTierCompositionError } from '../../kernel/errors.js'
+import { ConflictError, NotFoundError, UnsupportedTierCompositionError, ValidationError } from '../../kernel/errors.js'
 import { liveRecordIsElevated, liveRecordTier } from '../../kernel/tier-visibility.js'
 import { dekKey } from '../../with-party/team/tiers.js'
 import { detectMagic, isPreCompressed } from './mime-magic.js'
@@ -953,6 +953,20 @@ export class BlobSet {
 
   // ─── Version record I/O ───────────────────────────────────────────
 
+  /** #752: '::' is the version-key separator (`versionKey`) — a recordId/slotName/label
+   * containing it makes the `{recordId}::` prefix scans (listVersions / rehomeVersionRecords /
+   * collectVersionHolds) match ACROSS records, which escalated from mis-read to destructive
+   * with #750's shred path. Refused at the write surface only: legacy '::' data stays
+   * readable/sheddable. */
+  private assertKeyPartSafe(part: string, what: 'record id' | 'slot name' | 'version label'): void {
+    if (part.includes('::')) {
+      throw new ValidationError(
+        `Blob ${what} "${part}" must not contain '::' (reserved as the blob version-key separator; #752)`,
+      )
+    }
+  }
+
+  /** #752: `recordId`/`slotName`/`label` must not contain '::' — see `assertKeyPartSafe`. */
   private versionKey(slotName: string, label: string): string {
     return `${this.recordId}::${slotName}::${label}`
   }
@@ -1060,6 +1074,9 @@ export class BlobSet {
    *    If overwriting an existing slot, decrements the old eTag's refCount.
    */
   async put(slotName: string, data: Uint8Array, opts?: BlobPutOptions): Promise<void> {
+    this.assertKeyPartSafe(this.recordId, 'record id')
+    this.assertKeyPartSafe(slotName, 'slot name')
+
     // External-projection path: the field is declared `external` and an
     // ObjectProjection is configured → write the raw bytes as ONE native object
     // (unencrypted, servable) and record an `external` slot (the catalog entry).
@@ -1388,6 +1405,9 @@ export class BlobSet {
       meta?: Record<string, unknown>
     },
   ): Promise<void> {
+    this.assertKeyPartSafe(this.recordId, 'record id')
+    this.assertKeyPartSafe(slotName, 'slot name')
+
     const uploaderUserId = this.userId
     await this.casUpdateSlots((slots) => {
       slots[slotName] = {
@@ -1572,6 +1592,9 @@ export class BlobSet {
    * `rehomeForTier`) — no separate tier-scoping needed for the content side.
    */
   async publish(slotName: string, label: string): Promise<void> {
+    this.assertKeyPartSafe(this.recordId, 'record id')
+    this.assertKeyPartSafe(slotName, 'slot name')
+    this.assertKeyPartSafe(label, 'version label')
     this.assertBlobWritable() // #724 I1 completion: same write-time refusal as put()
     const { slots } = await this.loadSlots()
     const slot = slots[slotName]

--- a/packages/hub/src/with-shape/blobs/blob-set.ts
+++ b/packages/hub/src/with-shape/blobs/blob-set.ts
@@ -956,12 +956,16 @@ export class BlobSet {
   /** #752: '::' is the version-key separator (`versionKey`) — a recordId/slotName/label
    * containing it makes the `{recordId}::` prefix scans (listVersions / rehomeVersionRecords /
    * collectVersionHolds) match ACROSS records, which escalated from mis-read to destructive
-   * with #750's shred path. Refused at the write surface only: legacy '::' data stays
+   * with #750's shred path. Also refused: a part that starts or ends with ':' — otherwise a
+   * boundary colon re-segments the key (recordId `"a:"` + slotName `"slot"` yields
+   * `"a:::slot::label"`, which starts with `"a::"` and prefix-matches record `"a"`'s rows).
+   * With both rules, every '::' in a stored key is exactly a component separator — the grammar
+   * is unambiguous by construction. Refused at the write surface only: legacy '::' data stays
    * readable/sheddable. */
   private assertKeyPartSafe(part: string, what: 'record id' | 'slot name' | 'version label'): void {
-    if (part.includes('::')) {
+    if (part.includes('::') || part.startsWith(':') || part.endsWith(':')) {
       throw new ValidationError(
-        `Blob ${what} "${part}" must not contain '::' (reserved as the blob version-key separator; #752)`,
+        `Blob ${what} "${part}" must not contain '::' nor start/end with ':' (reserved as the blob version-key separator; #752)`,
       )
     }
   }


### PR DESCRIPTION
Closes #752. Milestone-34 follow-up from the #734/#750 whole-branch review.

## What

Blob version keys are `{recordId}::{slotName}::{label}`, and three sites resolve a record's versions by raw `{recordId}::` prefix scan (`listVersions`, `rehomeVersionRecords` #724, `collectVersionHolds` #750). With no key-grammar validation, ids `a` and `a::x` — or the boundary case `a:` (since `a:` + `::` re-segments as `a` + `:::`) — collide across records; after #750 that meant a `forget()` of one record could release refCount holds on, and crypto-shred, content another record still publishes.

`put`/`adoptExternal`/`publish` now refuse any key part that contains `::` or starts/ends with `:` (`ValidationError`). The rule makes the `::`-joined grammar **prefix-free by construction** (review verified this with a general proof, not just the named examples); interior single colons (`invoice:2025`) remain valid.

## Scope decision

Write surface ONLY — the constructor, reads, `delete`, `shredAllForRecord`, `rehomeForTier`, and `migrate` are deliberately unguarded so pre-existing `::`/boundary-colon records stay readable, sheddable (a guard there would abort `forget()` mid-erasure), and tier-movable. Residual documented on the issue: legacy ambiguous ids written before this guard keep the scan hazard until re-put under a clean id (pre-1.0, no migration shipped).

## Verification

blob-set suite 40/40 (2 RED-first rejection tests per guard dimension + interior-colon acceptance round-trip); typecheck / lint / `check:architecture` clean. Changeset `blob-key-guard.md` (hub patch) created local-only per repo convention.