### PR TITLE
fix(hub): derived/MV tier follow-ups — at-rest MV invalidation, source-grained gate, plaintext-tiers refusal (#736, #737, #740)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-mv-tier-followups.md
+++ b/docs/superpowers/plans/2026-07-17-mv-tier-followups.md
@@ -1,0 +1,90 @@
+# Derived/MV Tier Follow-ups (#736 + #737 + #740) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the lazy/manual materialized-view residue (#736 — a persisted output row keeps an elevated/forgotten source's plaintext at rest and serves it to cold sessions), make the tier-move derived-decode gate source-grained (#737), and refuse the incoherent `tiers × encrypted:false` composition at construction (#740).
+
+**Architecture (#736, the substantive task):** invalidation from the delete/forget/elevate path (`dispatchMaterializedViewsOnDelete`, `collection.ts:~2934`) must, for `lazy` AND `manual` MVs, do BOTH halves: (a) **delete the MV's persisted output rows** (the at-rest law — a stale mark alone leaves plaintext at rest) and (b) for `lazy`, **persist the stale mark** in a reserved `_mv_stale` store collection so a COLD session recomputes on first read instead of serving an empty MV (`stale.ts`'s WeakMap is in-memory only — its own doc admits "Persistence across vault close is NOT implemented"). `manual` gets rows deleted only (empty-until-`refreshView()` is the documented manual contract; erasure/invisibility wins over staleness). This fixes the SAME gap for `forget()` and `elevate()` at once — they share the dispatcher.
+
+**Tech Stack:** TypeScript ESM, vitest, `crypto.subtle` only.
+
+## Global Constraints
+
+- `collection.ts` ceiling 4549 (file at 4548) and `vault.ts` ceiling 3959 (file at exact ceiling) — additions there must be funded or land in `with-formula/materialized-views/*` (no ceiling). Prefer putting ALL new logic in `stale.ts`/a sibling and calling it from the dispatcher with minimal lines.
+- Never add Claude attribution. Hub portable. TDD.
+- Branch: `fix/736-740-mv-tier-followups` off main AFTER PR #760 merges.
+- Reserved collection name: `_mv_stale` (leading `_` = excluded from queries/list like other internals). Marker rows must be CONTENT-FREE (key = MV name is the only payload; staleness is low-sensitivity metadata — mirror an existing reserved-collection marker's envelope shape; find precedent via `grep -rn "_ts: now, _iv: ''" packages/hub/src` or how the subject index / sync markers write envelopes).
+
+---
+
+### Task 1: #736 — lazy/manual MV invalidation purges rows at rest + persists the lazy stale mark
+
+**Files:**
+- Modify: `packages/hub/src/with-formula/materialized-views/stale.ts` (new: `invalidateMVAtRest` helper, persisted-marker hydrate/clear)
+- Modify: `packages/hub/src/kernel/collection.ts` (`dispatchMaterializedViewsOnDelete` lazy/manual arms — keep the delta tiny, ceiling)
+- Modify: wherever `vault.refreshView` completes (clear the persisted marker alongside `clearMVStale` — find it)
+- Test: new `packages/hub/__tests__/mv-tier-staleness.test.ts`
+
+**Design points (fixed):**
+1. New `stale.ts` export, e.g. `invalidateMVAtRest(accessor-ish, reg, mode)`: enumerates the MV's `outputCollection` rows via the adapter, deletes each through the output collection's `_internalDelete` (tombstone semantics consistent with the eager path — check what `executor.refresh`'s delete leg uses and mirror; if `_internalDelete` needs the Collection, thread `getCollection` like the dispatcher already does). If multiple MVs share the output collection (registry supports it "in theory"), re-mark every OTHER lazy MV writing there stale too (they lost their rows) — enumerate via `registry.all()` filter.
+2. Persisted lazy marker: on `markMVStale` from the DELETE dispatcher only (not ordinary source writes — cheap writes must stay cheap; ordinary lazy staleness keeps today's in-memory-only behavior and its documented cold-session freshness caveat — the LEAK is what we're fixing, and after row-deletion there is no leak; the marker exists so the cold session recomputes instead of serving empty), write `_mv_stale/{mvName}` marker row. `resolveStaleMVOnRead` gains a once-per-registry hydrate: first call checks a `WeakMap<Registry, true>` flag; if unhydrated, `adapter.list(vault, '_mv_stale')` and folds names into the pending set (needs adapter+vault on the accessor — extend `MVStaleAccessor` minimally or thread via the existing query context; implementer's call, guard-clean). After a successful refresh, delete the marker row (and `clearMVStale`).
+3. `vault.refreshView()` completion also deletes the marker row.
+4. `manual` arm in the dispatcher: call the row-purge only. Document on the dispatcher doc comment: manual MV serves empty until `refreshView()` after a source forget/elevate — erasure wins.
+
+**Tests (TDD — RED first for 1 and 2):**
+1. THE LEAK (lazy): source collection + `refresh:'lazy'` MV, materialize (read once), elevate a source record → assert the MV's persisted output rows are GONE from the store (adapter-level check) and `_mv_stale/{name}` exists → close → reopen (cold) → read MV → recomputed WITHOUT the elevated record's contribution; marker row gone after the read.
+2. Same for `forget()` (the shared-dispatcher claim — one test, same assertions).
+3. Manual MV: elevate a source → rows gone at rest; read serves empty (no recompute); `vault.refreshView()` rebuilds without the elevated record.
+4. Ordinary lazy source WRITE (no delete/elevate): no `_mv_stale` row written (the cheap-path guarantee), in-memory behavior unchanged (reuse `isMVStale`).
+5. Eager MV regression: unchanged behavior (suite pass suffices).
+
+- [ ] Steps: failing tests → implement → focused suites (`mv`/`materialized`/`derivation` test files + `forget.test.ts` + `tiers-blobs.test.ts`) → commit `fix(hub): lazy/manual MV invalidation purges persisted rows + persists the lazy stale mark — cold sessions can't serve an elevated/forgotten source's plaintext (#736)`.
+
+---
+
+### Task 2: #737 — hasDerivedOutputs becomes source-grained
+
+> **CORRECTION (2026-07-17, shipped design):** the predicate below ("`spec.source === this.name`")
+> was too narrow — it would have missed triggerBy/sibling/rollup-child relations and silently
+> regressed #722. The implementation instead reuses the exact registry lookups the write
+> dispatchers use (`registry.strategiesForSource(this.name)` / `registry.mvsForSource(this.name)`,
+> both backed by the same `_bySource` maps dispatch reads), so the gate is provably in lock-step
+> with dispatch for every relation kind. Additionally, the whole-branch review found the plan's
+> Task-1 full-wipe purge destroys USER records for same-collection partition MVs — fixed by
+> scoping deletion to `_materializedFrom`-stamped rows (see the fix-wave commit).
+
+**Files:** `packages/hub/src/kernel/collection.ts` (the `TiersContext` build, ~4513 — `hasDerivedOutputs`), possibly a tiny helper on the registries.
+
+Currently `materializedViewSource !== undefined || derivationSource !== undefined` (vault-grained). Change to: this COLLECTION is a registered source — `registry.mvsForSource(this.name).length > 0` OR the derivation registry has a strategy with `spec.source === this.name` (find the exact derivation-registry lookup; a `mvsForSource` analogue may exist). Compute at ctx-build time per tier op (cheap filter; do NOT cache — registries late-attach).
+
+Test: the codebase's established no-decode observable — a vault with a derivation on collection B; tiered collection A with NO derivations; corrupt A's record envelope body at the store so any decode would throw `TamperedError`; `elevate()` on A succeeds (proves the pre-move decode was skipped). Plus positive: a tiered SOURCE collection still decodes (existing #722 tests cover — name the file in your report). Ceiling: the predicate swap should be ~line-neutral in collection.ts; fund by joining if needed.
+
+- [ ] Steps: RED (corrupt-envelope test fails today only if... verify: today the vault-grained gate makes elevate DECODE on A → throws on corrupt → RED is "elevate throws"; post-fix GREEN "elevate succeeds") → implement → suites → commit `perf(hub): hasDerivedOutputs is source-grained — tier moves on derivation-free collections skip the pre-move decode (#737)`.
+
+---
+
+### Task 3: #740 — refuse tiers × encrypted:false + changeset + close-out
+
+**Files:** `packages/hub/src/kernel/collection-config.ts` (beside the existing tiers mandates, ~913-944), test in `packages/hub/__tests__/tier-composition-guard.test.ts`.
+
+Guard: `tiers` declared AND `encrypted: false` → `UnsupportedTierCompositionError('plaintext', ...)` — message: tiers are per-tier ENCRYPTION keys; a plaintext collection has nothing to re-key, `putAtTier`/`elevate` would encrypt/decrypt incoherently; use an encrypted collection. Tests: refusal fires at construction; `encrypted:false` without tiers unaffected; tiers + encrypted (default) unaffected. Confirm first no existing test combines them (`grep -rn "encrypted: false" packages/hub/__tests__ | grep -l tiers` style — if one exists, STOP and report).
+
+Changeset `.changeset/mv-tier-followups.md` (hub patch):
+
+```md
+---
+"@noy-db/hub": patch
+---
+
+Derived-output tier/erasure completeness (#736, #737, #740). Invalidating a lazy or manual materialized view from `forget()` or a tier move now DELETES the MV's persisted output rows at rest (previously the pre-elevation/pre-forget plaintext row survived until an in-session refresh — and a cold session served it as fresh), and for lazy MVs persists the stale mark in the reserved `_mv_stale` collection so a cold session recomputes on first read instead of serving an empty view; a manual MV serves empty until `vault.refreshView()` (erasure wins over manual staleness). Ordinary source writes keep the cheap in-memory-only stale path. The tier-move pre-move decode gate is now source-grained (#737) — a tiered collection with no derivations of its own no longer decodes on elevate/demote when an unrelated derivation exists in the vault. And `tiers` on an `encrypted: false` collection is now refused at construction (`UnsupportedTierCompositionError`, #740) — per-record clearance IS per-tier encryption; a plaintext collection cannot honor it.
+```
+
+Full verification: hub test/typecheck/lint/check:architecture; ceilings intact.
+
+- [ ] Commit `fix(hub): refuse tiers on encrypted:false collections at construction (#740) + changeset`.
+
+## Self-Review Notes
+
+- #736's split (rows deleted ALWAYS on the delete/elevate dispatcher; marker ONLY for lazy; ordinary writes untouched) keeps the hot write path free of new store I/O while making the leak class impossible at rest.
+- The `_mv_stale` hydrate is once-per-registry-per-session — one `list()` on first MV read, zero when no MVs registered.
+- Shared-output-collection re-marking prevents a sibling lazy MV from silently losing rows without a stale bit.

--- a/packages/hub/__tests__/mv-tier-staleness.test.ts
+++ b/packages/hub/__tests__/mv-tier-staleness.test.ts
@@ -148,6 +148,44 @@ describe('#736 whole-branch review — invalidateMVAtRest scopes deletion to MV-
     expect(r2?.tag).toBe('y')
   })
 
+  it('IMPORTANT: hydrate-promise poison — a transient store failure on the first cold read must not brick the MV read surface for the rest of the session', async () => {
+    const store = memoryStore()
+    const lazyMV = withMaterializedView<Item>({
+      name: 'red-items',
+      query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'mv-tier-stale-hydrate-poison-2026',
+      materializedViewStrategies: [lazyMV],
+    })
+    const vault = await db.openVault('demo')
+    const items = vault.collection<Item>('items')
+    await items.put('a', { id: 'a', tag: 'red' })
+
+    // Make the store's list() reject ONCE for the reserved `_mv_stale` collection
+    // (the hydrate fold-in's only store call), then succeed on every later call.
+    let failed = false
+    const originalList = store.list.bind(store)
+    store.list = async (v, c) => {
+      if (c === MV_STALE_COLLECTION && !failed) {
+        failed = true
+        throw new Error('transient store failure')
+      }
+      return originalList(v, c)
+    }
+
+    // First read: the hydrate rejects — must surface, not be swallowed.
+    await expect(vault.collection<Item>('red-items').get('a')).rejects.toThrow('transient store failure')
+
+    // Second read: must RETRY the hydrate (not re-await the same cached rejection)
+    // and recover, serving the recomputed view.
+    const row = await vault.collection<Item>('red-items').get('a')
+    expect(row).not.toBeNull()
+    expect(row?.tag).toBe('red')
+  })
+
   it('orphaned _mv_stale marker for an unregistered MV name is deleted on the next read (renamed/removed MV)', async () => {
     const store = memoryStore()
     const mv = withMaterializedView<Item>({

--- a/packages/hub/__tests__/mv-tier-staleness.test.ts
+++ b/packages/hub/__tests__/mv-tier-staleness.test.ts
@@ -58,6 +58,126 @@ function memoryStore(): NoydbStore {
 }
 
 interface Item extends Record<string, unknown> { id: string; tag: string; subjectId?: string }
+interface Disbursement extends Record<string, unknown> { id: string; type: string; period: string; amount: number }
+
+describe('#736 whole-branch review — invalidateMVAtRest scopes deletion to MV-stamped rows', () => {
+  it('CRITICAL: same-collection partition MV (DERIV-PP30-001) — ordinary delete of one source record must NOT erase other source records at rest', async () => {
+    const store = memoryStore()
+    const mv = withMaterializedView<Disbursement>({
+      name: 'pp30-aggregate',
+      query: (db) => db.collection<Disbursement>('disbursements')
+        .query()
+        .where('type', 'in', ['vatSales', 'vatPurchase', 'vatCredit']),
+      rowKey: (r) => `pp30|${r.period}|${r.id}`,
+      refresh: 'lazy',
+      output: { collection: 'disbursements', partition: { field: 'type', value: 'pp30' } },
+      // `onEmpty: 'keep'` isolates this test to the `invalidateMVAtRest` fix under test —
+      // the executor's own `onEmpty: 'delete'` tombstone-diff pass has a SEPARATE,
+      // pre-existing bug for same-collection partition MVs (it diffs the new emitted-id
+      // set against EVERY id in the output collection, so an ordinary first materialize
+      // already tombstones untouched source rows before any delete/elevate/forget ever
+      // runs) — out of scope for this fix wave (stale.ts only); flagged separately.
+      onEmpty: 'keep',
+    })
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'mv-tier-stale-same-coll-critical-2026',
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('demo')
+    const disb = vault.collection<Disbursement>('disbursements')
+    await disb.put('d1', { id: 'd1', type: 'vatSales', period: '2026-05', amount: 1000 })
+    await disb.put('d2', { id: 'd2', type: 'vatPurchase', period: '2026-05', amount: 500 })
+    // Materialize (first read fires the lazy resolve — writes the pp30|* rows into the SAME collection).
+    expect(await disb.get('pp30|2026-05|d1')).not.toBeNull()
+    expect(await disb.get('pp30|2026-05|d2')).not.toBeNull()
+    // Sanity: the pre-existing executor bug (see comment above) is neutralized by
+    // `onEmpty: 'keep'` — both original source rows are still present after materialize.
+    expect(await store.get('demo', 'disbursements', 'd1')).not.toBeNull()
+    expect(await store.get('demo', 'disbursements', 'd2')).not.toBeNull()
+
+    // Ordinary delete of an UNTOUCHED source record — must invalidate this MV's own output
+    // rows but must NEVER erase the other user source record ('d2') sharing the collection.
+    await disb.delete('d1')
+
+    // The other user source record survives at rest — the bug this test guards against.
+    expect(await store.get('demo', 'disbursements', 'd2')).not.toBeNull()
+    // MV-stamped output rows are still purged (invalidation still works).
+    expect(await store.get('demo', 'disbursements', 'pp30|2026-05|d1')).toBeNull()
+    expect(await store.get('demo', 'disbursements', 'pp30|2026-05|d2')).toBeNull()
+  })
+
+  it('IMPORTANT: hydrate-once race — two concurrent first reads over a cold registry both see the recomputed view', async () => {
+    const store = memoryStore()
+    const lazyMV = withMaterializedView<Item>({
+      name: 'people-mirror',
+      query: (db) => db.collection<Item>('people').query(),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const open = async () => {
+      const db = await createNoydb({
+        store, user: 'owner', secret: 'mv-tier-stale-hydrate-race-2026',
+        materializedViewStrategies: [lazyMV],
+        historyStrategy: withHistory(),
+        forgetStrategy: withForgetCascade({ subjects: { people: 'subjectId' } }),
+      })
+      const vault = await db.openVault('demo')
+      return { vault, people: vault.collection<Item>('people') }
+    }
+
+    const { vault, people } = await open()
+    await people.put('p1', { id: 'p1', tag: 'x', subjectId: 'subj-1' })
+    await people.put('p2', { id: 'p2', tag: 'y', subjectId: 'subj-2' })
+    expect(await vault.collection<Item>('people-mirror').get('p1')).not.toBeNull()
+    expect(await vault.collection<Item>('people-mirror').get('p2')).not.toBeNull()
+
+    await vault.forget('subj-1')
+    // Rows purged at rest + the lazy marker persisted (mirrors the existing #736 forget test).
+    expect(await store.get('demo', MV_STALE_COLLECTION, 'people-mirror')).not.toBeNull()
+
+    // Cold session: fresh registry. Fire two concurrent first-reads for the SAME id —
+    // without the promise-memo fix, whichever call loses the race sees "hydrate already
+    // in flight" and an empty in-memory pending set, and returns the not-yet-recomputed
+    // (purged) row instead of waiting for the recompute to finish.
+    const { vault: coldVault } = await open()
+    const coll = coldVault.collection<Item>('people-mirror')
+    const [r1, r2] = await Promise.all([coll.get('p2'), coll.get('p2')])
+    expect(r1).not.toBeNull()
+    expect(r2).not.toBeNull()
+    expect(r1?.tag).toBe('y')
+    expect(r2?.tag).toBe('y')
+  })
+
+  it('orphaned _mv_stale marker for an unregistered MV name is deleted on the next read (renamed/removed MV)', async () => {
+    const store = memoryStore()
+    const mv = withMaterializedView<Item>({
+      name: 'red-items',
+      query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'mv-tier-stale-orphan-marker-2026',
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('demo')
+
+    // Plant a marker for a name that is NOT (and never will be) a registered MV —
+    // simulates a marker surviving a rename/removal of the MV that wrote it.
+    const env = (await store.get('demo', MV_STALE_COLLECTION, 'ghost-mv')) ?? null
+    expect(env).toBeNull()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const plainEnv = (await import('../src/kernel/enclave/index.js')).RecordCodec.buildPlaintextEnvelope({ version: 1, data: '{}' })
+    await store.put('demo', MV_STALE_COLLECTION, 'ghost-mv', plainEnv)
+    expect(await store.get('demo', MV_STALE_COLLECTION, 'ghost-mv')).not.toBeNull()
+
+    // One read (triggers hydrate + the stale-check path).
+    await vault.collection<Item>('items').get('nonexistent')
+
+    // The orphaned marker is gone — it can never re-hydrate into a real recompute.
+    expect(await store.get('demo', MV_STALE_COLLECTION, 'ghost-mv')).toBeNull()
+  })
+})
 
 describe('#736 MV lazy/manual invalidation purges persisted rows + persists the lazy stale mark', () => {
   it('lazy MV + elevate: output rows purged at rest, marker persisted, cold session recomputes without the elevated contribution', async () => {

--- a/packages/hub/__tests__/mv-tier-staleness.test.ts
+++ b/packages/hub/__tests__/mv-tier-staleness.test.ts
@@ -1,0 +1,211 @@
+/**
+ * #736 — `dispatchMaterializedViewsOnDelete` (the delete/forget/elevate fanout, shared by
+ * `forget()` and the tier-move `syncDerived` path) fully recomputes only EAGER MVs. For
+ * `refresh: 'lazy'` it flipped an in-memory-only stale bit (lost on vault close — `stale.ts`'s
+ * own doc admits persistence isn't implemented); `'manual'` no-opped entirely. Either way the
+ * PERSISTED output row(s) kept the elevated/forgotten source's plaintext at rest, and a cold
+ * session served it as fresh.
+ *
+ * Fix: on invalidation, delete the MV's persisted output rows (the at-rest law), and for
+ * `lazy` MVs persist the stale mark in the reserved `_mv_stale` collection so a cold session
+ * recomputes on first read instead of serving an empty view.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView, ConflictError } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { isMVStale, MV_STALE_COLLECTION } from '../src/with-formula/materialized-views/stale.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+
+/** One store, reopenable: open() twice = cold second session over the same ciphertext. */
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+interface Item extends Record<string, unknown> { id: string; tag: string; subjectId?: string }
+
+describe('#736 MV lazy/manual invalidation purges persisted rows + persists the lazy stale mark', () => {
+  it('lazy MV + elevate: output rows purged at rest, marker persisted, cold session recomputes without the elevated contribution', async () => {
+    const store = memoryStore()
+    const lazyMV = withMaterializedView<Item>({
+      name: 'red-items',
+      // Tiered options must land on the FIRST `collection()` call the query
+      // callback makes (registration-time, first-construction-wins) — see
+      // tiers-derived.test.ts for the same pattern.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      query: (db) => { (db as any).collection('items', { tiers: [0, 1], perRecordKeys: true }); return db.collection<Item>('items').query().where('tag', '==', 'red') },
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const open = async () => {
+      const db = await createNoydb({
+        store, user: 'owner', secret: 'mv-tier-stale-lazy-elevate-2026',
+        tiersStrategy: withTiers(), materializedViewStrategies: [lazyMV],
+      })
+      const vault = await db.openVault('demo')
+      return { vault, items: vault.collection<Item>('items', { tiers: [0, 1], perRecordKeys: true }) }
+    }
+
+    const { vault, items } = await open()
+    await items.put('a', { id: 'a', tag: 'red' })
+    await items.put('b', { id: 'b', tag: 'red' })
+    // Materialize (first read).
+    expect(await vault.collection<Item>('red-items').get('a')).not.toBeNull()
+    expect(await vault.collection<Item>('red-items').get('b')).not.toBeNull()
+
+    await items.elevate('a', 1)
+
+    // At-rest law: BOTH persisted output rows are gone (full-purge invalidation),
+    // not just the elevated one — adapter-level check bypasses the lazy resolve-on-read.
+    expect(await store.get('demo', 'red-items', 'a')).toBeNull()
+    expect(await store.get('demo', 'red-items', 'b')).toBeNull()
+    // The lazy stale mark survived the in-memory WeakMap's lifetime — persisted.
+    expect(await store.get('demo', MV_STALE_COLLECTION, 'red-items')).not.toBeNull()
+
+    // Cold session: fresh Noydb instance + fresh registry over the SAME store.
+    const { vault: coldVault } = await open()
+    const coldRow = await coldVault.collection<Item>('red-items').get('b')
+    expect(coldRow).not.toBeNull()
+    expect(coldRow?.tag).toBe('red')
+    expect(await coldVault.collection<Item>('red-items').get('a')).toBeNull()
+
+    // Marker cleaned up after the successful cold recompute.
+    expect(await store.get('demo', MV_STALE_COLLECTION, 'red-items')).toBeNull()
+  })
+
+  it('lazy MV + forget(): same at-rest purge + persisted marker + cold recompute (shared dispatcher)', async () => {
+    const store = memoryStore()
+    const lazyMV = withMaterializedView<Item>({
+      name: 'people-mirror',
+      query: (db) => db.collection<Item>('people').query(),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const open = async () => {
+      const db = await createNoydb({
+        store, user: 'owner', secret: 'mv-tier-stale-lazy-forget-2026',
+        materializedViewStrategies: [lazyMV],
+        historyStrategy: withHistory(),
+        forgetStrategy: withForgetCascade({ subjects: { people: 'subjectId' } }),
+      })
+      const vault = await db.openVault('demo')
+      return { vault, people: vault.collection<Item>('people') }
+    }
+
+    const { vault, people } = await open()
+    await people.put('p1', { id: 'p1', tag: 'x', subjectId: 'subj-1' })
+    await people.put('p2', { id: 'p2', tag: 'y', subjectId: 'subj-2' })
+    expect(await vault.collection<Item>('people-mirror').get('p1')).not.toBeNull()
+    expect(await vault.collection<Item>('people-mirror').get('p2')).not.toBeNull()
+
+    await vault.forget('subj-1')
+
+    expect(await store.get('demo', 'people-mirror', 'p1')).toBeNull()
+    expect(await store.get('demo', 'people-mirror', 'p2')).toBeNull()
+    expect(await store.get('demo', MV_STALE_COLLECTION, 'people-mirror')).not.toBeNull()
+
+    const { vault: coldVault } = await open()
+    const coldRow = await coldVault.collection<Item>('people-mirror').get('p2')
+    expect(coldRow).not.toBeNull()
+    expect(await coldVault.collection<Item>('people-mirror').get('p1')).toBeNull()
+    expect(await store.get('demo', MV_STALE_COLLECTION, 'people-mirror')).toBeNull()
+  })
+
+  it('manual MV + elevate: rows purged at rest; read serves empty (no recompute); refreshView() rebuilds', async () => {
+    const store = memoryStore()
+    const manualMV = withMaterializedView<Item>({
+      name: 'all-items',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      query: (db) => { (db as any).collection('items', { tiers: [0, 1], perRecordKeys: true }); return db.collection<Item>('items').query() },
+      rowKey: (r) => r.id,
+      refresh: 'manual',
+    })
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'mv-tier-stale-manual-elevate-2026',
+      tiersStrategy: withTiers(), materializedViewStrategies: [manualMV],
+    })
+    const vault = await db.openVault('demo')
+    const items = vault.collection<Item>('items', { tiers: [0, 1], perRecordKeys: true })
+    await items.put('a', { id: 'a', tag: 'red' })
+    await items.put('b', { id: 'b', tag: 'blue' })
+    await vault.refreshView('all-items')
+    expect(await vault.collection<Item>('all-items').get('a')).not.toBeNull()
+    expect(await vault.collection<Item>('all-items').get('b')).not.toBeNull()
+
+    await items.elevate('a', 1)
+
+    // Rows gone at rest.
+    expect(await store.get('demo', 'all-items', 'a')).toBeNull()
+    expect(await store.get('demo', 'all-items', 'b')).toBeNull()
+    // Manual MVs never get a persisted stale marker — erasure wins, no auto-recompute promise.
+    expect(await store.get('demo', MV_STALE_COLLECTION, 'all-items')).toBeNull()
+
+    // Serves empty — no auto-recompute for a manual MV.
+    expect(await vault.collection<Item>('all-items').get('b')).toBeNull()
+
+    // Explicit refreshView() rebuilds without the elevated record.
+    const result = await vault.refreshView('all-items')
+    expect(result.written).toBe(1)
+    expect(await vault.collection<Item>('all-items').get('b')).not.toBeNull()
+    expect(await vault.collection<Item>('all-items').get('a')).toBeNull()
+  })
+
+  it('ordinary lazy source write (no delete/elevate/forget): no _mv_stale row written — the cheap-path guarantee', async () => {
+    const store = memoryStore()
+    const lazyMV = withMaterializedView<Item>({
+      name: 'red-items',
+      query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'mv-tier-stale-cheap-write-2026',
+      materializedViewStrategies: [lazyMV],
+    })
+    const vault = await db.openVault('demo')
+
+    await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+
+    // In-memory stale behaviour is unchanged (ordinary write path, not the delete dispatcher).
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const reg = vault._getMaterializedViewRegistry()!
+    expect(isMVStale(reg, 'red-items')).toBe(true)
+    // No store I/O for the cheap ordinary-write path.
+    expect(await store.get('demo', MV_STALE_COLLECTION, 'red-items')).toBeNull()
+  })
+})

--- a/packages/hub/__tests__/tier-composition-guard.test.ts
+++ b/packages/hub/__tests__/tier-composition-guard.test.ts
@@ -17,7 +17,7 @@
  * elevated record's blob content.
  */
 import { describe, it, expect } from 'vitest'
-import { createNoydb, ConflictError, withSearch } from '../src/index.js'
+import { createNoydb, ConflictError, withSearch, UnsupportedTierCompositionError } from '../src/index.js'
 import { withTiers } from '../src/with-audit/tiers/index.js'
 import { withBlobs } from '../src/via/blob/index.js'
 import { withHistory } from '../src/with-commit/history/index.js'
@@ -163,6 +163,26 @@ describe('tier + blobFields composition (Arc-7 refusal removed — #724)', () =>
       store: memoryStore(), secret: 'pw', user: 'owner',
       tiersStrategy: withTiers(), historyStrategy: withHistory(),
     })
+    const vault = await db.openVault('v1')
+    expect(() => vault.collection<Doc>('docs', { tiers: [0, 1] })).not.toThrow()
+  })
+})
+
+describe('tiers + encrypted: false composition (#740)', () => {
+  it('tiers on a plaintext (encrypted: false) collection is refused at construction', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'owner', encrypt: false, tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    expect(() => vault.collection<Doc>('docs', { tiers: [0, 1] })).toThrow(UnsupportedTierCompositionError)
+  })
+
+  it('encrypted: false without tiers still constructs fine', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'owner', encrypt: false })
+    const vault = await db.openVault('v1')
+    expect(() => vault.collection<Doc>('docs')).not.toThrow()
+  })
+
+  it('tiers + default encryption still constructs fine', async () => {
+    const db = await createNoydb({ store: memoryStore(), secret: 'pw', user: 'owner', tiersStrategy: withTiers() })
     const vault = await db.openVault('v1')
     expect(() => vault.collection<Doc>('docs', { tiers: [0, 1] })).not.toThrow()
   })

--- a/packages/hub/__tests__/tiers-derived.test.ts
+++ b/packages/hub/__tests__/tiers-derived.test.ts
@@ -680,3 +680,72 @@ describe('#722 whole-branch review: pre-move decode must be tier-aware (not just
     expect((await buyers.get('b1'))?.totalSpent).toBe(200)
   })
 })
+
+/**
+ * #737 — `hasDerivedOutputs` (`with-audit/tiers/index.ts`'s `TiersContext`
+ * field, bound in `collection.ts`'s `tiersContext()`) was VAULT-grained
+ * (`materializedViewSource !== undefined || derivationSource !== undefined`):
+ * a tiered collection with NO derivations of its OWN still paid the pre-move
+ * decode on every tier op whenever ANY derivation existed anywhere in the
+ * vault. Fixed to be SOURCE-grained: gate on whether THIS collection is a
+ * registered MV source (`registry.mvsForSource(this.name)`) or derivation
+ * source (`registry.strategiesForSource(this.name)`).
+ *
+ * Observable: `putAtTier(id, record, tier>0)`'s pre-write `existing`-decode
+ * is the one site where the gated decode is decoupled from an unconditional
+ * decrypt of the SAME ciphertext elsewhere in the op — the write re-encrypts
+ * the CALLER-supplied plaintext `record`, never `existing`'s stored body, so
+ * `existing` is decoded ONLY to feed `syncDerived`, exactly when
+ * `hasDerivedOutputs` says to. (`elevate()`/`demote()` can't be used for
+ * this: their OWN body rewrap — `rewrapBodyToDek` — unconditionally decrypts
+ * the very same pre-move ciphertext the gated decode would, so a corrupted
+ * body throws `TamperedError` from the rewrap regardless of the gate — see
+ * the "Both elevates perform the identical body rewrap" comment above.)
+ * Corrupting `existing`'s stored `_data` therefore isolates the gate: with
+ * today's vault-grained gate, a derivation-free collection A still decodes
+ * (because SOME OTHER collection in the vault has a derivation) and throws;
+ * source-grained, A has no registered derivation of its own and skips the
+ * decode entirely, so the corrupted body never gets read.
+ */
+describe('#737 hasDerivedOutputs is source-grained', () => {
+  it('putAtTier(tier>0) on a derivation-free collection succeeds even when its stored body is corrupted, despite another collection in the same vault having a derivation', async () => {
+    interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number }
+    interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+    interface Doc extends Record<string, unknown> { id: string; title: string }
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const store = memoryStore()
+    const db = await createNoydb({
+      store,
+      user: 'owner',
+      secret: 'source-grained-derived-outputs-passphrase-2026',
+      tiersStrategy: withTiers(),
+      // The rollup's source is 'sales' — 'docs' below is neither its
+      // source, an extra source, a trigger, nor its rollup.from, so it is
+      // NOT a registered derivation source. Under the old vault-grained
+      // gate, `docs` still paid the pre-move decode solely because THIS
+      // vault has a derivation registered (on a different collection).
+      derivationStrategies: [totalSpentRollup],
+    })
+    const vault = await db.openVault('demo')
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1], perRecordKeys: true })
+
+    await docs.put('d1', { id: 'd1', title: 'Public' })
+
+    // Corrupt the STORED envelope's ciphertext body — any decode of it
+    // throws `TamperedError`. `putAtTier`'s write re-encrypts the fresh
+    // plaintext argument below, never this stored body — the corruption is
+    // only reachable through the gated `existing`-decode.
+    const stored = await store.get('demo', 'docs', 'd1')
+    expect(stored).not.toBeNull()
+    const goodChar = stored!._data[0]
+    const badChar = goodChar === 'A' ? 'B' : 'A'
+    await store.put('demo', 'docs', 'd1', { ...stored!, _data: badChar + stored!._data.slice(1) })
+
+    // GREEN: source-grained — `docs` has no derivation of its own, so the
+    // gated decode is skipped and the corrupted body is never read.
+    await expect(docs.putAtTier('d1', { id: 'd1', title: 'Renamed' }, 1)).resolves.toBeUndefined()
+  })
+})

--- a/packages/hub/__tests__/tiers-derived.test.ts
+++ b/packages/hub/__tests__/tiers-derived.test.ts
@@ -474,11 +474,11 @@ describe('#722 review fix: syncDerived pre-move decode is gated by hasDerivedOut
     interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number }
     interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
 
-    // `hasDerivedOutputs` is computed per-collection from the VAULT's
-    // derivation/MV registry presence (`this.derivationSource !==
-    // undefined || this.materializedViewSource !== undefined` —
-    // `tiersContext()`), not from whether this specific collection is a
-    // registered source — so the two elevates must run against two
+    // `hasDerivedOutputs` is computed per-collection from whether THIS
+    // collection is itself a registered source (`registry.strategiesForSource(this.name)`
+    // / `registry.mvsForSource(this.name)`, #737 — source-grained, was
+    // vault-grained), not from whether the vault has any derivation/MV
+    // registry configured at all — so the two elevates must run against two
     // SEPARATE vaults (one with no derivation strategy configured at all,
     // one with) to observe the gate.
     const plainDb = await createNoydb({
@@ -722,11 +722,12 @@ describe('#737 hasDerivedOutputs is source-grained', () => {
       user: 'owner',
       secret: 'source-grained-derived-outputs-passphrase-2026',
       tiersStrategy: withTiers(),
-      // The rollup's source is 'sales' — 'docs' below is neither its
-      // source, an extra source, a trigger, nor its rollup.from, so it is
-      // NOT a registered derivation source. Under the old vault-grained
-      // gate, `docs` still paid the pre-move decode solely because THIS
-      // vault has a derivation registered (on a different collection).
+      // The rollup's `spec.source` (parent) is 'buyers' and its
+      // `spec.rollup.from` (child/trigger) is 'sales' — 'docs' below is
+      // neither, nor an extra source, nor a trigger, so it is NOT a
+      // registered derivation source. Under the old vault-grained gate,
+      // `docs` still paid the pre-move decode solely because THIS vault has
+      // a derivation registered (on a different collection).
       derivationStrategies: [totalSpentRollup],
     })
     const vault = await db.openVault('demo')

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -958,6 +958,20 @@ export function resolveCollectionConfig<T>(opts: CollectionOpts<T>) {
     }
   }
 
+  // #740 — tiers declare per-tier ENCRYPTION keys (elevate/demote re-key and
+  // re-put the record under the target tier's DEK). A plaintext
+  // (`encrypted: false`) collection has nothing to re-key: `putAtTier`/
+  // `elevate` would encrypt/decrypt incoherently against a collection that
+  // never encrypts. Refuse at construction instead of leaking silently.
+  if (opts.tiers && opts.tiers.length > 0 && opts.encrypted === false) {
+    throw new UnsupportedTierCompositionError(
+      'plaintext',
+      `Collection "${opts.name}": tiers are per-tier ENCRYPTION keys — a plaintext collection ` +
+        `(\`encrypted: false\`) has nothing to re-key, so \`putAtTier\`/\`elevate\` would ` +
+        `encrypt/decrypt incoherently. Use an encrypted collection.`,
+    )
+  }
+
   // via() / sugar-key merge (#623 Task 9) — throws on a field declared in both.
   const effectiveViaFields = mergeViaFields(opts)
 

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -2928,7 +2928,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    * Mirror of {@link dispatchMaterializedViews} for the delete/forget path — no `_materializedFrom`
    * skip (record's gone); the `internal` gate at `_doDelete` is the recursion guard. Returns the
    * row count TOMBSTONED across every eager MV sourced here (#638 T6 — `forgetDerivedFanout`'s
-   * `derivedRecordsErased`); a lazy MV only flips its stale bit (0 contribution — resolved on read).
+   * `derivedRecordsErased`); lazy/manual MVs also purge their persisted output rows at rest
+   * (#736) — lazy persists a stale mark for cold-session recompute; manual serves empty until `refreshView()`.
    * @internal
    */
   async dispatchMaterializedViewsOnDelete(id: string): Promise<number> {
@@ -2951,13 +2952,12 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
           getQueryContext: () => this.materializedViewSource!.getQueryContext(),
           dispatchCtx: this.#dispatchCtx({ collection: this.name, id }),
         })).deleted
-      } else if (mode === 'lazy') {
+      } else {
         if (staleHelpers === null) {
           staleHelpers = await import('../with-formula/materialized-views/stale.js')
         }
-        staleHelpers.markMVStale(registry, reg.spec.name)
+        await staleHelpers.invalidateMVAtRest(this.materializedViewSource, reg, mode)
       }
-      // manual: no-op — `vault.refreshView(name)` is the only path.
     }
     return deleted
   }

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -4513,7 +4513,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       syncBlobs: (id: string, fromTier: number, toTier: number) => this.blobStrategy !== NO_BLOBS ? this.blob(id).rehomeForTier(fromTier, toTier, this.blobTierPolicy) : Promise.resolve(), // #724 I1: gate on blob storage enabled (not on declared blobFields) so undeclared-field blobs still rehome; rehomeForTier self-no-ops on an empty slot map
       syncLedger: async (id: string) => { await this.ledger?.purgeRecordDeltas(this.name, id) },
       syncDerived: (id: string, record: T | null, elevated: boolean, version?: number) => syncDerivedOutputs(this, id, record, elevated, version),
-      hasDerivedOutputs: this.materializedViewSource !== undefined || this.derivationSource !== undefined,
+      hasDerivedOutputs: (this.materializedViewSource !== undefined && this.materializedViewSource.registry().mvsForSource(this.name).length > 0) || (this.derivationSource !== undefined && this.derivationSource.registry().strategiesForSource(this.name).length > 0), // #737: source-grained (was vault-grained) — a derivation-free tiered collection skips the pre-move decode even when other collections in the vault have derivations
       provenance: this.provenance,
       tiers: this.tiers,
       tierMode: this.tierMode,

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -2777,10 +2777,10 @@ export class Vault {
       getQueryContext: () => this as unknown as MVQueryContext,
       dispatchCtx: this._dispatchCtx({ collection: name, id: 'refreshView' }),
     })
-    // Manual refresh clears any pending stale bit — the post-refresh
-    // state matches the registered strategy.
-    const { clearMVStale } = await import('../with-formula/materialized-views/stale.js')
-    clearMVStale(registry, name)
+    // Manual refresh clears any pending stale bit (+ persisted marker, #736) —
+    // the post-refresh state matches the registered strategy.
+    const { clearMVStaleFully } = await import('../with-formula/materialized-views/stale.js')
+    await clearMVStaleFully(this.adapter, this.name, registry, name)
     return result
   }
 

