### PR TITLE
fix(hub): tiers × external-projection guards + extraction canaries (#748)

### DIFF
--- a/packages/hub/__tests__/external-blob.test.ts
+++ b/packages/hub/__tests__/external-blob.test.ts
@@ -170,3 +170,57 @@ describe('#412 P3 — external blob fields route to the ObjectProjection', () =>
     await expect(docs.blob('d1').url('thumb')).rejects.toThrow(/not external/)
   })
 })
+
+describe('#748 — adoptExternal()/setExternalMeta() require a declared external slot', () => {
+  it('adoptExternal() throws when the slot is not declared blobFields[slot].external', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', objectStore: memoryObjectProjection(), blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    // 'scan' is entirely undeclared — no blobFields at all.
+    const docs = vault.collection<{ id: string }>('docs', {})
+    await docs.put('d1', { id: 'd1' })
+    await expect(
+      docs.blob('d1').adoptExternal('scan', { key: 'docs/d1/scan' }),
+    ).rejects.toThrow(/not declared external/)
+  })
+
+  it('adoptExternal() throws when the slot is declared but not external (internal blob field)', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', objectStore: memoryObjectProjection(), blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { thumb: {} } })
+    await docs.put('d1', { id: 'd1' })
+    await expect(
+      docs.blob('d1').adoptExternal('thumb', { key: 'docs/d1/thumb' }),
+    ).rejects.toThrow(/not declared external/)
+  })
+
+  it('adoptExternal() succeeds when the slot IS declared external (positive lock)', async () => {
+    const objects = memoryObjectProjection()
+    await objects.putObject('docs/r1/scan', payload(100), { contentType: 'image/png' })
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', objectStore: objects, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { scan: { external: true } } })
+    await docs.put('r1', { id: 'r1' })
+    await docs.blob('r1').adoptExternal('scan', { key: 'docs/r1/scan', size: 100, contentType: 'image/png' })
+    expect(Buffer.from((await docs.blob('r1').get('scan'))!).equals(Buffer.from(payload(100)))).toBe(true)
+  })
+
+  it('setExternalMeta() throws when the slot is not declared blobFields[slot].external', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', objectStore: memoryObjectProjection(), blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', {})
+    await docs.put('d1', { id: 'd1' })
+    await expect(
+      docs.blob('d1').setExternalMeta('scan', { width: 100 }),
+    ).rejects.toThrow(/not declared external/)
+  })
+
+  it('setExternalMeta() succeeds when the slot IS declared external (positive lock)', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', objectStore: memoryObjectProjection(), blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { video: { external: true } } })
+    await docs.put('d1', { id: 'd1' })
+    await docs.blob('d1').put('video', payload(200))
+    await docs.blob('d1').setExternalMeta('video', { durationSec: 12 })
+    expect(await docs.blob('d1').externalMeta('video')).toEqual({ durationSec: 12 })
+  })
+})

--- a/packages/hub/__tests__/extract-partition.test.ts
+++ b/packages/hub/__tests__/extract-partition.test.ts
@@ -17,7 +17,11 @@ import { ConflictError } from '../src/kernel/errors.js'
 import { decrypt, base64ToBuffer, generateDEK } from '../src/kernel/enclave/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
 import { reKeyClosure, sealDeks, extractPartition } from '../src/with-cargo/extract-partition.js'
+import { adoptPartition, createOwnerOnAdoptedPartition } from '../src/with-cargo/adopt-partition.js'
 import { readNoydbBundle, readNoydbBundleHeader, parseExtractedPartitionBody } from '../src/with-pod/bundle.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withBlobs } from '../src/via/blob/index.js'
