### PR TITLE
fix(hub): blob tier-completeness — tier-keyed BlobObject envelopes + blob(id).atTier() cleared reads (#747, #749)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-blob-tier-completeness.md
+++ b/docs/superpowers/plans/2026-07-17-blob-tier-completeness.md
@@ -1,0 +1,148 @@
+# Blob Tier-Completeness (#747 + #749) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish the tiers×blobs at-rest story: the `BlobObject` index envelope follows the owning eTag's tier DEK (#747, metadata leak), and cleared callers get a sanctioned read path to an elevated record's blobs (#749, `blob(id).atTier()` — the `getAtTier` analogue).
+
+**Architecture:** #747 threads an explicit/defaulted `tier` through the four `BlobObject` I/O helpers (`loadBlobObject`/`writeBlobObject`/`casUpdateRefCount`/`releaseRef`), defaulting to `ownerTier()` exactly like `loadSlots` already does, with a **flat-DEK fallback read** for the two legitimate flat-object classes (dedup-shared and legacy). #749 adds a `clearedRead` mode to `BlobSet` that skips the `recordIsElevated()` hidden-gate; clearance is enforced cryptographically (resolving the record's tier DEK is the gate — owners/admins mint, uncleared members throw), consistent with the family's key-possession philosophy.
+
+**No migration needed (load-bearing fact):** the entire #724/#751 tiers×blobs arc is merged-but-UNPUBLISHED (everything after `0.3.0-pre.12`). No elevated blob exists at rest outside this repo's tests, so #747 can change the at-rest keying of elevated index envelopes without a compatibility read path for "old elevated" data. Tier-0 envelopes are untouched by construction (`dekKey('_blob', 0) === '_blob'`).
+
+**Tech Stack:** TypeScript ESM, vitest, `crypto.subtle` only.
+
+## Global Constraints
+
+- `blob-set.ts` has NO line ceiling; `collection.ts` (4549) and `vault.ts` (3959) ceilings must NOT be touched — that is why #749 lives on `BlobSet`, not `Collection`.
+- The `enclave-body-only` grandfather count for blob-set.ts in `scripts/check-architecture.mjs` is 37 — do not add raw `_data`/`_iv` reads beyond existing patterns; if a new one is unavoidable, ratchet with a comment (as #750 did 36→37).
+- Never add Claude attribution. Hub stays portable (no Node built-ins).
+- Branch: `fix/747-749-blob-tier-completeness` off `main` (create AFTER PR #755 merges; base on the updated main).
+- Repo root: `/Users/vicio/lanna-db/noy-db`. TDD throughout.
+
+---
+
+### Task 1: #747 — BlobObject index envelope follows the eTag's tier DEK
+
+**Files:**
+- Modify: `packages/hub/src/with-shape/blobs/blob-set.ts` (`loadBlobObject` ~387, `writeBlobObject` ~400, `casUpdateRefCount` ~426, `releaseRef` ~460, plus the tier-knowing call sites listed below)
+- Test: `packages/hub/__tests__/tiers-blobs.test.ts` if it exists (check; the #724 arc's tests live somewhere — `grep -rln 'rehomeForTier' packages/hub/__tests__/`), else append to `packages/hub/__tests__/blob-set.test.ts`
+
+**Interfaces:**
+- Produces: `loadBlobObject(eTag, tier?)`, `writeBlobObject(blob, expectedVersion?, tier?)`, `casUpdateRefCount(eTag, delta, tier?)`, `releaseRef(eTag, n, reclaimLegacy, tier?)` — all `tier?: number`, default resolution `tier ?? await this.ownerTier()`. All private; no public-surface change.
+
+- [ ] **Step 1: Write the failing at-rest key-inspection tests**
+
+Mirror the #712/#724 at-rest test style (find it: `grep -rn 'not.*decrypt\|TamperedError' packages/hub/__tests__/ | grep -i 'tier\|rest' | head`). Cases (use `withTiers()` + `withTeam()` + `withBlobs()` + a `perRecordKeys: true` tiered collection; elevate via the collection's tier API):
+
+```ts
+// 1. THE LEAK (RED): after elevate(id, 1), the record's blob's _blob_index envelope
+//    must NOT decrypt under the flat '_blob' DEK — assert openEnvelopeJson (or a
+//    direct decrypt attempt via a second tier-0-only session reading the store)
+//    fails; and the blob still round-trips for the elevated owner (rehome intact).
+// 2. Demote(→0) re-keys the index envelope back to the flat DEK (decryptable again).
+// 3. Tier-0 record: envelope keyed exactly as before (flat DEK) — pre-existing
+//    blob-set tests already cover behavior; add one explicit decrypt-under-flat assert.
+// 4. dedup policy: elevated owner, shared blob left in place — index envelope STAYS
+//    flat (documented residue), reads still work via the fallback.
+```
+
+Write them as real tests (two sessions where needed: writer session + a reader session holding only tier-0 keys). RED: case 1 currently decrypts fine under the flat DEK.
+
+- [ ] **Step 2: Implement the tier threading**
+
+In `blob-set.ts`:
+
+1. `loadBlobObject(eTag: string, tier?: number)`: resolve `const t = tier ?? await this.ownerTier()`; if `t > 0`, try `getDEK(dekKey(BLOB_COLLECTION, t))` first and on decrypt failure (catch around `openEnvelopeJson`) retry under the flat `getDEK(BLOB_COLLECTION)` — the fallback covers the two legitimate flat classes (dedup-shared object pointed at by an elevated slot; legacy `_cek`-less object). `t === 0` → flat only (today's path). Return shape unchanged.
+2. `writeBlobObject(blob, expectedVersion?, tier?)`: encrypt under `getDEK(dekKey(BLOB_COLLECTION, tier ?? await this.ownerTier()))`. IMPORTANT: every write site that MUTATES an existing object (refCount CAS) must write back under the SAME DEK it decrypted with — extend `loadBlobObject` to also return which tier key opened it (`{ blob, version, atTier: number }`, internal), and have `casUpdateRefCount` pass that through to `writeBlobObject`. This is what keeps a dedup-shared flat object flat when an elevated owner releases a ref.
+3. `casUpdateRefCount(eTag, delta, tier?)` / `releaseRef(eTag, n, reclaimLegacy, tier?)`: accept and forward `tier`.
+4. Call sites that must pass an explicit tier (they know better than `ownerTier()`, which is wrong mid-move or post-tombstone):
+   - `rehomeForTier`'s loop (~639): `loadBlobObject(eTag, fromTier)`; its NEW object creation lands via `putUnderDEK` → `writeBlobContent` → the fresh `writeBlobObject` must use `toTier` — thread it (writeBlobContent already receives the target `blobDEK`; add the tier param alongside).
+   - `rehomeVersionRecords`/`rehomeVersionETag` (~742-767): `fromTier` for loads, `toTier` for the re-put.
+   - `shredAllForRecord`/`collectVersionHolds`: pass the method's `ownerTier` param down to `releaseRef` (post-tombstone, the default would resolve 0).
+   - `deleteVersion`, `delete`, `put`'s old-eTag decrement, `publish`'s +1: default (`ownerTier()`) is correct — leave them.
+   - `migrate()` (~855): legacy-only by definition → pass `0` explicitly.
+5. Keep the raw `_data` reads structurally as they are (same `!this.encrypted` branches) — no new grandfather entries expected.
+
+- [ ] **Step 3: GREEN + regression**
+
+Run the new tests + `pnpm vitest run packages/hub/__tests__/blob-set.test.ts packages/hub/__tests__/tier-composition-guard.test.ts packages/hub/__tests__/per-blob-cek.test.ts packages/hub/__tests__/forget.test.ts` and whichever file holds the #724 rehome tests. All green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "fix(hub): BlobObject index envelope follows the eTag's tier DEK — elevated blob metadata not tier-0-readable at rest (#747)"
+```
+
+---
+
+### Task 2: #749 — `blob(id).atTier()` cleared-read path
+
+**Files:**
+- Modify: `packages/hub/src/with-shape/blobs/blob-set.ts` (constructor opts + `recordIsElevated` gate + new `atTier()`)
+- Test: same file as Task 1's tests
+
+**Interfaces:**
+> **CORRECTION (2026-07-17, mid-arc):** the original design below — `getDEK` resolution as the
+> clearance gate — was WRONG and is retired. The implementer's probe proved `getDEK` (via
+> `ensureCollectionDEK`) auto-mints a fresh DEK for ANY role and never throws, so it cannot gate
+> anything and would mint junk key material into an ungranted keyring. The shipped design: the
+> keyring is threaded from `collection.ts`'s `blob()` opts (zero net lines, appended to the
+> existing joined line) and `atTier()` calls `assertTierAccess(keyring, collection, tier)` —
+> and, after the whole-branch review (M3), `assertTierAccess(keyring, BLOB_COLLECTION, tier)` —
+> BEFORE any `getDEK`, throwing `TierNotGrantedError` with no key material minted. Tests lock
+> the no-junk-mint property. The struck-through paragraph is retained for the spec trail only.
+- ~~Produces: `BlobSet.atTier(): Promise<BlobSet>` — resolves the record's live tier; tier 0 → returns `this`; tier N > 0 → resolves `getDEK(dekKey(collection, N))` (the cryptographic clearance gate: owner/admin/custodian mint, an uncleared member's getDEK throws → surfaces as `TierNotGrantedError` if that's what getDEK throws, else propagate as-is), then returns a NEW `BlobSet` sharing all opts plus internal `clearedTier: N`.~~
+- A `BlobSet` with `clearedTier` set: `recordIsElevated()` returns `false` (gate off) and `ownerTier()` returns `clearedTier` without re-peeking (stable view; a concurrent demote just means the next `atTier()` call sees the new tier).
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+// 1. Elevated record, cleared caller (owner role): blob(id).get() → null/hidden (existing
+//    gate), but (await blob(id).atTier()).get(slot) returns the bytes. Publish/list/
+//    blobInfo work through the cleared view too (spot-check list()).
+// 2. Elevated record, tier-0-only member session (grant NOT issued): atTier() rejects
+//    (TierNotGrantedError or the getDEK failure — assert rejects.toThrow, match the
+//    actual error the keyring throws for a member without the DEK; name it in the test).
+// 3. Tier-0 record: atTier() returns an equivalent working view (round-trip put/get).
+// 4. blob(id) WITHOUT atTier() still hides the elevated record's blobs (regression lock).
+```
+
+For case 2 you need a member-role session — mirror however the existing tier tests build a non-admin keyring (`grep -n "role: 'member'\|withTeam" packages/hub/__tests__/hierarchical-tiers.test.ts | head`).
+
+- [ ] **Step 2: Implement**
+
+- Constructor opts: add optional `clearedTier?: number` (internal; `openSlot` never sets it).
+- `recordIsElevated()`: `if (this.clearedTier !== undefined) return false` first line.
+- `ownerTier()`: `if (this.clearedTier !== undefined) return this.clearedTier` first line.
+- `atTier()`: live-peek tier via `liveRecordTier(...)` (already imported); `tier === 0 → return this`; else `await this.getDEK(dekKey(this.collection, tier))` (clearance gate — let the keyring's own error propagate), then construct the cleared clone (`new BlobSet({ ...same opts, clearedTier: tier })` — check how the constructor stores opts; replicate faithfully).
+- Doc comment: state the law — `blob(id)` stays the tier-0 surface (elevated → invisible); `atTier()` is the sanctioned cleared path, the `getAtTier` analogue; the DEK resolution IS the authorization check.
+
+- [ ] **Step 3: GREEN + regression** — same suites as Task 1 Step 3.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(hub): blob(id).atTier() — sanctioned cleared-read path to an elevated record's blobs (#749)"
+```
+
+---
+
+### Task 3: Guards + changeset
+
+- [ ] Full verification: `pnpm --filter @noy-db/hub test`, `typecheck`, `lint`, `pnpm check:architecture` — all green. If `enclave-body-only` moved, justify or eliminate.
+- [ ] Create `.changeset/blob-tier-completeness.md` (local-only, gitignored):
+
+```md
+---
+"@noy-db/hub": patch
+---
+
+Tiers×blobs completeness (#747, #749). The `BlobObject` index envelope (size/mimeType/compression/chunkCount/refCount/createdAt) now follows its eTag's tier `_blob` DEK, so an elevated record's blob metadata is no longer readable by a tier-0 DEK holder at rest — content was already tier-isolated (#724); this closes the metadata sidecar. Dedup-policy shared blobs and legacy blobs legitimately stay under the flat DEK (documented residue; reads fall back). No migration: the tiers×blobs arc has never been published. And `blob(id).atTier()` is the new sanctioned cleared-read path to an elevated record's blobs — the `getAtTier` analogue; resolving the record's tier DEK is the authorization gate (owners/admins/custodians mint; an ungranted member throws), while plain `blob(id)` keeps treating the elevated record's blobs as nonexistent.
+```
+
+- [ ] Commit anything tracked; report if nothing.
+
+## Self-Review Notes
+
+- The `atTier: number` return-through on `loadBlobObject` (Task 1 impl point 2) is the load-bearing correctness piece: CAS write-backs must re-key under the DEK that opened the object, or a dedup-flat object gets silently lifted to the owner's tier on a refCount change (corrupting the co-owner's read path).
+- Task 2's stable `clearedTier` view means a record demoted after `atTier()` keeps serving through the old tier DEK for that BlobSet instance — acceptable (keys don't vanish on demote) and documented.
+- #748 and #746/#753 are NOT in this arc (audit and durability-journal arcs respectively).

--- a/packages/hub/__tests__/tiers-blobs.test.ts
+++ b/packages/hub/__tests__/tiers-blobs.test.ts
@@ -4,7 +4,7 @@
  * owning record's _tier before returning bytes, exactly as get() does.
  */
 import { describe, it, expect } from 'vitest'
-import { createNoydb, ConflictError, dekKey, UnsupportedTierCompositionError, TierNotGrantedError } from '../src/index.js'
+import { createNoydb, ConflictError, dekKey, UnsupportedTierCompositionError, TierNotGrantedError, TamperedError } from '../src/index.js'
 import { withTiers } from '../src/with-audit/tiers/index.js'
 import { withBlobs } from '../src/via/blob/index.js'
 import { withForgetCascade } from '../src/with-audit/forget/index.js'
@@ -1305,6 +1305,15 @@ describe('#747 BlobObject index envelope follows the eTag tier DEK', () => {
     let indexEnv = await store.get('v1', BLOB_INDEX_COLLECTION, sharedETag)
     await expect(openEnvelopeJson(indexEnv!, tier0BlobDEK)).resolves.toBeDefined()
 
+    // I1 positive lock (whole-branch review): a cleared clone's read of
+    // this LEGITIMATE flat-fallback case (dedup-shared, never rehomed)
+    // must still round-trip — the #757 content-address re-verification on
+    // a flat fallback is a no-op for honest data, only a forged row trips it.
+    const clearedB = await docs.blob('b').atTier()
+    const bBytes = await clearedB.get('attachment')
+    expect(bBytes).not.toBeNull()
+    expect(new TextDecoder().decode(bBytes!)).toBe('dedup-policy shared bytes (#747)')
+
     // b's forget() releases ITS hold on the shared object (via `releaseRef`
     // resolving b's pre-tombstone tier, 1) — a refCount change driven by the
     // ELEVATED co-owner must not re-key the shared object onto b's tier-1
@@ -1377,13 +1386,17 @@ describe('#749 blob(id).atTier() — sanctioned cleared-read path', () => {
     await docs.blob('d1').put('attachment', new TextEncoder().encode('secret bytes'))
     await docs.elevate('d1', 1)
 
-    // Simulate an operator whose keyring never received the tier-1 grant —
-    // same technique `hierarchical-tiers.test.ts` uses for a non-admin,
-    // non-cleared caller.
+    // Simulate an operator whose keyring never received EITHER tier-1 grant
+    // — same technique `hierarchical-tiers.test.ts` uses for a non-admin,
+    // non-cleared caller. (The owner session that ran `elevate` above holds
+    // both `docs#1` and `_blob#1` honestly, minted by the rehome itself —
+    // dropping both here simulates a caller who was never granted either.)
     const kr = (vault as unknown as { keyring: { deks: Map<string, unknown>; role: string } }).keyring
     kr.deks.delete(dekKey('docs', 1))
+    kr.deks.delete(dekKey('_blob', 1))
     kr.role = 'operator'
     expect(kr.deks.has(dekKey('docs', 1))).toBe(false)
+    expect(kr.deks.has(dekKey('_blob', 1))).toBe(false)
 
     await expect(docs.blob('d1').atTier()).rejects.toThrow(TierNotGrantedError)
 
@@ -1391,6 +1404,44 @@ describe('#749 blob(id).atTier() — sanctioned cleared-read path', () => {
     // fresh (bogus, non-matching) tier-1 DEK into the ungranted caller's own
     // keyring as a side effect — `assertTierAccess` runs BEFORE any getDEK.
     expect(kr.deks.has(dekKey('docs', 1))).toBe(false)
+    // M3 (whole-branch review): same no-junk-mint property for the SECOND
+    // gate (the `_blob` collection DEK).
+    expect(kr.deks.has(dekKey('_blob', 1))).toBe(false)
+  })
+
+  it('M3 (whole-branch review): a member granted docs#N but not _blob#N is refused at the SECOND gate — before any junk _blob#N mint', async () => {
+    const db = await createNoydb({
+      store: memoryStore(), secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+
+    await docs.putAtTier('d1', { id: 'd1', title: 'Invoice', body: 'x' }, 0)
+    await docs.blob('d1').put('attachment', new TextEncoder().encode('secret bytes'))
+    await docs.elevate('d1', 1)
+
+    // Simulate a member session partially granted `docs#1` (the DATA
+    // collection) but never `_blob#1` (the blob DEK) — the gap M3 closes.
+    // The owner session already holds both (elevate's rehome minted
+    // `_blob#1`); drop only the blob grant and switch off the
+    // owner/admin/custodian bypass.
+    const kr = (vault as unknown as { keyring: { deks: Map<string, unknown>; role: string } }).keyring
+    expect(kr.deks.has(dekKey('docs', 1))).toBe(true)
+    expect(kr.deks.has(dekKey('_blob', 1))).toBe(true)
+    kr.deks.delete(dekKey('_blob', 1))
+    kr.role = 'operator'
+    expect(kr.deks.has(dekKey('docs', 1))).toBe(true)
+    expect(kr.deks.has(dekKey('_blob', 1))).toBe(false)
+
+    // The first gate (docs#1) passes — this is exactly the partial-grant
+    // hazard. Pre-fix, atTier() would return a working handle and the
+    // first content read would auto-mint a junk `_blob#1` DEK. Post-fix,
+    // the second gate refuses before that mint ever happens.
+    await expect(docs.blob('d1').atTier()).rejects.toThrow(TierNotGrantedError)
+    expect(kr.deks.has(dekKey('_blob', 1))).toBe(false)
   })
 
   it('a tier-0 record: atTier() returns an equivalent working view (round-trip put/get)', async () => {
@@ -1459,5 +1510,56 @@ describe('#749 blob(id).atTier() — sanctioned cleared-read path', () => {
     expect(res).not.toBeNull()
     const body = new Uint8Array(await res!.arrayBuffer())
     expect(new TextDecoder().decode(body)).toBe('versioned cleared bytes')
+  })
+})
+
+describe('#757 whole-branch review (I1): fallback content substitution is caught by content-address re-verification', () => {
+  it('a forged flat _blob_index/{eTag} row planted at an elevated blob\'s own address does NOT silently substitute content on a cleared higher-tier read — TamperedError, not attacker bytes', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+
+    // Victim: an elevated record's blob, tier-1 scoped from the read gate's
+    // perspective — a `docs#1`/`_blob#1` grant holder clears through
+    // atTier() to read it, exactly like the #749 tests above.
+    await docs.putAtTier('victim', { id: 'victim', title: 'V', body: 'x' }, 0)
+    await docs.blob('victim').put('attachment', new TextEncoder().encode('true secret bytes'))
+    await docs.elevate('victim', 1)
+    const victimETag = (await (await docs.blob('victim').atTier()).blobInfo('attachment'))!.eTag
+
+    // Attacker: an ordinary tier-0 write on a THROWAWAY record — nothing
+    // privileged about this, any flat `_blob` DEK holder with store write
+    // access can produce an honestly-flat-encrypted `_blob_index` row +
+    // chunk this way (mirrors the #747 at-rest raw-store technique: no
+    // decrypt of anything the attacker doesn't already hold).
+    await docs.put('throwaway', { id: 'throwaway', title: 'T', body: 'y' })
+    await docs.blob('throwaway').put('attachment', new TextEncoder().encode('forged attacker bytes'))
+    const attackerETag = (await docs.blob('throwaway').blobInfo('attachment'))!.eTag
+
+    // The forgery: overwrite the VICTIM eTag's `_blob_index` row (raw store
+    // write — the actual attack surface, no tier-1 key material needed) with
+    // the attacker's own honest, flat-encrypted index envelope. Its internal
+    // `.eTag` field still reads `attackerETag`, so `fetchAllChunks` resolves
+    // straight to the attacker's own (untouched) chunk row — no separate
+    // chunk forgery required.
+    const attackerIndexEnv = await store.get('v1', BLOB_INDEX_COLLECTION, attackerETag)
+    await store.put('v1', BLOB_INDEX_COLLECTION, victimETag, attackerIndexEnv!)
+
+    // Cleared read: the tier-1 open fails (the forged row is flat, not
+    // tier-1-keyed — TamperedError, correctly scoped through by M1) and
+    // falls through to the flat retry, which decrypts CLEANLY (it IS a
+    // legitimately flat-encrypted row, just planted at the wrong address).
+    // Pre-#757-fix this returns the attacker's bytes silently as the
+    // elevated record's content. Post-fix, the recomputed content address
+    // doesn't match `victimETag` (it hashes to `attackerETag` instead) —
+    // TamperedError.
+    const cleared = await docs.blob('victim').atTier()
+    await expect(cleared.get('attachment')).rejects.toThrow(TamperedError)
   })
 })

--- a/packages/hub/__tests__/tiers-blobs.test.ts
+++ b/packages/hub/__tests__/tiers-blobs.test.ts
@@ -1307,7 +1307,7 @@ describe('#747 BlobObject index envelope follows the eTag tier DEK', () => {
 
     // I1 positive lock (whole-branch review): a cleared clone's read of
     // this LEGITIMATE flat-fallback case (dedup-shared, never rehomed)
-    // must still round-trip — the #757 content-address re-verification on
+    // must still round-trip — the #747/#749-review-I1 content-address re-verification on
     // a flat fallback is a no-op for honest data, only a forged row trips it.
     const clearedB = await docs.blob('b').atTier()
     const bBytes = await clearedB.get('attachment')
@@ -1513,7 +1513,7 @@ describe('#749 blob(id).atTier() — sanctioned cleared-read path', () => {
   })
 })
 
-describe('#757 whole-branch review (I1): fallback content substitution is caught by content-address re-verification', () => {
+describe('#747/#749 whole-branch review (I1): fallback content substitution is caught by content-address re-verification', () => {
   it('a forged flat _blob_index/{eTag} row planted at an elevated blob\'s own address does NOT silently substitute content on a cleared higher-tier read — TamperedError, not attacker bytes', async () => {
     const store = memoryStore()
     const db = await createNoydb({
@@ -1555,7 +1555,7 @@ describe('#757 whole-branch review (I1): fallback content substitution is caught
     // tier-1-keyed — TamperedError, correctly scoped through by M1) and
     // falls through to the flat retry, which decrypts CLEANLY (it IS a
     // legitimately flat-encrypted row, just planted at the wrong address).
-    // Pre-#757-fix this returns the attacker's bytes silently as the
+    // Pre-I1-fix (#747/#749 review) this returns the attacker's bytes silently as the
     // elevated record's content. Post-fix, the recomputed content address
     // doesn't match `victimETag` (it hashes to `attackerETag` instead) —
     // TamperedError.

--- a/packages/hub/__tests__/tiers-blobs.test.ts
+++ b/packages/hub/__tests__/tiers-blobs.test.ts
@@ -185,9 +185,9 @@ describe('#724 solo blob at-rest isolation', () => {
     const env = await store.get('v1', BLOB_INDEX_COLLECTION, newETag)
     expect(env).not.toBeNull()
     // Raw at-rest inspection: the BlobObject index envelope's own wrapper
-    // key is untouched (still the flat tier-0 `_blob` DEK) — only the
-    // wrapped content CEK carried inside it is tier-scoped.
-    const blob = JSON.parse(await openEnvelopeJson(env!, tier0BlobDEK)) as { _cek?: string; refCount: number }
+    // key is now ALSO tier-scoped (#747 — it follows the eTag's home tier,
+    // same as the wrapped content CEK carried inside it).
+    const blob = JSON.parse(await openEnvelopeJson(env!, tier1BlobDEK)) as { _cek?: string; refCount: number }
     expect(blob._cek).toBeDefined()
 
     // AT-REST GUARANTEE: no longer unwrappable under tier-0…
@@ -231,7 +231,8 @@ describe('#724 solo blob at-rest isolation', () => {
     expect(newETag).not.toBe(oldETag)
 
     const env = await store.get('v1', BLOB_INDEX_COLLECTION, newETag)
-    const blob = JSON.parse(await openEnvelopeJson(env!, tier0BlobDEK)) as { _cek?: string }
+    // #747: the index envelope itself is now tier-1-keyed too.
+    const blob = JSON.parse(await openEnvelopeJson(env!, tier1BlobDEK)) as { _cek?: string }
     await expect(unwrapCek(blob._cek!, tier0BlobDEK)).rejects.toThrow()
     await expect(unwrapCek(blob._cek!, tier1BlobDEK)).resolves.toBeDefined()
   })
@@ -291,10 +292,11 @@ describe('#724 shared blob — blobTierPolicy', () => {
     const newETag = slots.attachment!.eTag
     expect(newETag).not.toBe(sharedETag)
 
-    // The new object's `_cek` unwraps under the tier-1 `_blob` DEK, not tier-0.
+    // The new object's `_cek` unwraps under the tier-1 `_blob` DEK, not tier-0
+    // — and #747: its index envelope is ITSELF now tier-1-keyed too.
     const newEnv = await store.get('v1', BLOB_INDEX_COLLECTION, newETag)
     expect(newEnv).not.toBeNull()
-    const newBlob = JSON.parse(await openEnvelopeJson(newEnv!, tier0BlobDEK)) as { _cek?: string; refCount: number }
+    const newBlob = JSON.parse(await openEnvelopeJson(newEnv!, tier1BlobDEK)) as { _cek?: string; refCount: number }
     expect(newBlob.refCount).toBe(1)
     expect(newBlob._cek).toBeDefined()
     await expect(unwrapCek(newBlob._cek!, tier0BlobDEK)).rejects.toThrow()
@@ -542,7 +544,8 @@ describe('#724 slot-map metadata + reversibility (Arc 10 Task 4)', () => {
     expect(elevatedETag).not.toBe(originalETag)
     expect(await store.get('v1', BLOB_INDEX_COLLECTION, originalETag)).toBeNull() // old address crypto-shredded
     let env = await store.get('v1', BLOB_INDEX_COLLECTION, elevatedETag)
-    let blob = JSON.parse(await openEnvelopeJson(env!, tier0BlobDEK)) as { _cek?: string }
+    // #747: the index envelope is itself tier-1-keyed too.
+    let blob = JSON.parse(await openEnvelopeJson(env!, tier1BlobDEK)) as { _cek?: string }
     await expect(unwrapCek(blob._cek!, tier1BlobDEK)).resolves.toBeDefined()
     await expect(unwrapCek(blob._cek!, tier0BlobDEK)).rejects.toThrow()
     expect(await docs.blob('d1').get('attachment')).toBeNull() // gated while elevated
@@ -565,7 +568,7 @@ describe('#724 slot-map metadata + reversibility (Arc 10 Task 4)', () => {
     // the SAME tier-scoped eTag as the first elevation.
     expect(slotsAfterSecondElevate.attachment!.eTag).toBe(elevatedETag)
     env = await store.get('v1', BLOB_INDEX_COLLECTION, elevatedETag)
-    blob = JSON.parse(await openEnvelopeJson(env!, tier0BlobDEK)) as { _cek?: string }
+    blob = JSON.parse(await openEnvelopeJson(env!, tier1BlobDEK)) as { _cek?: string }
     await expect(unwrapCek(blob._cek!, tier1BlobDEK)).resolves.toBeDefined()
     await expect(unwrapCek(blob._cek!, tier0BlobDEK)).rejects.toThrow()
     expect(await docs.blob('d1').get('attachment')).toBeNull() // gated again while elevated
@@ -613,9 +616,10 @@ describe('#724 slot-map metadata + reversibility (Arc 10 Task 4)', () => {
     expect(slots.slotB!.eTag).toBe(newETag) // BOTH slots repoint to the SAME new eTag
     expect(newETag).not.toBe(sharedETag)
 
-    // The new object holds BOTH of b's references — refCount 2.
+    // The new object holds BOTH of b's references — refCount 2. #747: its
+    // index envelope is itself tier-1-keyed too.
     const newEnv = await store.get('v1', BLOB_INDEX_COLLECTION, newETag)
-    const newBlob = JSON.parse(await openEnvelopeJson(newEnv!, tier0BlobDEK)) as { refCount: number; _cek?: string }
+    const newBlob = JSON.parse(await openEnvelopeJson(newEnv!, tier1BlobDEK)) as { refCount: number; _cek?: string }
     expect(newBlob.refCount).toBe(2)
     await expect(unwrapCek(newBlob._cek!, tier1BlobDEK)).resolves.toBeDefined()
     await expect(unwrapCek(newBlob._cek!, tier0BlobDEK)).rejects.toThrow()
@@ -721,7 +725,9 @@ describe('#724 tier-scoped eTag (C1/C2)', () => {
 
     const env = await store.get('v1', BLOB_INDEX_COLLECTION, eTag)
     expect(env).not.toBeNull()
-    const blob = JSON.parse(await openEnvelopeJson(env!, tier0BlobDEK)) as { _cek?: string }
+    // #747: born already-elevated — the index envelope is itself tier-1-keyed
+    // from birth too, not just the wrapped content CEK.
+    const blob = JSON.parse(await openEnvelopeJson(env!, tier1BlobDEK)) as { _cek?: string }
     expect(blob._cek).toBeDefined()
 
     await expect(unwrapCek(blob._cek!, tier0BlobDEK)).rejects.toThrow()
@@ -767,10 +773,11 @@ describe('#724 versions follow tier (C4)', () => {
     expect(record.label).toBe('v1')
 
     // AT-REST GUARANTEE 2: the version-HELD blob content's _cek must NOT
-    // unwrap under the tier-0 `_blob` DEK, only under the tier-1 one.
+    // unwrap under the tier-0 `_blob` DEK, only under the tier-1 one — and
+    // #747: neither does the index envelope itself anymore.
     const blobEnv = await store.get('v1', BLOB_INDEX_COLLECTION, record.eTag)
     expect(blobEnv).not.toBeNull()
-    const blob = JSON.parse(await openEnvelopeJson(blobEnv!, tier0BlobDEK)) as { _cek?: string }
+    const blob = JSON.parse(await openEnvelopeJson(blobEnv!, tier1BlobDEK)) as { _cek?: string }
     expect(blob._cek).toBeDefined()
     await expect(unwrapCek(blob._cek!, tier0BlobDEK)).rejects.toThrow()
     await expect(unwrapCek(blob._cek!, tier1BlobDEK)).resolves.toBeDefined()
@@ -806,7 +813,8 @@ describe('#724 versions follow tier (C4)', () => {
 
     const blobEnv = await store.get('v1', BLOB_INDEX_COLLECTION, record.eTag)
     expect(blobEnv).not.toBeNull()
-    const blob = JSON.parse(await openEnvelopeJson(blobEnv!, tier0BlobDEK)) as { _cek?: string }
+    // #747: the index envelope is itself tier-1-keyed too.
+    const blob = JSON.parse(await openEnvelopeJson(blobEnv!, tier1BlobDEK)) as { _cek?: string }
     await expect(unwrapCek(blob._cek!, tier0BlobDEK)).rejects.toThrow()
     await expect(unwrapCek(blob._cek!, tier1BlobDEK)).resolves.toBeDefined()
 
@@ -971,7 +979,8 @@ describe('#724 composition enforcement (I1)', () => {
 
     const env = await store.get('v1', BLOB_INDEX_COLLECTION, newETag)
     expect(env).not.toBeNull()
-    const blob = JSON.parse(await openEnvelopeJson(env!, tier0BlobDEK)) as { _cek?: string }
+    // #747: the index envelope is itself tier-1-keyed too.
+    const blob = JSON.parse(await openEnvelopeJson(env!, tier1BlobDEK)) as { _cek?: string }
     expect(blob._cek).toBeDefined()
 
     // AT-REST GUARANTEE: not unwrappable under tier-0 anymore, only tier-1.
@@ -1023,7 +1032,8 @@ describe('#724 composition enforcement (I1)', () => {
     const slots = JSON.parse(await openEnvelopeJson(slotsEnv!, collDEK1)) as Record<string, { eTag: string }>
     const eTag = slots.attachment!.eTag
     const env = await store.get('v1', BLOB_INDEX_COLLECTION, eTag)
-    const blob = JSON.parse(await openEnvelopeJson(env!, tier0BlobDEK)) as { _cek?: string }
+    // #747: the index envelope is itself tier-1-keyed too.
+    const blob = JSON.parse(await openEnvelopeJson(env!, tier1BlobDEK)) as { _cek?: string }
     expect(blob._cek).toBeDefined()
     await expect(unwrapCek(blob._cek!, tier0BlobDEK)).rejects.toThrow()
     await expect(unwrapCek(blob._cek!, tier1BlobDEK)).resolves.toBeDefined()
@@ -1164,5 +1174,152 @@ describe('#724 re-review: genuine slot-map read failure surfaces as forget resid
     // its slot map could not be read, so the erasure is incomplete and
     // must be surfaced as residue, not swallowed.
     expect(result.blobResidueCollections).toContain('docs')
+  })
+})
+
+describe('#747 BlobObject index envelope follows the eTag tier DEK', () => {
+  it('THE LEAK (RED pre-fix): elevate — the _blob_index envelope is NOT flat-decryptable at rest, but the content still round-trips for the owner', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+    const getDEK = (vault as unknown as { getDEK(name: string): Promise<EnclaveKey> }).getDEK
+    const tier0BlobDEK = await getDEK(dekKey('_blob', 0))
+    const tier1BlobDEK = await getDEK(dekKey('_blob', 1))
+    const collDEK1 = await getDEK(dekKey('docs', 1))
+
+    await docs.putAtTier('d1', { id: 'd1', title: 'Invoice', body: 'x' }, 0)
+    await docs.blob('d1').put('attachment', new TextEncoder().encode('index envelope secret'))
+
+    await docs.elevate('d1', 1)
+
+    const slotsEnv = await store.get('v1', '_blob_slots_docs', 'd1')
+    const slots = JSON.parse(await openEnvelopeJson(slotsEnv!, collDEK1)) as Record<string, { eTag: string }>
+    const eTag = slots.attachment!.eTag
+
+    const indexEnv = await store.get('v1', BLOB_INDEX_COLLECTION, eTag)
+    expect(indexEnv).not.toBeNull()
+
+    // THE LEAK — RED before the fix: the index envelope (size/mimeType/
+    // compression/chunkCount/refCount/createdAt) must NOT be readable
+    // under the flat tier-0 `_blob` DEK anymore, only under tier-1's.
+    await expect(openEnvelopeJson(indexEnv!, tier0BlobDEK)).rejects.toThrow()
+    const blob = JSON.parse(await openEnvelopeJson(indexEnv!, tier1BlobDEK)) as { _cek?: string; refCount: number }
+    expect(blob._cek).toBeDefined()
+    await expect(unwrapCek(blob._cek!, tier1BlobDEK)).resolves.toBeDefined()
+
+    // Rehome unaffected by the index-envelope re-key — content round-trips
+    // for the owner once demoted back within reach of the read gate.
+    await docs.demote('d1', 0)
+    const bytes = await docs.blob('d1').get('attachment')
+    expect(bytes).not.toBeNull()
+    expect(new TextDecoder().decode(bytes!)).toBe('index envelope secret')
+  })
+
+  it('demote re-keys the index envelope back to the flat DEK', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+    const getDEK = (vault as unknown as { getDEK(name: string): Promise<EnclaveKey> }).getDEK
+    const tier0BlobDEK = await getDEK(dekKey('_blob', 0))
+
+    await docs.putAtTier('d1', { id: 'd1', title: 'Invoice', body: 'x' }, 0)
+    await docs.blob('d1').put('attachment', new TextEncoder().encode('demote re-key bytes'))
+    const originalETag = (await docs.blob('d1').blobInfo('attachment'))!.eTag
+
+    await docs.elevate('d1', 1)
+    await docs.demote('d1', 0)
+
+    // Demote's re-put naturally reproduces the original tier-0 eTag
+    // (deterministic content-addressing) — see the #724 reversibility tests.
+    const eTag = (await docs.blob('d1').blobInfo('attachment'))!.eTag
+    expect(eTag).toBe(originalETag)
+
+    const indexEnv = await store.get('v1', BLOB_INDEX_COLLECTION, eTag)
+    expect(indexEnv).not.toBeNull()
+    await expect(openEnvelopeJson(indexEnv!, tier0BlobDEK)).resolves.toBeDefined()
+  })
+
+  it('tier-0 record: the index envelope stays flat-keyed, unchanged', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+    const getDEK = (vault as unknown as { getDEK(name: string): Promise<EnclaveKey> }).getDEK
+    const tier0BlobDEK = await getDEK(dekKey('_blob', 0))
+
+    await docs.putAtTier('d1', { id: 'd1', title: 'Invoice', body: 'x' }, 0)
+    await docs.blob('d1').put('attachment', new TextEncoder().encode('tier-0 bytes'))
+    const eTag = (await docs.blob('d1').blobInfo('attachment'))!.eTag
+
+    const indexEnv = await store.get('v1', BLOB_INDEX_COLLECTION, eTag)
+    expect(indexEnv).not.toBeNull()
+    await expect(openEnvelopeJson(indexEnv!, tier0BlobDEK)).resolves.toBeDefined()
+  })
+
+  it('dedup policy: forgetting the elevated co-owner releases its ref without lifting the shared object off the flat DEK', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { docs: 'id' } }),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+      blobTierPolicy: 'dedup',
+    })
+    const getDEK = (vault as unknown as { getDEK(name: string): Promise<EnclaveKey> }).getDEK
+    const tier0BlobDEK = await getDEK(dekKey('_blob', 0))
+
+    const bytes = new TextEncoder().encode('dedup-policy shared bytes (#747)')
+    await docs.put('a', { id: 'a', title: 'A', body: 'x' })
+    await docs.blob('a').put('attachment', bytes)
+    await docs.put('b', { id: 'b', title: 'B', body: 'y' })
+    await docs.blob('b').put('attachment', bytes)
+
+    const sharedETag = (await docs.blob('a').blobInfo('attachment'))!.eTag
+    expect((await docs.blob('a').blobInfo('attachment'))!.refCount).toBe(2)
+
+    await docs.elevate('b', 1)
+
+    // Shared object left in place (dedup policy, #741) — still flat:
+    // documented residue, and still readable via that flat DEK.
+    let indexEnv = await store.get('v1', BLOB_INDEX_COLLECTION, sharedETag)
+    await expect(openEnvelopeJson(indexEnv!, tier0BlobDEK)).resolves.toBeDefined()
+
+    // b's forget() releases ITS hold on the shared object (via `releaseRef`
+    // resolving b's pre-tombstone tier, 1) — a refCount change driven by the
+    // ELEVATED co-owner must not re-key the shared object onto b's tier-1
+    // DEK (which would corrupt a's flat-DEK reads — the correctness crux).
+    const result = await vault.forget('b')
+    expect(result.blobResidueCollections).toEqual([])
+
+    indexEnv = await store.get('v1', BLOB_INDEX_COLLECTION, sharedETag)
+    expect(indexEnv).not.toBeNull()
+    const blob = JSON.parse(await openEnvelopeJson(indexEnv!, tier0BlobDEK)) as { refCount: number }
+    expect(blob.refCount).toBe(1) // only a's hold remains, still flat
+
+    // 'a' still reads its blob intact — untouched by b's forget.
+    const aBytes = await docs.blob('a').get('attachment')
+    expect(aBytes).not.toBeNull()
+    expect(new TextDecoder().decode(aBytes!)).toBe('dedup-policy shared bytes (#747)')
   })
 })

--- a/packages/hub/__tests__/tiers-blobs.test.ts
+++ b/packages/hub/__tests__/tiers-blobs.test.ts
@@ -4,7 +4,7 @@
  * owning record's _tier before returning bytes, exactly as get() does.
  */
 import { describe, it, expect } from 'vitest'
-import { createNoydb, ConflictError, dekKey, UnsupportedTierCompositionError } from '../src/index.js'
+import { createNoydb, ConflictError, dekKey, UnsupportedTierCompositionError, TierNotGrantedError } from '../src/index.js'
 import { withTiers } from '../src/with-audit/tiers/index.js'
 import { withBlobs } from '../src/via/blob/index.js'
 import { withForgetCascade } from '../src/with-audit/forget/index.js'
@@ -1321,5 +1321,118 @@ describe('#747 BlobObject index envelope follows the eTag tier DEK', () => {
     const aBytes = await docs.blob('a').get('attachment')
     expect(aBytes).not.toBeNull()
     expect(new TextDecoder().decode(aBytes!)).toBe('dedup-policy shared bytes (#747)')
+  })
+})
+
+describe('#749 blob(id).atTier() — sanctioned cleared-read path', () => {
+  it('a cleared owner reads an elevated record\'s blobs via atTier() while blob(id) stays hidden — list()/blobInfo() too', async () => {
+    const db = await createNoydb({
+      store: memoryStore(), secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+
+    await docs.putAtTier('d1', { id: 'd1', title: 'Invoice', body: 'x' }, 0)
+    await docs.blob('d1').put('attachment', new TextEncoder().encode('cleared-view bytes'))
+    await docs.elevate('d1', 1)
+
+    // The tier-0 surface still hides it — unchanged by #749.
+    expect(await docs.blob('d1').get('attachment')).toBeNull()
+    expect(await docs.blob('d1').list()).toEqual([])
+    expect(await docs.blob('d1').blobInfo('attachment')).toBeNull()
+
+    // The owner (already holding the tier-1 DEK, minted at elevate()) clears
+    // through atTier() and sees the blob exactly as if it were tier-0.
+    const cleared = await docs.blob('d1').atTier()
+    const bytes = await cleared.get('attachment')
+    expect(bytes).not.toBeNull()
+    expect(new TextDecoder().decode(bytes!)).toBe('cleared-view bytes')
+
+    const listed = await cleared.list()
+    expect(listed).toHaveLength(1)
+    expect(listed[0]!.name).toBe('attachment')
+
+    const info = await cleared.blobInfo('attachment')
+    expect(info).not.toBeNull()
+    expect(info!.size).toBe(new TextEncoder().encode('cleared-view bytes').byteLength)
+
+    // The uncleared handle is untouched by the cleared clone's existence.
+    expect(await docs.blob('d1').get('attachment')).toBeNull()
+  })
+
+  it('an ungranted operator session\'s atTier() rejects with TierNotGrantedError and mints no junk DEK', async () => {
+    const db = await createNoydb({
+      store: memoryStore(), secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+
+    await docs.putAtTier('d1', { id: 'd1', title: 'Invoice', body: 'x' }, 0)
+    await docs.blob('d1').put('attachment', new TextEncoder().encode('secret bytes'))
+    await docs.elevate('d1', 1)
+
+    // Simulate an operator whose keyring never received the tier-1 grant —
+    // same technique `hierarchical-tiers.test.ts` uses for a non-admin,
+    // non-cleared caller.
+    const kr = (vault as unknown as { keyring: { deks: Map<string, unknown>; role: string } }).keyring
+    kr.deks.delete(dekKey('docs', 1))
+    kr.role = 'operator'
+    expect(kr.deks.has(dekKey('docs', 1))).toBe(false)
+
+    await expect(docs.blob('d1').atTier()).rejects.toThrow(TierNotGrantedError)
+
+    // The no-junk-mint property: a failed atTier() must not have minted a
+    // fresh (bogus, non-matching) tier-1 DEK into the ungranted caller's own
+    // keyring as a side effect — `assertTierAccess` runs BEFORE any getDEK.
+    expect(kr.deks.has(dekKey('docs', 1))).toBe(false)
+  })
+
+  it('a tier-0 record: atTier() returns an equivalent working view (round-trip put/get)', async () => {
+    const db = await createNoydb({
+      store: memoryStore(), secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+
+    await docs.putAtTier('d1', { id: 'd1', title: 'Invoice', body: 'x' }, 0)
+
+    const cleared = await docs.blob('d1').atTier()
+    await cleared.put('attachment', new TextEncoder().encode('tier-0 round-trip'))
+    const bytes = await cleared.get('attachment')
+    expect(bytes).not.toBeNull()
+    expect(new TextDecoder().decode(bytes!)).toBe('tier-0 round-trip')
+
+    // Round-trips through the ordinary tier-0 handle too — same record.
+    const viaOrdinary = await docs.blob('d1').get('attachment')
+    expect(viaOrdinary).not.toBeNull()
+    expect(new TextDecoder().decode(viaOrdinary!)).toBe('tier-0 round-trip')
+  })
+
+  it('regression lock: blob(id) WITHOUT atTier() still hides an elevated record\'s blobs', async () => {
+    const db = await createNoydb({
+      store: memoryStore(), secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+
+    await docs.putAtTier('d1', { id: 'd1', title: 'Invoice', body: 'x' }, 0)
+    await docs.blob('d1').put('attachment', new TextEncoder().encode('still hidden'))
+    await docs.elevate('d1', 1)
+
+    expect(await docs.blob('d1').get('attachment')).toBeNull()
+    expect(await docs.blob('d1').list()).toEqual([])
+    expect(await docs.blob('d1').blobInfo('attachment')).toBeNull()
   })
 })

--- a/packages/hub/__tests__/tiers-blobs.test.ts
+++ b/packages/hub/__tests__/tiers-blobs.test.ts
@@ -1435,4 +1435,29 @@ describe('#749 blob(id).atTier() — sanctioned cleared-read path', () => {
     expect(await docs.blob('d1').list()).toEqual([])
     expect(await docs.blob('d1').blobInfo('attachment')).toBeNull()
   })
+
+  it('a cleared owner reads a published VERSION\'s response on an elevated record via atTier() — the fourth fetchAllChunks site (review)', async () => {
+    const db = await createNoydb({
+      store: memoryStore(), secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+
+    await docs.putAtTier('d1', { id: 'd1', title: 'Invoice', body: 'x' }, 0)
+    await docs.blob('d1').put('attachment', new TextEncoder().encode('versioned cleared bytes'))
+    await docs.blob('d1').publish('attachment', 'v1')
+    await docs.elevate('d1', 1)
+
+    // The tier-0 surface hides it, same as every other blob accessor.
+    expect(await docs.blob('d1').responseVersion('attachment', 'v1')).toBeNull()
+
+    const cleared = await docs.blob('d1').atTier()
+    const res = await cleared.responseVersion('attachment', 'v1', { inline: true })
+    expect(res).not.toBeNull()
+    const body = new Uint8Array(await res!.arrayBuffer())
+    expect(new TextDecoder().decode(body)).toBe('versioned cleared bytes')
+  })
 })

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -4070,7 +4070,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       getDEK: this.getDEK,
       encrypted: this.storeCiphertext,
       userId: this.keyring.userId,
-      erasableBlobs: this.perRecordCek, tiersActive: this.tiers !== null,
+      erasableBlobs: this.perRecordCek, tiersActive: this.tiers !== null, keyring: this.keyring,
       debugPlaintext: this.keyring.debugPlaintext === true,
       ...(this.objectStore !== undefined ? { objectStore: this.objectStore } : {}),
       ...(this.blobFields !== undefined ? { blobFields: this.blobFields } : {}),

--- a/packages/hub/src/port/with/blob-strategy.ts
+++ b/packages/hub/src/port/with/blob-strategy.ts
@@ -23,6 +23,7 @@ import type { NoydbStore } from '../../kernel/types.js'
 import type { ObjectProjection } from '../../with-shape/blobs/object-projection.js'
 import type { BlobFieldsConfig } from '../../with-shape/blobs/blob-compaction.js'
 import type { EnclaveKey } from '../../kernel/enclave/index.js'
+import type { UnlockedKeyring } from '../../with-party/team/keyring.js'
 import { linkBlobVia } from '../../via/blob/binding.js'
 
 // Install the blob Via binder EAGERLY (#629 Task 7) — `blobFields` policies
@@ -81,6 +82,15 @@ export interface BlobStrategyOpenArgs {
   readonly objectStore?: ObjectProjection
   /** Per-collection blob field policies — used to resolve `external` / `public`. */
   readonly blobFields?: BlobFieldsConfig
+  /**
+   * The caller's unlocked keyring (#749). Threaded through so `BlobSet.atTier()`
+   * can run `assertTierAccess` — the SAME clearance gate `putAtTier`/`elevate`/
+   * `demote` run before any tier `getDEK` call — rather than relying on a bare
+   * `getDEK`, which auto-mints a DEK for ANY role and never throws (verified: it
+   * is not itself a gate). Omitted only by a construction path that never calls
+   * `atTier()`.
+   */
+  readonly keyring?: UnlockedKeyring
 }
 
 /**

--- a/packages/hub/src/with-shape/blobs/blob-set.ts
+++ b/packages/hub/src/with-shape/blobs/blob-set.ts
@@ -25,9 +25,10 @@ import {
   sha256Hex,
   type EnclaveKey,
 } from '../../kernel/enclave/index.js'
-import { ConflictError, NotFoundError, UnsupportedTierCompositionError, ValidationError } from '../../kernel/errors.js'
+import { ConflictError, NotFoundError, TierNotGrantedError, UnsupportedTierCompositionError, ValidationError } from '../../kernel/errors.js'
 import { liveRecordIsElevated, liveRecordTier } from '../../kernel/tier-visibility.js'
-import { dekKey } from '../../with-party/team/tiers.js'
+import { dekKey, assertTierAccess } from '../../with-party/team/tiers.js'
+import type { UnlockedKeyring } from '../../with-party/team/keyring.js'
 import { detectMagic, isPreCompressed } from './mime-magic.js'
 
 // ─── Internal collection names ─────────────────────────────────────────
@@ -155,6 +156,13 @@ export class BlobSet {
   private readonly debugPlaintext: boolean
   private readonly objectStore: ObjectProjection | undefined
   private readonly blobFields: BlobFieldsConfig | undefined
+  private readonly keyring: UnlockedKeyring | undefined
+  /**
+   * Set only on the cleared clone `atTier()` returns (#749) — never by
+   * `openSlot`/`Collection.blob()`. Its presence is what makes a `BlobSet`
+   * a cleared view: see `ownerRecordElevated()`/`ownerTier()`.
+   */
+  private readonly clearedTier: number | undefined
 
   constructor(opts: {
     store: NoydbStore
@@ -170,6 +178,8 @@ export class BlobSet {
     debugPlaintext?: boolean
     objectStore?: ObjectProjection
     blobFields?: BlobFieldsConfig
+    keyring?: UnlockedKeyring
+    clearedTier?: number
   }) {
     this.store = opts.store
     this.vault = opts.vault
@@ -184,6 +194,8 @@ export class BlobSet {
     this.debugPlaintext = opts.debugPlaintext === true
     this.objectStore = opts.objectStore
     this.blobFields = opts.blobFields
+    this.keyring = opts.keyring
+    this.clearedTier = opts.clearedTier
   }
 
   /**
@@ -238,8 +250,14 @@ export class BlobSet {
    * read on an elevated record is refused exactly like a `get()` on it
    * would be. Reads only the owning record's `_tier` envelope metadata;
    * runs before any blob decrypt.
+   *
+   * #749: a cleared clone (`this.clearedTier !== undefined`, produced only by
+   * `atTier()`) short-circuits to `false` — its whole purpose is to see past
+   * this gate, having already paid the `assertTierAccess` cost `atTier()`
+   * charged to get here. No live envelope peek needed on that path.
    */
   private async ownerRecordElevated(): Promise<boolean> {
+    if (this.clearedTier !== undefined) return false
     return liveRecordIsElevated(this.store, this.vault, this.collection, this.recordId)
   }
 
@@ -255,9 +273,73 @@ export class BlobSet {
    * before invoking `syncBlobs`), while the slot map is still physically at
    * `fromTier` until `rehomeForTier`'s own move step lands — so this peek
    * would resolve the wrong DEK mid-move.
+   *
+   * #749: a cleared clone reports its fixed `clearedTier` instead of
+   * re-peeking — a stable view for the caller's whole session with it. A
+   * concurrent demote/elevate on the underlying record is invisible to an
+   * already-cleared handle; call `atTier()` again to see it.
    */
   private async ownerTier(): Promise<number> {
+    if (this.clearedTier !== undefined) return this.clearedTier
     return liveRecordTier(this.store, this.vault, this.collection, this.recordId)
+  }
+
+  /**
+   * The sanctioned cleared-read path to an elevated record's blobs (#749).
+   *
+   * The law: `blob(id)` is the tier-0 surface — `get()`/`list()`/`blobInfo()`/
+   * etc. all hide an elevated record's blobs from EVERYONE, unconditionally
+   * (`ownerRecordElevated()`, #724 Task 1), with no cleared path of their own.
+   * `atTier()` is that cleared path, the `getAtTier()` analogue for blobs:
+   * live-peeks the owning record's tier, and for `tier > 0` runs
+   * `assertTierAccess` — the SAME gate `putAtTier`/`elevate`/`demote` run
+   * before ever touching a tier DEK — then returns a NEW `BlobSet` bound to
+   * that tier. Every subsequent call on the returned handle (`get()`,
+   * `list()`, `publish()`, …) sees through the gate as if the record were at
+   * tier 0.
+   *
+   * `assertTierAccess` — not a bare `getDEK` call — IS the authorization
+   * check: owner/admin/custodian bypass it (their on-demand tier-DEK mint is
+   * sanctioned), everyone else must already hold the tier DEK (via a prior
+   * grant or delegation) or it throws `TierNotGrantedError`. A bare `getDEK`
+   * would not gate anything here — it silently mints a fresh DEK for ANY
+   * caller when one is missing, which is exactly the "non-cleared caller
+   * creating tier key material inside the trust boundary" hazard
+   * `assertTierAccess`'s own doc comment (`with-party/team/tiers.ts`) warns
+   * against; running it BEFORE any `getDEK` call is what keeps an ungranted
+   * member's failed `atTier()` call from minting junk key material into
+   * their keyring as a side effect. No tier DEK is resolved here at all —
+   * every actual read still resolves its DEK lazily, same as today.
+   *
+   * `this.keyring` is undefined only on a construction path that never
+   * threads one through `openSlot` (`Collection.blob()` always does) — that
+   * can't prove clearance for anyone, so it throws the same
+   * `TierNotGrantedError` an ungranted caller would get.
+   */
+  async atTier(): Promise<BlobSet> {
+    const tier = await liveRecordTier(this.store, this.vault, this.collection, this.recordId)
+    if (tier === 0) return this
+
+    if (!this.keyring) throw new TierNotGrantedError(this.collection, tier)
+    assertTierAccess(this.keyring, this.collection, tier)
+
+    return new BlobSet({
+      store: this.store,
+      vault: this.vault,
+      collection: this.collection,
+      recordId: this.recordId,
+      getDEK: this.getDEK,
+      encrypted: this.encrypted,
+      erasableBlobs: this.erasableBlobs,
+      tiersActive: this.tiersActive,
+      debugPlaintext: this.debugPlaintext,
+      keyring: this.keyring,
+      clearedTier: tier,
+      ...(this.userId !== undefined ? { userId: this.userId } : {}),
+      ...(this.maxBlobBytes !== undefined ? { maxBlobBytes: this.maxBlobBytes } : {}),
+      ...(this.objectStore !== undefined ? { objectStore: this.objectStore } : {}),
+      ...(this.blobFields !== undefined ? { blobFields: this.blobFields } : {}),
+    })
   }
 
   /** The internal collection that holds slot metadata for this collection's blobs. */
@@ -1434,7 +1516,16 @@ export class BlobSet {
     const result = await this.loadBlobObject(slot.eTag)
     if (!result) return null
 
-    return this.fetchAllChunks(result.blob)
+    // #749: `fetchAllChunks`'s own `blobDEK` default (`resolveChunkKey`'s
+    // flat `_blob` fallback) predates #724 Task 3's tier-scoped content CEKs
+    // and was never wrong before `atTier()` existed — every pre-#749 caller
+    // reaching this line was, by construction, a tier-0 record (the
+    // `ownerRecordElevated()` gate above refused anything else). A cleared
+    // view's elevated content has its `_cek` wrapped under the tier that
+    // OPENED the index envelope (`result.atTier` — #747), not the flat one,
+    // so it must be resolved explicitly here.
+    const blobDEK = this.encrypted ? await this.getDEK(dekKey(BLOB_COLLECTION, result.atTier)) : undefined
+    return this.fetchAllChunks(result.blob, blobDEK)
   }
 
   /**
@@ -1621,7 +1712,9 @@ export class BlobSet {
     const result = await this.loadBlobObject(slot.eTag)
     if (!result) return null
 
-    return this.buildResponse(slot, result.blob, opts)
+    // #749: see the matching comment in `get()`.
+    const blobDEK = this.encrypted ? await this.getDEK(dekKey(BLOB_COLLECTION, result.atTier)) : undefined
+    return this.buildResponse(slot, result.blob, opts, blobDEK)
   }
 
   /**
@@ -1738,7 +1831,11 @@ export class BlobSet {
     const result = await this.loadBlobObject(record.eTag)
     if (!result) return null
 
-    return this.fetchAllChunks(result.blob)
+    // #749: see the matching comment in `get()` — `result.atTier` is the
+    // tier that actually opened the index envelope, which is what the
+    // wrapped content `_cek` is scoped under.
+    const blobDEK = this.encrypted ? await this.getDEK(dekKey(BLOB_COLLECTION, result.atTier)) : undefined
+    return this.fetchAllChunks(result.blob, blobDEK)
   }
 
   /**
@@ -1912,6 +2009,7 @@ export class BlobSet {
     slot: SlotRecord,
     blob: BlobObject,
     opts?: BlobResponseOptions,
+    blobDEK?: EnclaveKey,
   ): Promise<Response> {
     const fetchAllChunks = this.fetchAllChunks.bind(this)
 
@@ -1919,7 +2017,7 @@ export class BlobSet {
     const body = new ReadableStream<Uint8Array>({
       async start(controller) {
         try {
-          const output = await fetchAllChunks(blob)
+          const output = await fetchAllChunks(blob, blobDEK)
           controller.enqueue(output)
           controller.close()
         } catch (err) {

--- a/packages/hub/src/with-shape/blobs/blob-set.ts
+++ b/packages/hub/src/with-shape/blobs/blob-set.ts
@@ -384,27 +384,72 @@ export class BlobSet {
 
   // ─── Blob Index I/O (versioned for CAS refCount) ──────────────────
 
-  private async loadBlobObject(eTag: string): Promise<{ blob: BlobObject; version: number } | null> {
+  /**
+   * #747: the `_blob_index` envelope follows the eTag's HOME tier — the
+   * same tier the `_cek` payload wrapped inside it has been scoped to since
+   * #724. That fix only tier-scoped the WRAPPED content CEK; the outer
+   * index envelope itself stayed flat, so a tier-0 DEK holder could still
+   * read an elevated record's blob metadata (size/mimeType/compression/
+   * chunkCount/refCount/createdAt) straight off `_blob_index` at rest.
+   *
+   * `tier` defaults to `ownerTier()`, mirroring `loadSlots`. At `tier > 0`,
+   * try the tier DEK first; on a decrypt failure (wrong key — AES-GCM auth
+   * fails, not "missing") retry under the flat `_blob` DEK. The fallback
+   * covers the two legitimate classes that stay flat even for an elevated
+   * owner: a `dedup`-policy shared object (#741, left in place on purpose)
+   * and a legacy `_cek`-less object (chunks direct under the flat DEK,
+   * never tier-isolated — #724 I1). `atTier` reports which key actually
+   * opened it, so a caller mutating the object (`casUpdateRefCount`) can
+   * write it back under that SAME key — never lifting a flat dedup/legacy
+   * object onto the owner's tier as a side effect of a refCount change.
+   *
+   * No migration/compat path: the whole tiers×blobs arc is unpublished, so
+   * there is no previously-published elevated blob whose index envelope is
+   * stuck flat at rest — every elevated write from here on is born
+   * tier-keyed.
+   */
+  private async loadBlobObject(
+    eTag: string,
+    tier?: number,
+  ): Promise<{ blob: BlobObject; version: number; atTier: number } | null> {
     const envelope = await this.store.get(this.vault, BLOB_INDEX_COLLECTION, eTag)
     if (!envelope) return null
 
     if (!this.encrypted) {
-      return { blob: JSON.parse(envelope._data) as BlobObject, version: envelope._v }
+      return { blob: JSON.parse(envelope._data) as BlobObject, version: envelope._v, atTier: 0 }
+    }
+
+    const t = tier ?? await this.ownerTier()
+    if (t > 0) {
+      const tierDek = await this.getDEK(dekKey(BLOB_COLLECTION, t))
+      try {
+        const json = await openEnvelopeJson(envelope, tierDek)
+        return { blob: JSON.parse(json) as BlobObject, version: envelope._v, atTier: t }
+      } catch {
+        // Wrong key at this tier — fall through to the flat retry below
+        // (dedup-shared or legacy: see doc comment).
+      }
     }
 
     const dek = await this.getDEK(BLOB_COLLECTION)
     const json = await openEnvelopeJson(envelope, dek)
-    return { blob: JSON.parse(json) as BlobObject, version: envelope._v }
+    return { blob: JSON.parse(json) as BlobObject, version: envelope._v, atTier: 0 }
   }
 
-  private async writeBlobObject(blob: BlobObject, expectedVersion?: number): Promise<void> {
+  /**
+   * @param tier See {@link loadBlobObject}'s `tier` param — same resolution.
+   * A caller mutating an EXISTING object must pass the tier that OPENED it
+   * (`loadBlobObject`'s `atTier`), never its own ask — see
+   * `casUpdateRefCount`.
+   */
+  private async writeBlobObject(blob: BlobObject, expectedVersion?: number, tier?: number): Promise<void> {
     const json = JSON.stringify(blob)
     const now = new Date().toISOString()
     const newVersion = (expectedVersion ?? 0) + 1
     let envelope: EncryptedEnvelope
 
     if (this.encrypted) {
-      const dek = await this.getDEK(BLOB_COLLECTION)
+      const dek = await this.getDEK(dekKey(BLOB_COLLECTION, tier ?? await this.ownerTier()))
       const { iv, data } = await encrypt(json, dek)
       envelope = { _noydb: NOYDB_FORMAT_VERSION, _v: newVersion, _ts: now, _iv: iv, _data: data }
     } else {
@@ -422,15 +467,21 @@ export class BlobSet {
 
   /**
    * CAS retry loop for refCount changes on a BlobObject.
+   *
+   * @param tier Resolves the READ side (see {@link loadBlobObject}). The
+   * WRITE-back always uses `atTier` — the tier that actually opened the
+   * object — never `tier` itself: a dedup-shared or legacy object left flat
+   * on purpose must stay flat even when asked for under an elevated
+   * owner's tier, or a refCount change would silently lift it there (#747).
    */
-  private async casUpdateRefCount(eTag: string, delta: number): Promise<number> {
+  private async casUpdateRefCount(eTag: string, delta: number, tier?: number): Promise<number> {
     for (let attempt = 0; attempt < MAX_CAS_RETRIES; attempt++) {
-      const result = await this.loadBlobObject(eTag)
+      const result = await this.loadBlobObject(eTag, tier)
       if (!result) throw new NotFoundError(`BlobObject ${eTag} not found`)
-      const { blob, version } = result
+      const { blob, version, atTier } = result
       const updated: BlobObject = { ...blob, refCount: blob.refCount + delta }
       try {
-        await this.writeBlobObject(updated, version)
+        await this.writeBlobObject(updated, version, atTier)
         return updated.refCount
       } catch (err) {
         if (err instanceof ConflictError && attempt < MAX_CAS_RETRIES - 1) continue
@@ -456,16 +507,21 @@ export class BlobSet {
    *
    * @returns `'shredded'` (erasable, refCount 0, chunks dead) · `'retainedShared'`
    *   (erasable, still referenced) · `'residue'` (legacy — not a crypto-shred).
+   *
+   * @param tier See {@link loadBlobObject}'s `tier` param — forwarded to both
+   * the read and the refCount write-back (which resolves its own `atTier`
+   * from the read, per `casUpdateRefCount`'s doc comment).
    */
   private async releaseRef(
     eTag: string,
     n: number,
     reclaimLegacy: boolean,
+    tier?: number,
   ): Promise<'shredded' | 'retainedShared' | 'residue'> {
-    const loaded = await this.loadBlobObject(eTag)
+    const loaded = await this.loadBlobObject(eTag, tier)
     if (!loaded) return 'shredded' // already gone
     const erasable = loaded.blob._cek !== undefined
-    const remaining = await this.casUpdateRefCount(eTag, -n)
+    const remaining = await this.casUpdateRefCount(eTag, -n, tier)
     if (remaining > 0) return erasable ? 'retainedShared' : 'residue'
 
     if (erasable || reclaimLegacy) {
@@ -561,7 +617,10 @@ export class BlobSet {
     for (const [eTag, n] of holds) {
       // Forget erasure reclaims legacy orphans too (the record is being erased),
       // so reclaimLegacy = true — but only erasable blobs count as a crypto-shred.
-      const outcome = await this.releaseRef(eTag, n, true)
+      // #747: pass the pre-tombstone `ownerTier` — by now the record itself is
+      // tombstoned, so the `ownerTier()` default would resolve tier 0 and try
+      // the wrong DEK first for an elevated owner's holds.
+      const outcome = await this.releaseRef(eTag, n, true, ownerTier)
       if (outcome === 'shredded') shredded.push(eTag)
       else if (outcome === 'retainedShared') retainedShared.push(eTag)
       else residue.push(eTag)
@@ -686,7 +745,7 @@ export class BlobSet {
         const toBlobDEK = await this.getDEK(dekKey(BLOB_COLLECTION, toTier))
 
         for (const eTag of eTags) {
-          const loaded = await this.loadBlobObject(eTag)
+          const loaded = await this.loadBlobObject(eTag, fromTier)
           if (!loaded) continue
           const { blob } = loaded
           if (blob._cek === undefined) continue // legacy: no rewrap (see doc comment)
@@ -701,12 +760,16 @@ export class BlobSet {
           rehomedETags.set(eTag, await hmacSha256Hex(toBlobDEK, plaintext))
           for (const [slotName, slot] of Object.entries(slots)) {
             if (slot.eTag !== eTag) continue
+            // #747: `fromTier` still pins the slot-map CAS (it's physically
+            // there until this method's own move step, last); `toTier` is the
+            // NEW object's home — thread it alongside `toBlobDEK` so the fresh
+            // `_blob_index` envelope is born tier-keyed, not flat.
             await this.putUnderDEK(slotName, plaintext, toBlobDEK, {
               filename: slot.filename,
               ...(blob.mimeType !== undefined ? { mimeType: blob.mimeType } : {}),
               compress: blob.compression === 'gzip',
               ...(slot.uploadedBy !== undefined ? { uploadedBy: slot.uploadedBy } : {}),
-            }, fromTier)
+            }, fromTier, toTier)
           }
         }
       }
@@ -761,7 +824,7 @@ export class BlobSet {
         ? JSON.parse(await openEnvelopeJson(envelope, fromCollDEK)) as VersionRecord
         : JSON.parse(envelope._data) as VersionRecord
 
-      const newETag = await this.rehomeVersionETag(record, fromBlobDEK, toBlobDEK, policy, rehomedETags)
+      const newETag = await this.rehomeVersionETag(record, fromTier, toTier, fromBlobDEK, toBlobDEK, policy, rehomedETags)
       const moved: VersionRecord = newETag === record.eTag ? record : { ...record, eTag: newETag }
       await this.writeVersionRecordAtKey(key, moved, toTier)
     }
@@ -781,9 +844,16 @@ export class BlobSet {
    * plaintext itself via `writeBlobContent` — the same content-write core
    * `put()`/the slot loop use, no new crypto — mirroring the slot case's
    * legacy/`dedup`-shared skip conditions.
+   *
+   * @param fromTier / @param toTier #747: same from/to split as the slot
+   * loop above — reads of the version's CURRENTLY-held eTag (and releases of
+   * it) pin `fromTier`; the re-put and the refCount bump onto an
+   * already-rehomed (slot-loop-produced) eTag pin `toTier`.
    */
   private async rehomeVersionETag(
     record: VersionRecord,
+    fromTier: number,
+    toTier: number,
     fromBlobDEK: EnclaveKey,
     toBlobDEK: EnclaveKey,
     policy: 'isolate' | 'dedup',
@@ -791,12 +861,12 @@ export class BlobSet {
   ): Promise<string> {
     const already = rehomedETags.get(record.eTag)
     if (already !== undefined) {
-      await this.casUpdateRefCount(already, +1)
-      await this.releaseRef(record.eTag, 1, false).catch(() => {})
+      await this.casUpdateRefCount(already, +1, toTier)
+      await this.releaseRef(record.eTag, 1, false, fromTier).catch(() => {})
       return already
     }
 
-    const loaded = await this.loadBlobObject(record.eTag)
+    const loaded = await this.loadBlobObject(record.eTag, fromTier)
     if (!loaded || loaded.blob._cek === undefined) return record.eTag // legacy/missing: no-op
     if (policy === 'dedup' && loaded.blob.refCount > 1) return record.eTag // #741: same residue as the slot case
 
@@ -805,10 +875,10 @@ export class BlobSet {
       filename: record.label,
       ...(loaded.blob.mimeType !== undefined ? { mimeType: loaded.blob.mimeType } : {}),
       compress: loaded.blob.compression === 'gzip',
-    })
+    }, toTier)
     rehomedETags.set(record.eTag, newETag) // memoize: two versions may share an eTag outside the slot map too
     if (newETag !== record.eTag) {
-      await this.releaseRef(record.eTag, 1, false).catch(() => {})
+      await this.releaseRef(record.eTag, 1, false, fromTier).catch(() => {})
     }
     return newETag
   }
@@ -858,11 +928,13 @@ export class BlobSet {
     if (!this.encrypted) return { migrated, alreadyErasable }
 
     const blobDEK = await this.getDEK(BLOB_COLLECTION)
-    const { slots } = await this.loadSlots()
+    // #747: legacy-only by definition (a per-blob `_cek` is what migrate()
+    // is minting) — pin flat rather than depend on `ownerTier()`.
+    const { slots } = await this.loadSlots(0)
     const eTags = new Set(Object.values(slots).map((s) => s.eTag))
 
     for (const eTag of eTags) {
-      const loaded = await this.loadBlobObject(eTag)
+      const loaded = await this.loadBlobObject(eTag, 0)
       if (!loaded) continue
       const blob = loaded.blob
       if (blob._cek !== undefined) { alreadyErasable.push(eTag); continue }
@@ -1170,7 +1242,15 @@ export class BlobSet {
    * @param slotsTier #724 Arc 10 Task 4: pins the slot-map CAS update
    * (Step 7) to a specific tier instead of the caller's `ownerTier()`
    * default — `rehomeForTier` passes `fromTier`, since mid-move the slot
-   * map is still physically there (see `ownerTier()`'s doc comment).
+   * map is still physically there (see `ownerTier()`'s doc comment). The
+   * old eTag being replaced lives wherever the slot map itself is
+   * physically keyed, so its release (#747, below) reuses this SAME value
+   * rather than a separate param.
+   * @param contentTier #747: pins the `_blob_index` read/write inside
+   * `writeBlobContent` to a specific tier — `rehomeForTier` passes `toTier`
+   * (matching `blobDEK`, already resolved at `toTier`), since mid-move
+   * `ownerTier()` already reads `toTier` too but this is more direct.
+   * Omitted → `ownerTier()`, correct for `put()`'s ordinary (non-rehome) call.
    */
   private async putUnderDEK(
     slotName: string,
@@ -1178,8 +1258,9 @@ export class BlobSet {
     blobDEK: EnclaveKey | null,
     opts?: BlobPutOptions,
     slotsTier?: number,
+    contentTier?: number,
   ): Promise<void> {
-    const { eTag, mimeType } = await this.writeBlobContent(data, blobDEK, opts)
+    const { eTag, mimeType } = await this.writeBlobContent(data, blobDEK, opts, contentTier)
 
     // Step 7 — CAS-update slot metadata
     const uploaderUserId = opts?.uploadedBy ?? this.userId
@@ -1205,7 +1286,10 @@ export class BlobSet {
     if (this._deferredRefDecrement) {
       const oldETag = this._deferredRefDecrement
       this._deferredRefDecrement = undefined
-      await this.releaseRef(oldETag, 1, false).catch(() => {
+      // #747: the old eTag lives at `slotsTier` (the slot map's CURRENT
+      // physical location — see the param doc above), not this record's
+      // live tier — those diverge mid-rehome.
+      await this.releaseRef(oldETag, 1, false, slotsTier).catch(() => {
         // Best-effort — a missed decrement is reconciled by a later pass.
       })
     }
@@ -1218,11 +1302,17 @@ export class BlobSet {
    * the slot map — `putUnderDEK`'s remaining Step 7 is slot-specific).
    * Content-addressed and dedup-aware exactly like `put()`: hashing the same
    * plaintext under the same `blobDEK` twice always lands on the same eTag.
+   *
+   * @param tier #747: the index-envelope tier to read/write at (see
+   * {@link loadBlobObject}'s `tier` param) — `putUnderDEK`'s `contentTier`,
+   * matching whichever tier `blobDEK` itself was resolved at. Omitted →
+   * `ownerTier()`, correct for `put()`'s ordinary (non-rehome) call.
    */
   private async writeBlobContent(
     data: Uint8Array,
     blobDEK: EnclaveKey | null,
     opts?: BlobPutOptions,
+    tier?: number,
   ): Promise<{ eTag: string; mimeType: string | undefined }> {
     // Step 1 — keyed content-hash (plaintext, before compression)
     const eTag = blobDEK
@@ -1252,13 +1342,13 @@ export class BlobSet {
     if (this.debugPlaintext) shouldCompress = false
 
     // Step 3 — deduplication check
-    const existingBlob = await this.loadBlobObject(eTag)
+    const existingBlob = await this.loadBlobObject(eTag, tier)
 
     if (existingBlob) {
       // eTag already exists — just increment refCount (CAS retry). Dedup is
       // preserved across the content-CEK split: the chunks (and the BlobObject's
       // `_cek`, if any) are reused as-is; a new referencer never re-encrypts.
-      await this.casUpdateRefCount(eTag, +1)
+      await this.casUpdateRefCount(eTag, +1, tier)
       return { eTag, mimeType }
     }
 
@@ -1309,7 +1399,7 @@ export class BlobSet {
       createdAt: new Date().toISOString(),
       refCount: 1,
       ...(wrappedCek !== undefined ? { _cek: wrappedCek } : {}),
-    })
+    }, undefined, tier)
 
     return { eTag, mimeType }
   }

--- a/packages/hub/src/with-shape/blobs/blob-set.ts
+++ b/packages/hub/src/with-shape/blobs/blob-set.ts
@@ -1225,7 +1225,7 @@ export class BlobSet {
   // ─── Fetch all chunks for a blob ──────────────────────────────────
 
   /**
-   * #757 I1 (whole-branch review): when `loadBlobObject`'s tier-scoped open
+   * #747/#749 whole-branch review I1: when `loadBlobObject`'s tier-scoped open
    * fell through to the flat retry while a CLEARED higher-tier view (#749)
    * was reading (`this.clearedTier > 0`, `result.atTier === 0`), the
    * `_blob_index` row that "won" the read is not necessarily the one this
@@ -1282,7 +1282,7 @@ export class BlobSet {
         throw new TamperedError(
           `Blob content for eTag "${verifyFlatETag}" failed content-address verification after a ` +
             'flat-tier fallback open — the _blob_index/_blob_chunks rows do not match the requested ' +
-            'content address (#757 I1)',
+            'content address (#747/#749 review I1)',
         )
       }
     }
@@ -1291,7 +1291,7 @@ export class BlobSet {
   }
 
   /**
-   * #757 I1: the eTag to pass as `fetchAllChunks`'s `verifyFlatETag` — set
+   * #747/#749 review I1: the eTag to pass as `fetchAllChunks`'s `verifyFlatETag` — set
    * only when `loadBlobObject` fell through to the flat retry
    * (`resolvedAtTier === 0`) on a CLEARED higher-tier view
    * (`this.clearedTier > 0`). Every ordinary (non-cleared) call reaching

--- a/packages/hub/src/with-shape/blobs/blob-set.ts
+++ b/packages/hub/src/with-shape/blobs/blob-set.ts
@@ -277,7 +277,13 @@ export class BlobSet {
    * #749: a cleared clone reports its fixed `clearedTier` instead of
    * re-peeking — a stable view for the caller's whole session with it. A
    * concurrent demote/elevate on the underlying record is invisible to an
-   * already-cleared handle; call `atTier()` again to see it.
+   * already-cleared handle; call `atTier()` again to see it. This is not a
+   * silent-corruption risk: a WRITE through a stale clone after a concurrent
+   * move fails loud, not quiet — the slot map/index envelope has already
+   * been physically re-keyed to the record's new tier by `rehomeForTier`, so
+   * the stale clone's `clearedTier`-pinned DEK can no longer open it and the
+   * write throws an AEAD decrypt error rather than silently writing under
+   * the wrong key.
    */
   private async ownerTier(): Promise<number> {
     if (this.clearedTier !== undefined) return this.clearedTier
@@ -1901,7 +1907,9 @@ export class BlobSet {
       ...(record.publishedBy !== undefined ? { uploadedBy: record.publishedBy } : {}),
     }
 
-    return this.buildResponse(slotLike, result.blob, opts)
+    // #749: see the matching comment in `get()`.
+    const blobDEK = this.encrypted ? await this.getDEK(dekKey(BLOB_COLLECTION, result.atTier)) : undefined
+    return this.buildResponse(slotLike, result.blob, opts, blobDEK)
   }
 
   // ─── Diagnostics ──────────────────────────────────────────────────

--- a/packages/hub/src/with-shape/blobs/blob-set.ts
+++ b/packages/hub/src/with-shape/blobs/blob-set.ts
@@ -883,16 +883,23 @@ export class BlobSet {
     return newETag
   }
 
-  /** CAS retry loop for an arbitrary BlobObject mutation. */
+  /**
+   * CAS retry loop for an arbitrary BlobObject mutation. Used only by
+   * `migrate()`, which is legacy-only by definition — a legacy object is
+   * always flat-keyed — so the tier is pinned to `0` explicitly rather than
+   * left to `loadBlobObject`/`writeBlobObject`'s independent `ownerTier()`
+   * defaults, which could diverge on an elevated owner and re-key the
+   * envelope under the elevated tier DEK while chunks stay flat (#747 review).
+   */
   private async casUpdateBlobObject(
     eTag: string,
     mutate: (blob: BlobObject) => BlobObject,
   ): Promise<void> {
     for (let attempt = 0; attempt < MAX_CAS_RETRIES; attempt++) {
-      const result = await this.loadBlobObject(eTag)
+      const result = await this.loadBlobObject(eTag, 0)
       if (!result) throw new NotFoundError(`BlobObject ${eTag} not found`)
       try {
-        await this.writeBlobObject(mutate(result.blob), result.version)
+        await this.writeBlobObject(mutate(result.blob), result.version, 0)
         return
       } catch (err) {
         if (err instanceof ConflictError && attempt < MAX_CAS_RETRIES - 1) continue

--- a/packages/hub/src/with-shape/blobs/blob-set.ts
+++ b/packages/hub/src/with-shape/blobs/blob-set.ts
@@ -25,7 +25,7 @@ import {
   sha256Hex,
   type EnclaveKey,
 } from '../../kernel/enclave/index.js'
-import { ConflictError, NotFoundError, TierNotGrantedError, UnsupportedTierCompositionError, ValidationError } from '../../kernel/errors.js'
+import { ConflictError, NotFoundError, TamperedError, TierNotGrantedError, UnsupportedTierCompositionError, ValidationError } from '../../kernel/errors.js'
 import { liveRecordIsElevated, liveRecordTier } from '../../kernel/tier-visibility.js'
 import { dekKey, assertTierAccess } from '../../with-party/team/tiers.js'
 import type { UnlockedKeyring } from '../../with-party/team/keyring.js'
@@ -328,6 +328,13 @@ export class BlobSet {
 
     if (!this.keyring) throw new TierNotGrantedError(this.collection, tier)
     assertTierAccess(this.keyring, this.collection, tier)
+    // M3 (whole-branch review): the first gate only proves clearance on the
+    // DATA collection (`docs#N`) — a member holding that grant but not the
+    // `_blob#N` DEK grant would otherwise pass straight through and have
+    // the first content read auto-mint a junk `_blob#N` DEK as a side
+    // effect. Gate the blob DEK's own tier too, in the same
+    // before-any-mint spot as the line above.
+    assertTierAccess(this.keyring, BLOB_COLLECTION, tier)
 
     return new BlobSet({
       store: this.store,
@@ -513,9 +520,16 @@ export class BlobSet {
       try {
         const json = await openEnvelopeJson(envelope, tierDek)
         return { blob: JSON.parse(json) as BlobObject, version: envelope._v, atTier: t }
-      } catch {
-        // Wrong key at this tier — fall through to the flat retry below
-        // (dedup-shared or legacy: see doc comment).
+      } catch (err) {
+        // M1 (whole-branch review): only a decrypt/auth failure under the
+        // tier key (`decrypt()` throws `TamperedError` on AES-GCM auth
+        // failure — wrong key or tampered ciphertext) means "not ours at
+        // this tier" — fall through to the flat retry below (dedup-shared
+        // or legacy: see doc comment). A JSON.parse failure AFTER a
+        // successful decrypt under the CORRECT tier key is genuine
+        // corruption, not a wrong-key signal, and must propagate instead
+        // of being masked by a misleading flat-DEK error.
+        if (!(err instanceof TamperedError)) throw err
       }
     }
 
@@ -1210,7 +1224,40 @@ export class BlobSet {
 
   // ─── Fetch all chunks for a blob ──────────────────────────────────
 
-  private async fetchAllChunks(blob: BlobObject, blobDEK?: EnclaveKey): Promise<Uint8Array> {
+  /**
+   * #757 I1 (whole-branch review): when `loadBlobObject`'s tier-scoped open
+   * fell through to the flat retry while a CLEARED higher-tier view (#749)
+   * was reading (`this.clearedTier > 0`, `result.atTier === 0`), the
+   * `_blob_index` row that "won" the read is not necessarily the one this
+   * handle's `assertTierAccess` grant vouches for. Chunk AAD
+   * (`{eTag}:{index}:{count}`) is attacker-computable, and a legacy
+   * (`_cek`-less) object has no wrapped content CEK to unwrap under a key
+   * the attacker doesn't hold — so ANY flat `_blob` DEK holder with store
+   * write access can plant a `_cek`-less forgery at `_blob_index/{eTag}`
+   * (this elevated blob's own address) whose chunks are their own flat
+   * bytes, and it will decrypt cleanly under the flat DEK the fallback
+   * already tries.
+   *
+   * `verifyFlatETag`, when set, is the eTag the CALLER originally asked
+   * for (the slot/version's `.eTag` — never `blob.eTag`, which is
+   * attacker-controlled content pulled from the same forged row and would
+   * make the check tautological). After assembling the plaintext, we
+   * recompute the SAME content address every write path mints
+   * (`hmacSha256Hex(flatBlobDEK, plaintext)` — `writeBlobContent`'s Step 1,
+   * unconditional on `_cek`) and compare it to that requested eTag. A
+   * forged row can produce valid ciphertext under the flat DEK, but can't
+   * produce plaintext that re-hashes to an address it doesn't control.
+   *
+   * Both legitimate flat-fallback classes — a `dedup`-policy shared object
+   * (#741) and a legacy `_cek`-less object (#724 I1) — were minted this
+   * same way, so an honest read's recomputed hash always matches and this
+   * is a no-op for them.
+   */
+  private async fetchAllChunks(
+    blob: BlobObject,
+    blobDEK?: EnclaveKey,
+    verifyFlatETag?: string,
+  ): Promise<Uint8Array> {
     // Chunks are keyed under the per-blob content CEK (erasable) or directly
     // under the `_blob` DEK (legacy) — resolveChunkKey discriminates on `_cek`.
     const chunkKey = await this.resolveChunkKey(blob, blobDEK)
@@ -1227,7 +1274,35 @@ export class BlobSet {
     }
 
     const assembled = concatChunks(chunks)
-    return blob.compression === 'gzip' ? await decompressBytes(assembled) : assembled
+    const plaintext = blob.compression === 'gzip' ? await decompressBytes(assembled) : assembled
+
+    if (verifyFlatETag !== undefined && blobDEK) {
+      const recomputed = await hmacSha256Hex(blobDEK, plaintext)
+      if (recomputed !== verifyFlatETag) {
+        throw new TamperedError(
+          `Blob content for eTag "${verifyFlatETag}" failed content-address verification after a ` +
+            'flat-tier fallback open — the _blob_index/_blob_chunks rows do not match the requested ' +
+            'content address (#757 I1)',
+        )
+      }
+    }
+
+    return plaintext
+  }
+
+  /**
+   * #757 I1: the eTag to pass as `fetchAllChunks`'s `verifyFlatETag` — set
+   * only when `loadBlobObject` fell through to the flat retry
+   * (`resolvedAtTier === 0`) on a CLEARED higher-tier view
+   * (`this.clearedTier > 0`). Every ordinary (non-cleared) call reaching
+   * a content-fetch site already has `ownerTier() === 0` (elevated records
+   * are hidden by `ownerRecordElevated()` before this point), so
+   * `loadBlobObject` never even attempts the tier branch for them — no
+   * fallback occurred, nothing to verify.
+   */
+  private flatFallbackVerifyETag(requestedETag: string, resolvedAtTier: number): string | undefined {
+    if (this.clearedTier === undefined || this.clearedTier <= 0) return undefined
+    return resolvedAtTier === 0 ? requestedETag : undefined
   }
 
   // ─── Public API: Slot management ──────────────────────────────────
@@ -1531,7 +1606,7 @@ export class BlobSet {
     // OPENED the index envelope (`result.atTier` — #747), not the flat one,
     // so it must be resolved explicitly here.
     const blobDEK = this.encrypted ? await this.getDEK(dekKey(BLOB_COLLECTION, result.atTier)) : undefined
-    return this.fetchAllChunks(result.blob, blobDEK)
+    return this.fetchAllChunks(result.blob, blobDEK, this.flatFallbackVerifyETag(slot.eTag, result.atTier))
   }
 
   /**
@@ -1720,7 +1795,7 @@ export class BlobSet {
 
     // #749: see the matching comment in `get()`.
     const blobDEK = this.encrypted ? await this.getDEK(dekKey(BLOB_COLLECTION, result.atTier)) : undefined
-    return this.buildResponse(slot, result.blob, opts, blobDEK)
+    return this.buildResponse(slot, result.blob, opts, blobDEK, this.flatFallbackVerifyETag(slot.eTag, result.atTier))
   }
 
   /**
@@ -1841,7 +1916,7 @@ export class BlobSet {
     // tier that actually opened the index envelope, which is what the
     // wrapped content `_cek` is scoped under.
     const blobDEK = this.encrypted ? await this.getDEK(dekKey(BLOB_COLLECTION, result.atTier)) : undefined
-    return this.fetchAllChunks(result.blob, blobDEK)
+    return this.fetchAllChunks(result.blob, blobDEK, this.flatFallbackVerifyETag(record.eTag, result.atTier))
   }
 
   /**
@@ -1909,7 +1984,7 @@ export class BlobSet {
 
     // #749: see the matching comment in `get()`.
     const blobDEK = this.encrypted ? await this.getDEK(dekKey(BLOB_COLLECTION, result.atTier)) : undefined
-    return this.buildResponse(slotLike, result.blob, opts, blobDEK)
+    return this.buildResponse(slotLike, result.blob, opts, blobDEK, this.flatFallbackVerifyETag(record.eTag, result.atTier))
   }
 
   // ─── Diagnostics ──────────────────────────────────────────────────
@@ -2018,6 +2093,7 @@ export class BlobSet {
     blob: BlobObject,
     opts?: BlobResponseOptions,
     blobDEK?: EnclaveKey,
+    verifyFlatETag?: string,
   ): Promise<Response> {
     const fetchAllChunks = this.fetchAllChunks.bind(this)
 
@@ -2025,7 +2101,7 @@ export class BlobSet {
     const body = new ReadableStream<Uint8Array>({
       async start(controller) {
         try {
-          const output = await fetchAllChunks(blob, blobDEK)
+          const output = await fetchAllChunks(blob, blobDEK, verifyFlatETag)
           controller.enqueue(output)
           controller.close()
         } catch (err) {


### PR DESCRIPTION
Closes #747. Closes #749. Milestone-34 Batch B (blob tier-completeness arc); plan (incl. the recorded mid-arc design correction): `docs/superpowers/plans/2026-07-17-blob-tier-completeness.md`.

## What

- **#747 — metadata at rest:** the `BlobObject` index envelope now follows its eTag's tier `_blob` DEK. Loads report which key opened the object (`atTier`) and every CAS write-back re-keys under THAT key — the mechanism that keeps a dedup-shared flat object flat when an elevated co-owner changes a refCount (the corruption crux, test-pinned). Rehome splits from/to tiers; `migrate()`'s CAS helper pins flat (defense-in-depth; its reachable tier-blindness is #756). No migration path needed: the tiers×blobs arc has never been published.
- **#749 — cleared reads:** `blob(id).atTier()` is the `getAtTier` analogue. Authorization = `assertTierAccess` on the caller's keyring for BOTH the data collection and `_blob` tier DEKs, strictly BEFORE any `getDEK` — the plan's original getDEK-as-gate design was disproved mid-arc (getDEK auto-mints for any role, never throws) and is recorded as retired in the committed plan. Tests lock the no-junk-mint property. Folded latent fix: 4 chunk-decrypt sites resolved the flat DEK unconditionally (dead code pre-#749, load-bearing for cleared reads).
- **Whole-branch hardening:** a cleared read that falls back to the flat DEK now re-verifies the content address (`hmacSha256Hex(flatDEK, plaintext)` vs the requested slot/version eTag) and throws `TamperedError` — closing a NEW substitution path this branch would otherwise have opened (a flat-DEK holder with store write access forging an elevated blob's content). Fallback catch narrowed to `TamperedError`; partial-grant (`docs#N` without `_blob#N`) junk-mint hole closed.

## Review trail

Per-task reviews (2 review-fix commits: `casUpdateBlobObject` pin-0, `responseVersion` fourth site) + fable whole-branch review ("with fixes" → fix wave + re-review Approved). Issues filed from this arc's reviews: #756 (migrate() tier-blind, m34), #757 (decryptResponse missing `_cek` unwrap + the same substitution side door — severity upgraded on the issue). Accepted residue (in changeset): cleared-view `blobInfo()`/`list()` metadata is not content-verified.

## Verification

Full hub suite 509 files / 4221+ green; typecheck / lint / `check:architecture` clean; `collection.ts` at 4548/4549 ceiling (zero net lines — keyring threaded on an existing joined line). Changeset `blob-tier-completeness.md` (hub patch) local-only per convention.