--- a/packages/hub/src/with-formula/materialized-views/stale.ts
+++ b/packages/hub/src/with-formula/materialized-views/stale.ts
@@ -125,10 +125,10 @@ async function hydratePersistedStaleMarkers(accessor: MVStaleAccessor, registry:
  * output row) using the adapter directly so the read-path's `resolveStaleMVOnRead`
  * isn't triggered mid-invalidation. `mode: 'lazy'` also persists the stale mark so a
  * cold session recomputes on next read; `'manual'` gets the purge only — the MV
- * serves empty until an explicit `vault.refreshView()` (erasure wins). If another
- * registered MV shares this output collection, it just lost its rows too without a
- * write of its own — every OTHER `lazy` sibling on the same output is re-marked
- * stale (persisted) as well.
+ * serves empty until an explicit `vault.refreshView()` (erasure wins). Deletion is
+ * stamp-scoped (`_materializedFrom.mvName === reg.spec.name` — see the loop below),
+ * so another registered MV sharing this output collection keeps its own rows intact:
+ * no cross-MV re-marking is needed here, only `reg` itself is marked stale.
  *
  * @internal
  */
@@ -161,17 +161,14 @@ export async function invalidateMVAtRest(
     await (outputColl as any)._internalDelete(id, txCtx)
   }
 