+import { BLOB_SLOTS_PREFIX, BLOB_INDEX_COLLECTION } from '../src/with-shape/blobs/blob-set.js'
 
 function memory(): NoydbStore {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -184,5 +188,98 @@ describe('extractPartition end-to-end', () => {
     const env = backup.collections['clients']!['c-1']!
     const recordJson = await decrypt(env._iv, env._data, clientsDek)
     expect(JSON.parse(recordJson)).toMatchObject({ id: 'c-1', name: 'Hotel' })
+  })
+})
+
+/**
+ * #748 — pinning regression: an elevated record is structurally excluded from
+ * an extract-partition closure/bundle. `walkClosure` selects roots via
+ * `Collection.list()` and expands inbound via the same tier-gated read
+ * surface (collection.ts `ensureHydrated`/`#getRaw` skip `_tier > 0`
+ * envelopes) — an elevated record can never become a seed nor an
+ * inbound-expansion target, so it (and any blob it owns) never enters the
+ * closure `reKeyClosure`/`reKeyBlobs` re-key. Absence, not a thrown error:
+ * the extraction succeeds and simply never mentions the elevated record.
+ */
+describe('extractPartition — #748: elevated records are structurally excluded', () => {
+  interface Client { id: string; name: string }
+  interface Invoice { id: string; clientId: string }
+
+  it('an elevated blob-bearing parent (and its blob) is silently absent from the closure and bundle', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      cargoStrategy: withCargo(),
+      store,
+      user: 'alice',
+      secret: 'test-passphrase-1234',
+      tiersStrategy: withTiers(),
+      blobStrategy: withBlobs(),
+    })
+    const company = await db.openVault('demo-co')
+    const clients = company.collection<Client>('clients', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+    const invoices = company.collection<Invoice>('invoices', { refs: { clientId: ref('clients') } })
+
+    // c-1 would otherwise match the seed predicate below and travel with its
+    // blob + FK-connected invoice — elevate it BEFORE extraction so it never
+    // qualifies as a root.
+    await clients.putAtTier('c-1', { id: 'c-1', name: 'Redacted Co' }, 0)
+    await clients.blob('c-1').put('attachment', new TextEncoder().encode('ELEVATED SECRET BYTES'))
+    await invoices.put('inv-1', { id: 'inv-1', clientId: 'c-1' })
+    await clients.elevate('c-1', 1)
+
+    // Sibling stays tier-0 — proves the exclusion is targeted, not global.
+    await clients.putAtTier('c-2', { id: 'c-2', name: 'Visible Co' }, 0)
+    await clients.blob('c-2').put('attachment', new TextEncoder().encode('VISIBLE SIBLING BYTES'))
+    await invoices.put('inv-2', { id: 'inv-2', clientId: 'c-2' })
+
+    // Matches every (visible) client — c-1 never reaches the predicate
+    // because `Collection.list()` already filters it out.
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { clients: () => true },
+    })
+
+    const { dumpJson } = await readNoydbBundle(bundleBytes)
+    const { dump } = parseExtractedPartitionBody(dumpJson)
+    const backup = JSON.parse(dump) as {
+      collections: Record<string, Record<string, EncryptedEnvelope>>
+      _internal?: Record<string, Record<string, EncryptedEnvelope>>
+    }
+
+    // The elevated record + its FK-connected invoice never entered the
+    // closure at all — silently absent, not a tombstone/error placeholder.
+    expect(Object.keys(backup.collections['clients'] ?? {})).toEqual(['c-2'])
+    expect(Object.keys(backup.collections['invoices'] ?? {})).toEqual(['inv-2'])
+
+    // Its blob artifacts never entered `_internal` either — only c-2's slot
+    // map + a single carried blob (c-1's is absent, not just unreadable).
+    const slots = backup._internal?.[`${BLOB_SLOTS_PREFIX}clients`] ?? {}
+    expect(Object.keys(slots)).toEqual(['c-2'])
+    expect(Object.keys(backup._internal?.[BLOB_INDEX_COLLECTION] ?? {})).toHaveLength(1)
+
+    // End-to-end: the recipient never even learns c-1 existed, and c-2's
+    // blob round-trips untouched.
+    const dest = memory()
+    await adoptPartition(bundleBytes, { transferKey, destinationStore: dest, vaultName: 'fresh' })
+    await createOwnerOnAdoptedPartition(dest, 'fresh', {
+      userId: 'belle', passphrase: 'belle-pass-phrase-2026', transferKey,
+    })
+    const recipientDb = await createNoydb({
+      cargoStrategy: withCargo(), store: dest, user: 'belle', secret: 'belle-pass-phrase-2026',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const recipientVault = await recipientDb.openVault('fresh')
+    const recipientClients = recipientVault.collection<Client>('clients', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+    expect(await recipientClients.get('c-1')).toBeNull()
+    expect(await recipientClients.get('c-2')).toMatchObject({ name: 'Visible Co' })
+    const c2Blob = await recipientClients.blob('c-2').get('attachment')
+    expect(c2Blob).not.toBeNull()
+    expect(new TextDecoder().decode(c2Blob!)).toBe('VISIBLE SIBLING BYTES')
+
+    recipientDb.close()
+    db.close()
   })
 })