-  const registry = accessor.registry()
-  const toMark = new Set<string>(mode === 'lazy' ? [reg.spec.name] : [])
-  for (const other of registry.all()) {
-    if (other.spec.name === reg.spec.name) continue
-    if (other.outputCollection !== reg.outputCollection) continue
-    if (other.spec.refresh !== 'lazy') continue
-    toMark.add(other.spec.name)
-  }
-  for (const name of toMark) {
-    markMVStale(registry, name)
-    await writeMVStaleMarker(adapter, vault, name)
+  // `mode: 'manual'` gets the purge only (erasure wins, no auto-recompute promise);
+  // `'lazy'` also marks + persists ITS OWN stale bit for cold-session recompute. No
+  // sibling MV on the same output collection is touched here — the stamp-scoped
+  // deletion above never erased sibling rows in the first place (#736 re-review).
+  if (mode === 'lazy') {
+    const registry = accessor.registry()
+    markMVStale(registry, reg.spec.name)
+    await writeMVStaleMarker(adapter, vault, reg.spec.name)
   }
 }
 
@@ -207,10 +204,16 @@ export async function resolveStaleMVOnRead(
   // hydrate is still awaiting `adapter.list` must await the SAME promise —
   // otherwise it observes "already hydrating", skips straight to an empty
   // pending set, and serves the purged/stale view as fresh (#736
-  // whole-branch review, hydrate-once race).
+  // whole-branch review, hydrate-once race). On rejection, evict the entry
+  // BEFORE rethrowing — a cached rejected promise would otherwise poison the
+  // MV read surface for the rest of the session (every later read re-awaits
+  // the same rejection instead of retrying the store call) (#736 re-review).
   let hydrate = _hydratedByRegistry.get(registry)
   if (!hydrate) {
-    hydrate = hydratePersistedStaleMarkers(accessor, registry)
+    hydrate = hydratePersistedStaleMarkers(accessor, registry).catch((err: unknown) => {
+      _hydratedByRegistry.delete(registry)
+      throw err
+    })
     _hydratedByRegistry.set(registry, hydrate)
   }
   await hydrate

--- a/packages/hub/src/with-formula/materialized-views/stale.ts
+++ b/packages/hub/src/with-formula/materialized-views/stale.ts
@@ -75,8 +75,14 @@ export function isMVStale(registry: MaterializedViewRegistry, mvName: string): b
  */
 export const MV_STALE_COLLECTION = '_mv_stale'
 
-/** Once-per-registry hydrate guard for `resolveStaleMVOnRead`'s persisted-marker fold-in. */
-const _hydratedByRegistry = new WeakMap<MaterializedViewRegistry, true>()
+/**
+ * Once-per-registry hydrate guard for `resolveStaleMVOnRead`'s persisted-marker fold-in.
+ * Stores the in-flight/settled PROMISE (not a boolean) — a concurrent cold first read that
+ * arrives while the hydrate is still awaiting `adapter.list` must await the SAME promise
+ * rather than observing "already hydrating" and reading an empty pending set (#736
+ * whole-branch review).
+ */
+const _hydratedByRegistry = new WeakMap<MaterializedViewRegistry, Promise<void>>()
 
 /** The adapter + vault name backing any collection in this vault (all collections share both). */
 function storeOf(accessor: MVStaleAccessor, collectionName: string): { adapter: NoydbStore; vault: string } {
@@ -135,6 +141,22 @@ export async function invalidateMVAtRest(
   const txCtx = accessor.getActiveTxContext()
   const { adapter, vault } = storeOf(accessor, reg.outputCollection)
   for (const id of await adapter.list(vault, reg.outputCollection)) {
+    // A same-collection partition MV (`output: { collection: <source>, partition }`,
+    // the DERIV-PP30-001 shape) writes INTO its own source collection — `adapter.list`
+    // over `reg.outputCollection` then also returns untouched user source records.
+    // Decode each candidate row (the invalidation path is rare; this cost is fine
+    // here) and only erase rows THIS MV stamped via `_materializedFrom.mvName` —
+    // an unstamped row, or one stamped by a different MV, is never this MV's to
+    // delete (#736 whole-branch review, Critical).
+    const envelope = await adapter.get(vault, reg.outputCollection, id)
+    if (envelope === null) continue
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const decoded = await (outputColl as any)._decodeEnvelope(envelope, id)
+    const stampedBy =
+      decoded !== null && typeof decoded === 'object'
+        ? (decoded as Record<string, unknown>)._materializedFrom as { mvName?: string } | undefined
+        : undefined
+    if (stampedBy?.mvName !== reg.spec.name) continue
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (outputColl as any)._internalDelete(id, txCtx)
   }
@@ -180,13 +202,35 @@ export async function resolveStaleMVOnRead(
   const registry = accessor.registry()
   // Cold session: the in-memory WeakMap has no entry for this (freshly
   // constructed) registry yet — fold any persisted `_mv_stale` markers in
-  // before reading the pending set, once per registry (#736).
-  if (!_hydratedByRegistry.has(registry)) {
-    _hydratedByRegistry.set(registry, true)
-    await hydratePersistedStaleMarkers(accessor, registry)
+  // before reading the pending set, once per registry (#736). Memoize the
+  // PROMISE, not a boolean: a concurrent first read arriving while the
+  // hydrate is still awaiting `adapter.list` must await the SAME promise —
+  // otherwise it observes "already hydrating", skips straight to an empty
+  // pending set, and serves the purged/stale view as fresh (#736
+  // whole-branch review, hydrate-once race).
+  let hydrate = _hydratedByRegistry.get(registry)
+  if (!hydrate) {
+    hydrate = hydratePersistedStaleMarkers(accessor, registry)
+    _hydratedByRegistry.set(registry, hydrate)
   }
+  await hydrate
   const pending = _staleByRegistry.get(registry)
   if (!pending || pending.size === 0) return
+
+  const { adapter, vault } = storeOf(accessor, outputCollection)
+
+  // Clean up persisted markers for MV names no longer registered (renamed or
+  // removed since the marker was written). Without this sweep an orphaned name
+  // can never become a `candidate` below — `candidates` is built from
+  // `registry.all()`, which no longer lists it — so both the in-memory pending
+  // entry and the persisted `_mv_stale` row would linger forever, re-hydrating
+  // on every cold session (#736 whole-branch review).
+  for (const name of pending) {
+    if (registry.byName(name)) continue
+    pending.delete(name)
+    await deleteMVStaleMarker(adapter, vault, name)
+  }
+  if (pending.size === 0) return
 
   // Find every MV that writes to this output collection AND is
   // currently flagged stale. Multiple MVs CAN share an output
@@ -201,11 +245,15 @@ export async function resolveStaleMVOnRead(
   if (candidates.length === 0) return
 
   let executor: typeof MVExecutorType | null = null
-  const { adapter, vault } = storeOf(accessor, outputCollection)
   for (const name of candidates) {
     const reg = registry.byName(name)
     if (!reg) {
+      // Unreachable in practice — `candidates` is drawn from `registry.all()`,
+      // and the orphan sweep above already cleared any name absent from it.
+      // Kept as a defensive fallback; also clears the persisted marker so it
+      // can't linger if this ever does fire.
       pending.delete(name)
+      await deleteMVStaleMarker(adapter, vault, name)
       continue
     }
     if (executor === null) {
@@ -231,6 +279,10 @@ export async function resolveStaleMVOnRead(
       ...(dispatchCtx !== undefined ? { dispatchCtx } : {}),
     })
     pending.delete(name)
+    // Runs even when no marker was ever persisted for this name (an in-session-only
+    // stale bit — e.g. the cheap ordinary-write path never writes one, see the
+    // "cheap-path guarantee" test). `adapter.delete` on an absent key is a harmless
+    // void — keeping this unconditional avoids branching on marker origin here.
     await deleteMVStaleMarker(adapter, vault, name)
   }
 }

--- a/packages/hub/src/with-formula/materialized-views/stale.ts
+++ b/packages/hub/src/with-formula/materialized-views/stale.ts
@@ -1,12 +1,14 @@
 import type { Collection } from '../../kernel/collection.js'
 import type { TxContext } from '../../with-commit/tx/transaction.js'
 import type { PutDerivedOutputCtx } from '../../kernel/via/dispatch.js'
-import type { MaterializedViewRegistry } from './registry.js'
+import type { MaterializedViewRegistry, RegisteredMV } from './registry.js'
 // Type-only — runtime class loaded via dynamic import in
 // `resolveStaleMVOnRead` only when a stale flag actually fires.
 // Keeps the executor chunk out of the floor bundle (mirrors v1 floor-bundle isolation).
 import type { MaterializedViewExecutor as MVExecutorType } from './executor.js'
 import type { MVQueryContext } from './types.js'
+import type { NoydbStore } from '../../kernel/types.js'
+import { RecordCodec } from '../../kernel/enclave/index.js'
 
 /**
  * Accessor shape passed in from the owning Vault. Provides the
@@ -63,6 +65,95 @@ export function isMVStale(registry: MaterializedViewRegistry, mvName: string): b
 }
 
 /**
+ * Reserved collection holding CONTENT-FREE lazy-stale markers (record id =
+ * MV name, plaintext `_iv: ''` envelope, no payload) — mirrors the
+ * `_meta`/schema-fence marker envelope shape. Written only from the
+ * delete/forget/elevate dispatcher (#736); ordinary source writes stay
+ * in-memory-only (the cheap path). Read via the adapter directly, never
+ * through `vault.collection()` — same reserved-collection convention as
+ * `_subject_index`/`_meta`.
+ */
+export const MV_STALE_COLLECTION = '_mv_stale'
+
+/** Once-per-registry hydrate guard for `resolveStaleMVOnRead`'s persisted-marker fold-in. */
+const _hydratedByRegistry = new WeakMap<MaterializedViewRegistry, true>()
+
+/** The adapter + vault name backing any collection in this vault (all collections share both). */
+function storeOf(accessor: MVStaleAccessor, collectionName: string): { adapter: NoydbStore; vault: string } {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const c = accessor.getCollection(collectionName) as any
+  return { adapter: c.adapter as NoydbStore, vault: c.vault as string }
+}
+
+async function writeMVStaleMarker(adapter: NoydbStore, vault: string, mvName: string): Promise<void> {
+  // Content-free — the marker's only payload is its key (the MV name).
+  const env = RecordCodec.buildPlaintextEnvelope({ version: 1, data: '{}' })
+  await adapter.put(vault, MV_STALE_COLLECTION, mvName, env)
+}
+
+async function deleteMVStaleMarker(adapter: NoydbStore, vault: string, mvName: string): Promise<void> {
+  await adapter.delete(vault, MV_STALE_COLLECTION, mvName)
+}
+
+/**
+ * On first `resolveStaleMVOnRead` call for a (cold-reopened) registry, fold every
+ * persisted `_mv_stale` marker into the in-memory pending set — otherwise a cold
+ * session's empty `WeakMap` entry reads as "fresh" and serves the emptied output
+ * collection forever.
+ */
+async function hydratePersistedStaleMarkers(accessor: MVStaleAccessor, registry: MaterializedViewRegistry): Promise<void> {
+  const mvs = registry.all()
+  if (mvs.length === 0) return
+  const { adapter, vault } = storeOf(accessor, mvs[0]!.outputCollection)
+  // No try/catch: a genuine store failure here must surface, not be read as
+  // "nothing pending" — silently treating it as fresh is the exact leak class
+  // this module closes (mirrors `subject-index.ts`'s bare `adapter.list` reads).
+  for (const name of await adapter.list(vault, MV_STALE_COLLECTION)) markMVStale(registry, name)
+}
+
+/**
+ * Invalidate an MV from the delete/forget/elevate dispatcher (#736) — the ordinary
+ * source-write path (`dispatchMaterializedViews`) never calls this. Deletes EVERY
+ * persisted row in `reg.outputCollection` via `_internalDelete` (the at-rest law: a
+ * stale mark alone leaves the elevated/forgotten source's plaintext sitting in the
+ * output row) using the adapter directly so the read-path's `resolveStaleMVOnRead`
+ * isn't triggered mid-invalidation. `mode: 'lazy'` also persists the stale mark so a
+ * cold session recomputes on next read; `'manual'` gets the purge only — the MV
+ * serves empty until an explicit `vault.refreshView()` (erasure wins). If another
+ * registered MV shares this output collection, it just lost its rows too without a
+ * write of its own — every OTHER `lazy` sibling on the same output is re-marked
+ * stale (persisted) as well.
+ *
+ * @internal
+ */
+export async function invalidateMVAtRest(
+  accessor: MVStaleAccessor,
+  reg: RegisteredMV,
+  mode: 'lazy' | 'manual',
+): Promise<void> {
+  const outputColl = accessor.getCollection(reg.outputCollection)
+  const txCtx = accessor.getActiveTxContext()
+  const { adapter, vault } = storeOf(accessor, reg.outputCollection)
+  for (const id of await adapter.list(vault, reg.outputCollection)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (outputColl as any)._internalDelete(id, txCtx)
+  }
+
+  const registry = accessor.registry()
+  const toMark = new Set<string>(mode === 'lazy' ? [reg.spec.name] : [])
+  for (const other of registry.all()) {
+    if (other.spec.name === reg.spec.name) continue
+    if (other.outputCollection !== reg.outputCollection) continue
+    if (other.spec.refresh !== 'lazy') continue
+    toMark.add(other.spec.name)
+  }
+  for (const name of toMark) {
+    markMVStale(registry, name)
+    await writeMVStaleMarker(adapter, vault, name)
+  }
+}
+
+/**
  * Called from `Collection.get` (and any reader that materializes the
  * MV's output collection). If any MV producing `outputCollection` is
  * flagged stale, runs the executor against the live source state
@@ -87,6 +178,13 @@ export async function resolveStaleMVOnRead(
   dispatchCtx?: PutDerivedOutputCtx,
 ): Promise<void> {
   const registry = accessor.registry()
+  // Cold session: the in-memory WeakMap has no entry for this (freshly
+  // constructed) registry yet — fold any persisted `_mv_stale` markers in
+  // before reading the pending set, once per registry (#736).
+  if (!_hydratedByRegistry.has(registry)) {
+    _hydratedByRegistry.set(registry, true)
+    await hydratePersistedStaleMarkers(accessor, registry)
+  }
   const pending = _staleByRegistry.get(registry)
   if (!pending || pending.size === 0) return
 
@@ -103,6 +201,7 @@ export async function resolveStaleMVOnRead(
   if (candidates.length === 0) return
 
   let executor: typeof MVExecutorType | null = null
+  const { adapter, vault } = storeOf(accessor, outputCollection)
   for (const name of candidates) {
     const reg = registry.byName(name)
     if (!reg) {
@@ -114,6 +213,17 @@ export async function resolveStaleMVOnRead(
         MaterializedViewExecutor: typeof MVExecutorType
       })
     }
+    // A cold-hydrated stale flag (unlike an in-session one) can fire with
+    // NONE of the MV's dependency collections touched yet this session —
+    // the sync `Query.toArray()` `spec.query()` runs reads straight off
+    // `Collection`'s in-memory cache, populated only by a prior async
+    // touch (`ensureHydrated()`, called from `get`/`list`/`put`, never
+    // from `query()` itself). Warm every dependency first so the recompute
+    // sees the live persisted state instead of an empty cache (#736).
+    for (const dep of reg.dependencies) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (accessor.getCollection(dep) as any).ensureHydrated()
+    }
     await executor.refresh(reg, {
       getCollection: (n) => accessor.getCollection(n),
       getActiveTxContext: () => accessor.getActiveTxContext(),
@@ -121,6 +231,7 @@ export async function resolveStaleMVOnRead(
       ...(dispatchCtx !== undefined ? { dispatchCtx } : {}),
     })
     pending.delete(name)
+    await deleteMVStaleMarker(adapter, vault, name)
   }
 }
 
@@ -135,4 +246,21 @@ export async function resolveStaleMVOnRead(
  */
 export function clearMVStale(registry: MaterializedViewRegistry, mvName: string): void {
   _staleByRegistry.get(registry)?.delete(mvName)
+}
+
+/**
+ * `clearMVStale` plus the persisted marker (#736) — `Vault.refreshView()`'s
+ * completion path. A lingering persisted marker after a manual refresh would
+ * make the NEXT cold session recompute redundantly.
+ *
+ * @internal
+ */
+export async function clearMVStaleFully(
+  adapter: NoydbStore,
+  vault: string,
+  registry: MaterializedViewRegistry,
+  mvName: string,
+): Promise<void> {
+  clearMVStale(registry, mvName)
+  await deleteMVStaleMarker(adapter, vault, mvName)
 }


### PR DESCRIPTION
Closes #736. Closes #737. Closes #740. Milestone-34 Batch C; plan (incl. recorded corrections): `docs/superpowers/plans/2026-07-17-mv-tier-followups.md`.

## What

- **#736 — lazy/manual MV invalidation is now real erasure.** `dispatchMaterializedViewsOnDelete` (shared by `forget()`'s fanout and tier-move `syncDerived`) previously flipped an in-memory stale bit (lazy) or no-oped (manual) — the persisted output row kept the elevated/forgotten source's plaintext at rest and cold sessions served it as fresh. Now: the MV's persisted output rows are deleted at rest — **scoped to `_materializedFrom`-stamped rows** (the whole-branch review caught that a blanket wipe erased user *source* records in same-collection partition MVs — the canonical DERIV-PP30-001 shape; reproduced, fixed, regression-locked) — and for lazy MVs the stale mark persists in the reserved content-free `_mv_stale` collection so a cold session recomputes on first read (hydrate is promise-memoized with failure eviction: a transient store error doesn't poison the read surface; concurrency + recovery tests). Manual MVs serve empty until `refreshView()` — erasure wins. Ordinary source writes keep the zero-I/O in-memory path (test-pinned).
- **#737 — source-grained decode gate.** `hasDerivedOutputs` now uses the dispatchers' own registry lookups (`strategiesForSource`/`mvsForSource` — covering source/siblings/triggerBy/rollup relations in lock-step with dispatch), so a tiered collection with no derivations of its own skips the pre-move decode. Verified by a corrupt-envelope no-decode observable on `putAtTier` (elevate always decrypts via `rewrapBodyToDek`, so it can't witness the gate — recorded in the test).
- **#740 — `tiers` + `encrypted: false` refused at construction** (`UnsupportedTierCompositionError`): per-record clearance IS per-tier encryption; a plaintext collection can't honor it. Catches the `createNoydb({ encrypt: false })` default too.

## Review trail

Per-task reviews Approved ×3; fable whole-branch review ("No" → Critical same-collection wipe + 2 Importants fixed across two fix waves → merge gate cleared). Issues filed from this arc's reviews: **#761** (erasure-candor set: `derivedRecordsErased` under-count, manual-sibling coverage, MV-output history snapshots, undecodable-stamped-candidate residue notice, rename-stamp edge), **#762** (priority-high pre-existing: eager executor's `onEmpty:'delete'` diff erases user rows on FIRST materialize of same-collection MVs — same unscoped-ownership root cause, fix = adopt the stamp-scoping shipped here).

## Verification

Full hub suite 510 files / 4245 tests green; typecheck / lint / `check:architecture` clean; `collection.ts` and `vault.ts` both land exactly at their ceilings. Changeset `mv-tier-followups.md` (hub patch) local-only per convention.