--- a/packages/hub/__tests__/tiers-blobs.test.ts
+++ b/packages/hub/__tests__/tiers-blobs.test.ts
@@ -1563,3 +1563,55 @@ describe('#747/#749 whole-branch review (I1): fallback content substitution is c
     await expect(cleared.get('attachment')).rejects.toThrow(TamperedError)
   })
 })
+
+describe('#748 composition enforcement — tiers × external public:true', () => {
+  it('a tiered collection declaring a `public: true` external blob field throws at construction', async () => {
+    const db = await createNoydb({
+      store: memoryStore(), secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    expect(() => vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { video: { external: true, public: true } },
+    })).toThrow(UnsupportedTierCompositionError)
+    expect(() => vault.collection<Doc>('docs2', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { video: { external: true, public: true } },
+    })).toThrow(/video/)
+  })
+
+  it('a tiered collection declaring a private (non-public) external blob field constructs fine', async () => {
+    const db = await createNoydb({
+      store: memoryStore(), secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    // `public` omitted — presigned/private external, unaffected.
+    expect(() => vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { video: { external: true } },
+    })).not.toThrow()
+    // `public: false` explicit — also unaffected.
+    expect(() => vault.collection<Doc>('docs2', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { video: { external: true, public: false } },
+    })).not.toThrow()
+  })
+
+  it('a non-tiered collection declaring a `public: true` external blob field still constructs fine', async () => {
+    const db = await createNoydb({ store: memoryStore(), secret: 'pw', user: 'owner', blobStrategy: withBlobs() })
+    const vault = await db.openVault('v1')
+    expect(() => vault.collection<Doc>('docs', {
+      blobFields: { video: { external: true, public: true } },
+    })).not.toThrow()
+  })
+
+  it('a tiered collection with a `public: true` external field alongside an ordinary (non-external) blob field still throws, naming the offending field', async () => {
+    const db = await createNoydb({
+      store: memoryStore(), secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    expect(() => vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true,
+      blobFields: { attachment: {}, video: { external: true, public: true } },
+    })).toThrow(/video/)
+  })
+})

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -933,6 +933,31 @@ export function resolveCollectionConfig<T>(opts: CollectionOpts<T>) {
     )
   }
 
+  // #748 — tiers × a `public: true` external blob field is a structural dead
+  // end, not a crypto gap the perRecordKeys mandate above can close. An
+  // external-public object's key (`{collection}/{recordId}/{slotName}`) is
+  // deterministic and its bytes are world-readable by design (CDN origin) —
+  // elevating the owning record re-keys/re-scopes the ENCRYPTED slot catalog
+  // entry, but can never retroactively hide an already-public bucket object,
+  // nor stop a future `public: true` write from re-publishing it at the same
+  // predictable key. Refuse at construction; private/presigned external
+  // fields (`public` omitted or `false`) are unaffected — only the catalog
+  // entry needs tier-isolation there, which perRecordKeys already provides.
+  if (opts.tiers && opts.tiers.length > 0 && opts.blobFields !== undefined) {
+    for (const [field, policy] of Object.entries(opts.blobFields)) {
+      if (policy?.external && policy.public === true) {
+        throw new UnsupportedTierCompositionError(
+          'blobs',
+          `Collection "${opts.name}": blob field "${field}" cannot be both \`external: true, public: true\` ` +
+            `and declared on a tiered collection — the object key is deterministic and its bytes are ` +
+            `world-readable by design, so tier-invisibility can never be enforced for it once elevated. ` +
+            `Use a private/presigned external field (\`public\` omitted or \`false\`) or move this field to ` +
+            `a non-tiered collection.`,
+        )
+      }
+    }
+  }
+
   // via() / sugar-key merge (#623 Task 9) — throws on a field declared in both.
   const effectiveViaFields = mergeViaFields(opts)
 

--- a/packages/hub/src/with-cargo/extract-partition.ts
+++ b/packages/hub/src/with-cargo/extract-partition.ts
@@ -88,6 +88,19 @@ export async function reKeyClosure(
     for (const id of ids) {
       const env = await adapter.get(vaultName, collectionName, id)
       if (!env) continue
+      // #748 defense-in-depth canary: `closure` is built exclusively through
+      // tier-gated `Collection.list()`/`get()` (collection.ts `ensureHydrated`
+      // / `#getRaw` both skip `_tier > 0` envelopes), so an elevated record
+      // can never reach this raw `adapter.get` fetch — this should be
+      // unreachable by construction. Not a user-facing guard; a cheap tripwire
+      // in case that invariant ever regresses.
+      if ((env._tier ?? 0) > 0) {
+        throw new Error(
+          `#748: reKeyClosure fetched an elevated envelope (collection="${collectionName}" id="${id}" `
+          + `_tier=${env._tier}) — this is unreachable by construction (walkClosure only ever adds ids `
+          + `reachable through tier-gated Collection reads). Refusing to carry it into a partition.`,
+        )
+      }
       if (env._cek !== undefined) {
         // Per-record CEK: a naive `{ ...env }` spread would carry a
         // SOURCE-DEK-wrapped CEK into a bundle re-keyed under a different
@@ -326,6 +339,16 @@ export async function reKeyBlobs(
     for (const id of ids) {
       const env = await adapter.get(vaultName, slotsCollection, id)
       if (!env) continue
+      // #748 defense-in-depth canary — see the matching one in `reKeyClosure`:
+      // `ids` comes from the same tier-gated `closure`, so an elevated
+      // record's slot map should never be reachable here. Unreachable by
+      // construction; a cheap tripwire, not a user-facing guard.
+      if ((env._tier ?? 0) > 0) {
+        throw new Error(
+          `#748: reKeyBlobs fetched an elevated slot-map envelope (collection="${slotsCollection}" `
+          + `id="${id}" _tier=${env._tier}) — this is unreachable by construction. Refusing to carry it into a partition.`,
+        )
+      }
       const slots = JSON.parse(await openEnvelopeJson(env, srcDek)) as Record<string, SlotRecord>
       // FR-7: drop projected-out blob fields' slots (slot names are blob field
       // names) — their eTags then never enter the travel set.
@@ -350,6 +373,14 @@ export async function reKeyBlobs(
       if (proj && slotName !== undefined && !proj.has(slotName)) continue
       const env = await adapter.get(vaultName, versionsCollection, key)
       if (!env) continue
+      // #748 defense-in-depth canary — see `reKeyClosure`'s. Unreachable by
+      // construction; a cheap tripwire, not a user-facing guard.
+      if ((env._tier ?? 0) > 0) {
+        throw new Error(
+          `#748: reKeyBlobs fetched an elevated version-record envelope (collection="${versionsCollection}" `
+          + `key="${key}" _tier=${env._tier}) — this is unreachable by construction. Refusing to carry it into a partition.`,
+        )
+      }
       const record = JSON.parse(await openEnvelopeJson(env, srcDek)) as VersionRecord
       addRef(record.eTag)
       const { iv, data } = await encrypt(JSON.stringify(record), destDek)

--- a/packages/hub/src/with-cargo/extract-partition.ts
+++ b/packages/hub/src/with-cargo/extract-partition.ts
@@ -95,7 +95,7 @@ export async function reKeyClosure(
       // unreachable by construction. Not a user-facing guard; a cheap tripwire
       // in case that invariant ever regresses.
       if ((env._tier ?? 0) > 0) {
-        throw new Error(
+        throw new PartitionExtractionError(
           `#748: reKeyClosure fetched an elevated envelope (collection="${collectionName}" id="${id}" `
           + `_tier=${env._tier}) — this is unreachable by construction (walkClosure only ever adds ids `
           + `reachable through tier-gated Collection reads). Refusing to carry it into a partition.`,
@@ -344,7 +344,7 @@ export async function reKeyBlobs(
       // record's slot map should never be reachable here. Unreachable by
       // construction; a cheap tripwire, not a user-facing guard.
       if ((env._tier ?? 0) > 0) {
-        throw new Error(
+        throw new PartitionExtractionError(
           `#748: reKeyBlobs fetched an elevated slot-map envelope (collection="${slotsCollection}" `
           + `id="${id}" _tier=${env._tier}) — this is unreachable by construction. Refusing to carry it into a partition.`,
         )
@@ -376,7 +376,7 @@ export async function reKeyBlobs(
       // #748 defense-in-depth canary — see `reKeyClosure`'s. Unreachable by
       // construction; a cheap tripwire, not a user-facing guard.
       if ((env._tier ?? 0) > 0) {
-        throw new Error(
+        throw new PartitionExtractionError(
           `#748: reKeyBlobs fetched an elevated version-record envelope (collection="${versionsCollection}" `
           + `key="${key}" _tier=${env._tier}) — this is unreachable by construction. Refusing to carry it into a partition.`,
         )

--- a/packages/hub/src/with-shape/blobs/blob-set.ts
+++ b/packages/hub/src/with-shape/blobs/blob-set.ts
@@ -223,6 +223,25 @@ export class BlobSet {
   }
 
   /**
+   * #748: `adoptExternal()`/`setExternalMeta()` write an `external` slot
+   * reference directly — unlike `put()`, which only takes the external path
+   * when `blobFields[slotName].external` is declared (the construction-time
+   * tiers×blobFields mandate, `collection-config.ts`, then applies). Without
+   * this gate, either method can attach an external reference to a slot the
+   * collection never declared `external` — bypassing that mandate on a tiered
+   * collection. Mirrors `put()`'s own gate.
+   */
+  private assertExternalDeclared(slotName: string): void {
+    if (!this.blobFields?.[slotName]?.external) {
+      throw new ValidationError(
+        `Collection "${this.collection}": blob field "${slotName}" is not declared external `
+          + `(blobFields["${slotName}"].external must be true) — cannot attach an external `
+          + `reference to an undeclared slot (#748).`,
+      )
+    }
+  }
+
+  /**
    * Resolve the key the blob's CHUNKS are encrypted under.
    *
    * - `_cek` present (erasable blob) → unwrap the per-blob content CEK under
@@ -1680,6 +1699,7 @@ export class BlobSet {
   ): Promise<void> {
     this.assertKeyPartSafe(this.recordId, 'record id')
     this.assertKeyPartSafe(slotName, 'slot name')
+    this.assertExternalDeclared(slotName)
 
     const uploaderUserId = this.userId
     await this.casUpdateSlots((slots) => {
@@ -1709,6 +1729,7 @@ export class BlobSet {
    * once it has probed the object. No-op for a missing or non-external slot.
    */
   async setExternalMeta(slotName: string, meta: Record<string, unknown>): Promise<void> {
+    this.assertExternalDeclared(slotName)
     await this.casUpdateSlots((slots) => {
       const slot = slots[slotName]
       if (!slot?.external) return null


### PR DESCRIPTION
Closes #748. Milestone-34 Batch B close-out for the extract-partition/external-projection audit.

## What

The #748 investigation (posted on the issue) overturned the original premise — elevated records are structurally excluded from closure roots and inbound expansion (tier-gated `list()`/`get()`; per-tier eTag namespacing), and post-#747 any flat decode of an elevated artifact fails loud. What remained, and is fixed here:

1. **`adoptExternal()`/`setExternalMeta()` were fully unguarded** — an external reference could be attached to any slot on any collection, bypassing both `put()`'s `blobFields[slot].external` declaration gate and the construction-time tiers mandate. Both now require the declaration (`ValidationError`).
2. **`tiers` × external `public: true` is a structural dead end** (deterministic key, world-readable bytes — elevation can never protect it): refused at construction with `UnsupportedTierCompositionError`, per the campaign's refuse-loudly registration-guard philosophy. Private/presigned external fields unaffected.
3. **Regression pinning + canaries:** a test locks the root/inbound exclusion so future `walkClosure`/hydration changes can't silently regress it; `reKeyClosure`/`reKeyBlobs` gained `_tier > 0` canaries (`PartitionExtractionError`) so the one remaining reachable path — an elevated FK parent entering via outbound completion, found empirically during implementation and filed as **#759** — fails with a named error instead of an opaque CEK-unwrap crash.

## Review trail

Combined task/final review: Approved (both minors folded: canaries use `PartitionExtractionError`; the error-precedence edge noted on the issue). Investigation + empirical correction recorded as comments on #748.

## Verification

Full hub suite 509 files / 4233 tests green; typecheck / lint / `check:architecture` clean. Changeset `external-tier-guards.md` (hub patch) local-only per convention.