### PR TITLE
fix(hub): milestone-34 batch D — time-machine gate, index-flush race, lazy prior, machinery write ring (#730, #725, #720, #718, #708, #733)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-m34-batch-d.md
+++ b/docs/superpowers/plans/2026-07-17-m34-batch-d.md
@@ -1,0 +1,91 @@
+# Milestone-34 Batch D (#730 #725 #720 #718 #708-edge #733) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the remaining read-gate, race, and write-ring items of milestone 34: the time-machine tier gate (#730), the persisted-search-index flush race (#725), the lazy `putAtTier` dropped-field sidecar (#720), the internal-delete write-ring rule + the coordinated-cutover refusal (#718 + #708's sharp edge), and the `assertTierComposition` placement cleanup (#733).
+
+**Architecture / rulings (fixed):**
+- **#718 rule: internal deletes SKIP elevated records** (return "nothing deleted", like every read gate treats them as missing) — machinery operating at tier 0 must not see, and therefore must not delete, an elevated record; refusal would strand derived-output cleanup. **#708's cutover REFUSES loudly** (`TierWriteRefusedError` or sibling): a schema cutover that silently skipped records would diverge schema versions across tiers — the caller must demote first. Document both rules where they land.
+- Each issue's body contains its own verified fix shape — implement those as written (they came from prior arcs' reviews with probes).
+
+**Tech Stack:** TypeScript ESM, vitest, `crypto.subtle` only.
+
+## Global Constraints
+
+- `collection.ts` ceiling 4549 metric and `vault.ts` 3959 — both EXACT; every touch there must be line-neutral or funded in place. No-ceiling homes preferred (`time-machine.ts`, `persisted-index-store.ts`, `collection-facade.ts`, `with-audit/tiers/index.ts`).
+- Never add Claude attribution. Hub portable. TDD per task.
+- Branch: `fix/m34-batch-d` off main after PR #763 merges.
+
+---
+
+### Task 1: #730 — time-machine tier gate
+
+**Files:** `packages/hub/src/with-commit/history/time-machine.ts` (`CollectionInstant.get()` ~136, `.list()`), tests in a new or adjacent history/time-machine test file (find the existing time-machine tests).
+
+Per the issue: gate `get()`/`list()` on the live record's tier exactly like `history()`/`getVersion()` (the #712 read-gate — find its `liveRecordIsElevated` call and mirror it): elevated live record → `get()` returns `null`, `list()` omits the id. Fold in the pre-existing perRecordKeys bug: `get()` ignores `_cek` — route the decrypt through the same envelope-open helper `history()` uses so per-record-CEK snapshots decrypt correctly (find how `getVersion` opens snapshots post-#712 rewrap and reuse).
+
+Tests (RED first): (1) elevated record → `vault.at(ts).get(id)` is `null` (was: opaque throw), `.list()` omits the id (was: existence reveal); (2) demoted back → time-machine reads work again; (3) perRecordKeys collection, no tiers: `at(ts).get()` returns the historical body (locks the `_cek` fix); (4) tier-0 record unaffected.
+
+Commit: `fix(hub): time-machine reads are tier-gated — vault.at() honors the invisibility law; perRecordKeys snapshots decrypt (#730)`.
+
+---
+
+### Task 2: #725 — persisted-index flush epoch
+
+**Files:** `packages/hub/src/with-lookup/indexing/persisted-index-store.ts` (+ its facade `collection-facade.ts` save path if the epoch check lands there), tests beside the existing persisted-index tests (`search-persist-forget.test.ts` neighborhood).
+
+Per the issue's fix shape: `PersistedIndexStore` gains an epoch counter + tracks the in-flight persist promise. `removePersisted()` (and any purge entry) bumps the epoch; a `save()` whose captured epoch is stale no-ops its `adapter.put`. Both variants die: a delete can never be overtaken by a save scheduled before it.
+
+Tests (RED first, deterministic — no real timers if avoidable; drive the debounce/flush hooks directly or with fake timers): (1) start a flush, `removePersisted()` mid-flight (await ordering controlled), assert the `_ftindex` blob stays ABSENT at the adapter after both settle — via the `elevate()` entry; (2) same via the `forget()` entry; (3) a normal flush with no interleaved purge still persists (epoch unchanged → put lands).
+
+Commit: `fix(hub): persisted-index saves are epoch-guarded — a purge can't be overtaken by an in-flight debounced flush (#725)`.
+
+---
+
+### Task 3: #720 — lazy putAtTier prior via tier-gated decode
+
+**Files:** `packages/hub/src/with-lookup/indexing/collection-facade.ts` (`syncTierIndexes` ~491), tests beside #709's tier-indexing tests.
+
+Per the issue: `prior = ctx.cache.get(id)` is always null in lazy mode. Fix: LRU first, then a tier-gated adapter decode fallback — reuse the campaign's standard `(env._tier ?? 0) > 0` skip (return null prior for an elevated envelope; never an ungated decode) and the same decode primitive the regular lazy put path uses (`collection.ts:1916-1927` — thread it, don't duplicate crypto). Also fix the adjacent nit if trivial in the same touch: `version ?? 1` dead default (`:496`) — make the param required if all callers pass it.
+
+Test (RED first — the issue's probe): lazy + tiered + indexed collection; `put` sets `salary: 100` (sidecar exists); `putAtTier(id, { /* salary dropped */ }, 0)` → sidecar for the old value DELETED at the adapter. Plus: same sequence where the record was elevated first → the fallback decode skips (no throw, prior treated as null — assert no error and sidecars for the elevated record already purged by elevate).
+
+Commit: `fix(hub): lazy putAtTier resolves the prior via a tier-gated decode — dropped-field sidecars are cleared (#720)`.
+
+---
+
+### Task 4: #718 + #708 sharp edge — the internal write ring
+
+**Files:** `packages/hub/src/kernel/collection.ts` (`_doDelete` internal arm; the cutover rewrite path ~2560-2600 `'schema:coordinated-cutover'`) — CEILING: both changes must be tiny/funded; heavy logic (if any) goes to `with-audit/tiers/` helpers. Tests: tier-write-ring test file (exists: `tier-write-ring.test.ts`).
+
+1. **#718 (skip):** in `_doDelete`, the `internal: true` path gains the elevated-record SKIP: if the live envelope has `_tier > 0`, return the "nothing deleted" result without writing a marker (mirror how the public arm detects elevation — reuse its peek; keep it one compact line + a comment stating the rule: tier-0 machinery treats elevated records as nonexistent, so internal cleanup skips them; the elevated record's own derived state is handled by the tier ops). REPRO FIRST per the issue: a tiered MV/derivation OUTPUT collection with an elevated row, trigger internal cleanup targeting it (the issue says unconfirmed — if you cannot construct the repro through public APIs in reasonable effort, test the skip at the `_doDelete` unit level via an internal-delete call and say so in the report).
+2. **#708 edge (refuse):** the coordinated-cutover bulk-rewrite (`_rewriteAllRecords` / the `'cutover'` dispatch) currently decodes/rewrites every record at tier 0 — an elevated record would be silently demoted (its rewrite lands without `_tier`) or crash. Add a loud refusal BEFORE any rewrite when any live envelope carries `_tier > 0`: throw `TierWriteRefusedError` (check its constructor) naming the collection + first offending id + "demote before a coordinated cutover". Test: cutover on a collection with an elevated record → throws, NO record was rewritten (all-or-nothing pre-check); after demote → cutover succeeds.
+
+Commit: `fix(hub): internal deletes skip elevated records; coordinated cutover refuses them loudly — the write ring covers machinery paths (#718, #708)`.
+
+---
+
+### Task 5: #733 move + changeset + close-out
+
+1. Move `assertTierComposition` (+ its #748 public:true sibling if colocated — check what else lives in that block) from `with-lookup/indexing/unique-constraints.ts` to `with-audit/tiers/index.ts` per the issue's zero-cost import plan: collection.ts already imports from `with-audit/tiers/index.js` (grandfathered) — fold the symbol into that existing import line and drop it from the unique-constraints line; collection.ts must stay line-NEUTRAL (4548 raw). Careful: the guard is CALLED from `resolveCollectionConfig`/`collection-config.ts` too post-#740/#748 — check the actual call sites and move imports accordingly (collection-config.ts has no ceiling). `pnpm check:architecture` is the acceptance bar (no new grandfather entries).
+2. Changeset `.changeset/m34-batch-d.md`:
+
+```md
+---
+"@noy-db/hub": patch
+---
+
+Milestone-34 batch D — read-gate, race, and write-ring completeness (#730, #725, #720, #718, #708). Time-machine reads (`vault.at(ts)`) now honor the tier invisibility law: an elevated record's history returns `null`/is omitted instead of an opaque decrypt error plus an id-existence reveal, and per-record-CEK snapshots decrypt correctly. Persisted full-text-index saves are epoch-guarded, closing the debounced-flush race that could briefly re-persist an elevated or forgotten record's text at rest (both the elevate and forget entry points are test-locked). Lazy `putAtTier` resolves the prior record through a tier-gated decode, so dropping an indexed field clears its sidecar exactly like `put()` does. The write ring now covers machinery paths: internal derivation/MV cleanup deletes SKIP elevated records (tier-0 machinery treats them as nonexistent — no tier-signal erasure), and a coordinated schema cutover REFUSES loudly (`TierWriteRefusedError`) while any record is elevated, instead of silently demoting it — demote first, then cut over. Housekeeping: the tier-composition guard now lives in the tier domain (`with-audit/tiers`).
+```
+
+3. Full verification (hub test/typecheck/lint/check:architecture); ceilings exact.
+
+Commit: `chore(hub): tier guard lives in the tier domain (#733) + batch-D changeset`.
+
+---
+
+## Self-Review Notes
+
+- The skip-vs-refuse split (#718 skip, #708-cutover refuse) is the batch's one policy decision and is recorded in the Architecture block; both tests pin the chosen semantics.
+- #725's epoch guard is deliberately in the store (not the facade) so EVERY purge entry benefits, not just the two known ones.
+- After this batch, milestone 34's remaining set is: #708 (close via comment once Task 4 lands — the documented-limitation half), #712-residue #746 #753 #756 #759 #761 (the durability/candor constellation) — reassess scope then.

--- a/docs/superpowers/plans/2026-07-17-m34-batch-d.md
+++ b/docs/superpowers/plans/2026-07-17-m34-batch-d.md
@@ -30,6 +30,22 @@ Commit: `fix(hub): time-machine reads are tier-gated — vault.at() honors the i
 
 ---
 
+> **CORRECTIONS (2026-07-18, shipped designs — recorded per the campaign's plan-trail convention):**
+> - **Task 2:** the file lives at `with-lookup/search/persisted-index-store.ts` (not `indexing/`). The
+>   shipped design is LAYERED, not the literal "stale save no-ops its put": epoch capture + a
+>   gate-before-put `isStale()` predicate (checked post-encrypt) + a compensate-after remove when a
+>   purge landed mid-save + a STICKY retry when the compensating remove itself fails (every store
+>   entrypoint re-attempts before proceeding). Crash residuals are documented, not claimed away.
+>   Follow-up #764 tracks the stuck-compensation blast radius.
+> - **Task 3:** the plan's "LRU first, then tier-gated adapter decode fallback" is IMPOSSIBLE — by
+>   the time `syncTierIndexes` runs, the write has landed and an adapter read re-observes the new
+>   value. Shipped: the tier ops thread their already-captured PRE-WRITE envelope through an
+>   optional `priorEnvelope` param, decoded via the existing tier-gated `skipValidation` primitive.
+> - **Task 5:** `assertTierComposition` was discovered DEAD (Arc 10's runtime read gate superseded
+>   it; zero call sites) — shipped as a pure relocation with its docblock updated to state the
+>   superseded status (the #724 leak analysis it carries is load-bearing documentation);
+>   collection.ts needed no import fold at all.
+
 ### Task 2: #725 — persisted-index flush epoch
 
 **Files:** `packages/hub/src/with-lookup/indexing/persisted-index-store.ts` (+ its facade `collection-facade.ts` save path if the epoch check lands there), tests beside the existing persisted-index tests (`search-persist-forget.test.ts` neighborhood).

--- a/packages/hub/__tests__/search-persist-flush-purge-race.test.ts
+++ b/packages/hub/__tests__/search-persist-flush-purge-race.test.ts
@@ -1,0 +1,171 @@
+/**
+ * #725 — persisted-index flush/purge race. `PersistedIndexStore` debounces a
+ * save (encrypt + `adapter.put`) of the `_ftindex` blob; `removePersisted()`
+ * (elevate's tier purge, forget's erasure) must never be overtaken by a save
+ * that was already in flight when the purge landed — otherwise a purged or
+ * forgotten record's derived plaintext resurrects at rest (#721's residual
+ * race, both variants named in the issue).
+ *
+ * Determinism: a gate on the underlying adapter's `put('_ftindex', ...)`
+ * blocks the in-flight save right where its real `encryptJsonString` → `put`
+ * gap sits, and signals once it has genuinely arrived there. The purge is then
+ * run to full completion WHILE the save is still blocked — the worst-case
+ * ordering (delete lands, then a stale put resolves after) — before the gate
+ * is released, reproducing the exact interleaving the issue describes without
+ * any real-time sleep.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withSearch, ConflictError } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { withI18n } from '../src/via/i18n/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+/** Wrap a store so a `put` to `_ftindex` blocks on `gate` while `gate` is
+ *  armed, and calls `onReached` right before blocking — lets a test know the
+ *  in-flight save has genuinely reached its adapter.put boundary. */
+function gateFtindexPut(store: NoydbStore, hooks: { gate: () => Promise<void> | null; onReached: () => void }): NoydbStore {
+  return {
+    ...store,
+    async put(v, c, id, env, ev) {
+      const g = c === '_ftindex' ? hooks.gate() : null
+      if (g) { hooks.onReached(); await g }
+      return store.put(v, c, id, env, ev)
+    },
+  }
+}
+
+const SECRET = 'flush-purge-race-passphrase-725'
+
+describe('#725 elevate() purge cannot be overtaken by an in-flight debounced flush', () => {
+  interface Doc { id: string; body: string }
+
+  it('the _ftindex blob stays ABSENT at the adapter once both the in-flight flush and elevate() settle', async () => {
+    const base = memoryStore()
+    let gate: Promise<void> | null = null
+    let reached: (() => void) | null = null
+    const store = gateFtindexPut(base, { gate: () => gate, onReached: () => reached?.() })
+
+    const db = await createNoydb({ store, user: 'owner', secret: SECRET, searchStrategy: withSearch(), tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1],
+      perRecordKeys: true,
+      textIndexes: ['body'],
+      textIndexPersist: true,
+    })
+
+    await docs.put('e1', { id: 'e1', body: 'topsecret-alpha-bravo' })
+    await docs.flushIndex() // initial persist, uninterrupted (gate not yet armed)
+    expect(await store.get('v1', '_ftindex', 'docs')).not.toBeNull()
+
+    // Arm the gate and start a SECOND flush without awaiting it — wait until
+    // it has genuinely reached the `_ftindex` put before doing anything else.
+    let release!: () => void
+    gate = new Promise<void>((r) => { release = r })
+    const reachedPromise = new Promise<void>((r) => { reached = r })
+    const flushPromise = docs.flushIndex()
+    await reachedPromise // the flush is now blocked INSIDE the in-flight save
+
+    // elevate() purges to completion WHILE the save is still blocked mid-flight
+    // — the worst-case ordering: the purge's delete lands, and only THEN does
+    // the stale save's put resolve and (absent the fix) resurrect the blob.
+    await docs.elevate('e1', 1)
+    expect(await store.get('v1', '_ftindex', 'docs')).toBeNull() // purge landed first
+
+    release() // now let the stale, already-in-flight save's put resolve
+    await flushPromise
+
+    expect(await store.get('v1', '_ftindex', 'docs')).toBeNull()
+  })
+})
+
+describe('#725 forget() erasure cannot be overtaken by an in-flight debounced flush', () => {
+  interface Invoice { id: string; buyerId: string; memo: string }
+
+  it('the _ftindex blob stays ABSENT at the adapter once both the in-flight flush and forget() settle', async () => {
+    const base = memoryStore()
+    let gate: Promise<void> | null = null
+    let reached: (() => void) | null = null
+    const store = gateFtindexPut(base, { gate: () => gate, onReached: () => reached?.() })
+
+    const db = await createNoydb({
+      store,
+      user: 'alice',
+      secret: SECRET,
+      searchStrategy: withSearch(),
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+      i18nStrategy: withI18n(),
+    })
+    const vault = await db.openVault('v1')
+    const invoices = vault.collection<Invoice>('invoices', {
+      textIndexes: ['memo'],
+      textIndexPersist: true,
+    })
+
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', memo: 'overdue payment frombuyer1' })
+    await invoices.flushIndex() // initial persist, uninterrupted (gate not yet armed)
+    expect(await store.get('v1', '_ftindex', 'invoices')).not.toBeNull()
+
+    // Arm the gate and start a SECOND flush without awaiting it — wait until
+    // it has genuinely reached the `_ftindex` put before doing anything else.
+    let release!: () => void
+    gate = new Promise<void>((r) => { release = r })
+    const reachedPromise = new Promise<void>((r) => { reached = r })
+    const flushPromise = invoices.flushIndex()
+    await reachedPromise // the flush is now blocked INSIDE the in-flight save
+
+    // forget() erases to completion WHILE the save is still blocked mid-flight
+    // — the worst-case ordering: the erasure's delete lands, and only THEN does
+    // the stale save's put resolve and (absent the fix) resurrect the
+    // forgotten record's text.
+    const result = await vault.forget('buyer-1')
+    expect(result.recordsShredded).toBe(1)
+    expect(await store.get('v1', '_ftindex', 'invoices')).toBeNull() // erasure landed first
+
+    release() // now let the stale, already-in-flight save's put resolve
+    await flushPromise
+
+    expect(await store.get('v1', '_ftindex', 'invoices')).toBeNull()
+  })
+})

--- a/packages/hub/__tests__/search-persisted-index-store.test.ts
+++ b/packages/hub/__tests__/search-persisted-index-store.test.ts
@@ -115,4 +115,139 @@ describe('PersistedIndexStore epoch-guarded flush/purge race (#725)', () => {
     expect(state.saves).toBe(savesBefore + 1)
     expect(state.blob).not.toBeNull()
   })
+
+  it('gate-before-put: isStale() goes true while a save is mid-"encrypt" (before its own write), and the save skips the write entirely', async () => {
+    // Mirrors collection-facade.ts's real save(): an async encrypt-like gap, THEN a
+    // pre-put staleness check — proving the check actually prevents the write (not
+    // just papering over it after the fact, which is persist()'s separate backstop).
+    const state: { blob: { json: string; fingerprint: Fingerprint } | null; puts: number } = { blob: null, puts: 0 }
+    let encryptGate: Promise<void> | null = null
+    let reachedEncrypt: (() => void) | null = null
+    const store = new PersistedIndexStore({
+      load: async () => state.blob,
+      save: async (json, f, isStale) => {
+        if (encryptGate) { reachedEncrypt?.(); await encryptGate }
+        if (isStale()) return
+        state.puts++
+        state.blob = { json, fingerprint: f }
+      },
+      remove: async () => { state.blob = null },
+      currentFingerprint: () => ({ count: 1, maxVersion: 1 }),
+      debounceMs: 10,
+    })
+
+    await store.ensureBuilt(() => docs) // warm build + save, uninterrupted
+    const putsBefore = state.puts
+
+    let releaseEncrypt!: () => void
+    encryptGate = new Promise<void>((r) => { releaseEncrypt = r })
+    const reachedPromise = new Promise<void>((r) => { reachedEncrypt = r })
+    const flushPromise = store.flush()
+    await reachedPromise // blocked mid-"encrypt" — isStale() has NOT been checked yet
+
+    await store.removePersisted() // the purge lands while the save is still encrypting
+
+    releaseEncrypt()
+    await flushPromise
+
+    expect(state.puts).toBe(putsBefore) // the write itself was skipped — isStale() caught it pre-put
+    expect(state.blob).toBeNull()
+  })
+
+  it('a failed compensation is retried by the NEXT store operation, not silently dropped (#725 review)', async () => {
+    const state: { blob: { json: string; fingerprint: Fingerprint } | null; removeCalls: number } = { blob: null, removeCalls: 0 }
+    let failOnCall = -1
+    let gate: Promise<void> | null = null
+    let reached: (() => void) | null = null
+    const store = new PersistedIndexStore({
+      load: async () => state.blob,
+      save: async (json, f) => {
+        if (gate) { reached?.(); await gate }
+        state.blob = { json, fingerprint: f }
+      },
+      remove: async () => {
+        state.removeCalls++
+        if (state.removeCalls === failOnCall) throw new Error('simulated remove failure')
+        state.blob = null
+      },
+      currentFingerprint: () => ({ count: 1, maxVersion: 1 }),
+      debounceMs: 10,
+    })
+
+    await store.ensureBuilt(() => docs) // warm build + save, uninterrupted
+
+    // Arm the gate for a racy save; let removePersisted's OWN remove (call #1)
+    // succeed, but make the save's COMPENSATING remove (call #2) fail once.
+    let release!: () => void
+    gate = new Promise<void>((r) => { release = r })
+    const reachedPromise = new Promise<void>((r) => { reached = r })
+    const flushPromise = store.flush()
+    await reachedPromise
+
+    failOnCall = 2
+    await store.removePersisted() // call #1 — succeeds
+    expect(state.blob).toBeNull()
+
+    release() // the stale save lands, then its own compensation (call #2) fails
+    await expect(flushPromise).rejects.toThrow('simulated remove failure')
+    // The debounced-flush path would swallow this exact failure via its
+    // `.catch(() => {})` — here it propagates because flush() is awaited
+    // directly, but the RESIDUE (a resurrected blob) is identical either way.
+    expect(state.blob).not.toBeNull() // the resurrection survives the failed compensation…
+
+    // …but is NOT silently dropped: the next store operation retries it first.
+    await store.removePersisted() // call #3 — retries the pending compensation, then does its own remove
+    expect(state.blob).toBeNull()
+    expect(state.removeCalls).toBeGreaterThanOrEqual(3)
+  })
+
+  it('variant (b) is subsumed: removePersisted always clears the in-memory index, so a flush after a purge can never skip the rebuild and pair a stale (pre-purge) index with the live fingerprint', async () => {
+    const withE1: IndexDoc[] = [{ id: 'e1', fields: [{ field: 'd', text: 'topsecret-e1' }] }, { id: 't0', fields: [{ field: 'd', text: 'public-t0' }] }]
+    const withoutE1: IndexDoc[] = [{ id: 't0', fields: [{ field: 'd', text: 'public-t0' }] }]
+    let liveCacheDocs: IndexDoc[] = withE1
+    const buildFromLiveCache = () => liveCacheDocs
+
+    const state: { blob: { json: string; fingerprint: Fingerprint } | null; fp: Fingerprint } =
+      { blob: null, fp: { count: 2, maxVersion: 1 } }
+    const store = new PersistedIndexStore({
+      load: async () => state.blob,
+      save: async (json, f) => { state.blob = { json, fingerprint: f } },
+      remove: async () => { state.blob = null },
+      currentFingerprint: () => state.fp,
+      debounceMs: 10,
+    })
+
+    // Warm build INCLUDING e1 (state before any purge).
+    await store.ensureBuilt(buildFromLiveCache)
+    expect(state.blob?.json).toContain('e1')
+
+    // A write happens (markDirty) — a debounced flush is now conceptually pending.
+    store.markDirty()
+
+    // Before that flush fires, a retrieve() rebuilds using the SAME (still
+    // pre-purge) live cache — the issue's "retrieve() rebuilt the index between
+    // markDirty and the timer firing." Force a rebuild (not a fingerprint-matched
+    // warm-load) by bumping the fingerprint, simulating an unrelated write.
+    state.fp = { count: 2, maxVersion: 2 }
+    await store.ensureBuilt(buildFromLiveCache)
+    expect(state.blob?.json).toContain('e1') // still pre-purge — expected, no purge yet
+
+    // NOW the purge lands (elevate/forget): cache eviction always precedes
+    // removePersisted() in both call paths, so the live cache flips first.
+    liveCacheDocs = withoutE1
+    state.fp = { count: 1, maxVersion: 2 }
+    await store.removePersisted()
+    expect(state.blob).toBeNull()
+
+    // The debounced flush "fires": `lastBuild` is still `buildFromLiveCache`, but
+    // removePersisted() just cleared `this.index`, so this MUST rebuild (not skip
+    // it) — and rebuilding calls `buildFromLiveCache()`, which now reads the
+    // POST-eviction cache.
+    await store.flush()
+
+    // The persisted blob must reflect the post-eviction state — never a stale
+    // pre-purge snapshot paired with a coincidentally-live-matching fingerprint.
+    expect(state.blob?.json).not.toContain('e1')
+    expect(state.blob?.fingerprint).toEqual({ count: 1, maxVersion: 2 })
+  })
 })

--- a/packages/hub/__tests__/search-persisted-index-store.test.ts
+++ b/packages/hub/__tests__/search-persisted-index-store.test.ts
@@ -66,3 +66,53 @@ describe('PersistedIndexStore (#308 L1.5)', () => {
     expect(state.removes).toBe(1); expect(store.built).toBe(false)
   })
 })
+
+describe('PersistedIndexStore epoch-guarded flush/purge race (#725)', () => {
+  it('removePersisted mid-flight self-undoes an in-flight save once it settles', async () => {
+    const state: { blob: { json: string; fingerprint: Fingerprint } | null; removes: number } = { blob: null, removes: 0 }
+    let gate: Promise<void> | null = null
+    let reached: (() => void) | null = null
+    const store = new PersistedIndexStore({
+      load: async () => state.blob,
+      save: async (json, f) => {
+        if (gate) { reached?.(); await gate }
+        state.blob = { json, fingerprint: f }
+      },
+      remove: async () => { state.removes++; state.blob = null },
+      currentFingerprint: () => ({ count: 1, maxVersion: 1 }),
+      debounceMs: 10,
+    })
+
+    // Warm build + save, uninterrupted (gate not yet armed).
+    await store.ensureBuilt(() => docs)
+    expect(state.blob).not.toBeNull()
+
+    // Arm the gate for the NEXT save and start a flush — it blocks INSIDE
+    // save(), after the epoch has been captured, before the blob is written.
+    let release!: () => void
+    gate = new Promise<void>((r) => { release = r })
+    const reachedPromise = new Promise<void>((r) => { reached = r })
+    const flushPromise = store.flush()
+    await reachedPromise // the flush is now genuinely in flight
+
+    // A purge lands while that save is still in flight.
+    const removePromise = store.removePersisted()
+
+    release()
+    await Promise.all([flushPromise, removePromise])
+
+    // The in-flight save's resurrection must not survive the purge.
+    expect(state.blob).toBeNull()
+    expect(store.built).toBe(false)
+  })
+
+  it('a flush with no interleaved purge still persists normally', async () => {
+    const { store, state } = harness()
+    await store.ensureBuilt(() => docs)
+    const savesBefore = state.saves
+    store.markDirty()
+    await store.flush()
+    expect(state.saves).toBe(savesBefore + 1)
+    expect(state.blob).not.toBeNull()
+  })
+})

--- a/packages/hub/__tests__/tier-write-ring.test.ts
+++ b/packages/hub/__tests__/tier-write-ring.test.ts
@@ -8,7 +8,7 @@
  * into collection.ts's choke points and appends the integration tests.
  */
 import { describe, it, expect } from 'vitest'
-import { createNoydb, TierWriteRefusedError } from '../src/index.js'
+import { createNoydb, TierWriteRefusedError, withDerivation } from '../src/index.js'
 import { withTiers } from '../src/with-audit/tiers/index.js'
 import { withHistory } from '../src/with-commit/history/index.js'
 import { withCrdt } from '../src/with-commit/crdt/index.js'
@@ -169,5 +169,132 @@ describe('#715/#716 write ring: tier-0 put/delete over an elevated record are re
     // signal — the elevated record's prior versions would then re-decrypt
     // through #712's live-peek gate.
     expect(await docs.history('d1')).toEqual([])
+  })
+})
+
+describe('#718: internal deletes skip elevated records (the write ring covers machinery paths)', () => {
+  interface Worker extends Record<string, unknown> {
+    id: string
+    employmentPeriods: ReadonlyArray<{ from: string; to: string }>
+  }
+  interface ActivePeriod extends Record<string, unknown> {
+    id: string
+    workerId: string
+    period: string
+  }
+
+  it('REPRO (#718): an array-shape derivation output row, elevated, survives a source-driven fanout shrink — a sibling non-elevated row is still cleaned up', async () => {
+    // #718's exact scenario: a tiered derivation/MV OUTPUT collection with an
+    // elevated row, cleanup pass (here: fanout shrink on source update) targets
+    // it. Pre-fix: `_doDelete(id, true)` was ungated for `internal` — since this
+    // store has no `onDirty`, it fell through to `adapter.delete`, silently
+    // ERASING the elevated derived row outright (worse than #716's bare marker).
+    const rawStore = memoryStore()
+    const strategy = withDerivation<Worker, { activeInPeriod: ActivePeriod[] }>({
+      source: 'workers',
+      deterministic: true,
+      outputs: { activeInPeriod: { shape: 'array', collection: 'workerActiveInPeriod', key: (o) => `${o['workerId'] as string}|${o['period'] as string}`, maxFanout: 12 } },
+      derive: (worker) => ({
+        activeInPeriod: worker.employmentPeriods.map(p => ({ id: `${worker.id}|${p.from}`, workerId: worker.id, period: p.from })),
+      }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({ store: rawStore, user: 'alice', secret: 'pw-718-repro', derivationStrategies: [strategy], tiersStrategy: withTiers() })
+    const vault = await db.openVault('acme')
+    const workers = vault.collection<Worker>('workers')
+    const activePeriods = vault.collection<ActivePeriod>('workerActiveInPeriod', { tiers: [0, 1], perRecordKeys: true })
+
+    await workers.put('w1', { id: 'w1', employmentPeriods: [{ from: '2026-03', to: '2026-03' }, { from: '2026-04', to: '2026-04' }] })
+    expect(await rawStore.get('acme', 'workerActiveInPeriod', 'w1|2026-03')).not.toBeNull()
+    expect(await rawStore.get('acme', 'workerActiveInPeriod', 'w1|2026-04')).not.toBeNull()
+
+    await activePeriods.elevate('w1|2026-03', 1)
+
+    // Shrink: drop both periods — the fanout diff calls _internalDelete on
+    // BOTH derived ids. The elevated one must survive untouched; the plain
+    // one must still be erased (internal cleanup keeps working normally).
+    await workers.put('w1', { id: 'w1', employmentPeriods: [] })
+
+    const elevated = await rawStore.get('acme', 'workerActiveInPeriod', 'w1|2026-03')
+    expect(elevated).not.toBeNull()
+    expect(elevated!._tier).toBe(1) // untouched: no marker, no erasure, tier signal intact
+    expect(await rawStore.get('acme', 'workerActiveInPeriod', 'w1|2026-04')).toBeNull() // sibling cleanup unaffected
+  })
+
+  it('at the _doDelete level: an internal delete over an elevated id is a no-op (no marker, tier intact); a non-elevated id still deletes', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw-718-unit', user: 'owner', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1], perRecordKeys: true })
+    await docs.put('d1', { id: 'd1', title: 'secret', body: 'x' })
+    await docs.put('d2', { id: 'd2', title: 'plain', body: 'y' })
+    await docs.elevate('d1', 1)
+
+    // `_internalDelete`'s own prior-read sees a live envelope before `_doDelete`'s
+    // skip fires, so it still reports `true` — a residual accounting gap (the
+    // record is genuinely untouched, verified below; not a confidentiality
+    // issue, but the caller can't tell "skipped" from "erased" from this alone).
+    expect(await docs._internalDelete('d1')).toBe(true)
+    expect((await store.get('v1', 'docs', 'd1'))!._tier).toBe(1)
+
+    expect(await docs._internalDelete('d2')).toBe(true) // ordinary internal cleanup unaffected
+    expect(await store.get('v1', 'docs', 'd2')).toBeNull()
+  })
+})
+
+describe('#708 sharp edge: coordinated cutover refuses an elevated record', () => {
+  it('cutover on a collection with an elevated record throws BEFORE any rewrite — all-or-nothing', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw-708-cutover', user: 'owner', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1], perRecordKeys: true })
+    await docs.put('d1', { id: 'd1', title: 'a', body: 'x' })
+    await docs.put('d2', { id: 'd2', title: 'b', body: 'y' })
+    await docs.elevate('d1', 1)
+    const v1Before = (await store.get('v1', 'docs', 'd1'))!._v
+    const v2Before = (await store.get('v1', 'docs', 'd2'))!._v
+
+    const err = await docs._applyCutoverTransform(d => ({ ...d, title: 'clobbered' })).catch(e => e)
+    expect(err).toBeInstanceOf(TierWriteRefusedError)
+    expect((err as InstanceType<typeof TierWriteRefusedError>).collection).toBe('docs')
+    expect((err as InstanceType<typeof TierWriteRefusedError>).tier).toBe(1)
+
+    // NO record was rewritten — not even the non-elevated one that sorts first.
+    expect((await store.get('v1', 'docs', 'd1'))!._v).toBe(v1Before)
+    expect((await store.get('v1', 'docs', 'd2'))!._v).toBe(v2Before)
+  })
+
+  it('the refusal names the collection, the offending id, and "demote before a coordinated cutover"', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw-708-msg', user: 'owner', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1], perRecordKeys: true })
+    await docs.put('d1', { id: 'd1', title: 'a', body: 'x' })
+    await docs.elevate('d1', 1)
+    await expect(docs._applyCutoverTransform(d => d)).rejects.toThrow(/docs.*d1.*demote.*coordinated cutover/is)
+  })
+
+  it('after demote, the cutover proceeds normally', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw-708-demote', user: 'owner', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1], perRecordKeys: true })
+    await docs.put('d1', { id: 'd1', title: 'a', body: 'x' })
+    await docs.elevate('d1', 1)
+    await docs.demote('d1', 0)
+
+    const count = await docs._applyCutoverTransform(d => ({ ...d, title: 'migrated' }))
+    expect(count).toBe(1)
+    expect((await docs.get('d1'))?.title).toBe('migrated')
+  })
+
+  it('a collection that never declares tiers pays no extra cost on cutover', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw-708-nt', user: 'owner' })
+    const vault = await db.openVault('v1')
+    const plain = vault.collection<Doc>('plain', {})
+    await plain.put('p1', { id: 'p1', title: 'a', body: 'x' })
+    const count = await plain._applyCutoverTransform(d => ({ ...d, title: 'b' }))
+    expect(count).toBe(1)
   })
 })

--- a/packages/hub/__tests__/tiers-indexing.test.ts
+++ b/packages/hub/__tests__/tiers-indexing.test.ts
@@ -13,7 +13,7 @@ import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.
 
 interface Emp {
   id: string
-  salary: number
+  salary?: number
 }
 
 // Copied verbatim from hierarchical-tiers.test.ts.
@@ -186,5 +186,34 @@ describe('#709 tier ops maintain indexes', () => {
     // re-verified (builder.ts:1160-1166 drops the clause) → a silent false positive.
     expect(docs.query().where('salary', '==', 100).toArray().length).toBe(0)
     expect(docs.query().where('salary', '==', 555).toArray().map(r => r.id)).toEqual(['p1'])
+  })
+})
+
+describe('#720 lazy putAtTier resolves the prior via a tier-gated decode', () => {
+  it('LAZY: putAtTier(0) DROPPING an indexed field clears the OLD value\'s sidecar', async () => {
+    const { store, docs } = await openLazyIndexed()
+    await docs.put('p1', { id: 'p1', salary: 100 })
+    expect(await store.get('v1', 'docs', '_idx/salary/p1')).not.toBeNull()
+    // Pre-#720: syncTierIndexes resolved `prior` from `ctx.cache` — always
+    // null in lazy mode (lazy writes populate the LRU, not the eager cache)
+    // — so the clear branch in maintainPersistedIndexesOnPut never fired and
+    // the stale salary=100 sidecar survived, tier-0-readable.
+    await docs.putAtTier('p1', { id: 'p1' }, 0)
+    expect(await store.get('v1', 'docs', '_idx/salary/p1')).toBeNull()
+  })
+
+  it('LAZY: demote(0) off an elevated record resolves prior via the tier-gated fallback cleanly — no throw', async () => {
+    const { store, docs } = await openLazyIndexed()
+    await docs.put('e1', { id: 'e1', salary: 200000 })
+    await docs.elevate('e1', 1)
+    // elevate() already purged the sidecar; nothing left to clean up. The
+    // demote-to-0 fallback decode's `priorEnvelope` is the PRE-demote
+    // (still-elevated, tier > 0) envelope — the tier gate must skip it
+    // without attempting an ungated decode, regardless of cekCache warmth.
+    expect(await store.get('v1', 'docs', '_idx/salary/e1')).toBeNull()
+    await expect(docs.demote('e1', 0)).resolves.not.toThrow()
+    // Restored to tier 0 with its current value — freshly (re)indexed, not
+    // resurrecting a stale pre-elevation sidecar.
+    expect(await store.get('v1', 'docs', '_idx/salary/e1')).not.toBeNull()
   })
 })

--- a/packages/hub/__tests__/time-machine.test.ts
+++ b/packages/hub/__tests__/time-machine.test.ts
@@ -20,6 +20,7 @@ import { describe, expect, it, beforeEach } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
 import { ConflictError, ReadOnlyAtInstantError, createNoydb } from '../src/index.js'
 import { withHistory } from '../src/with-commit/history/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
 import type { Noydb } from '../src/index.js'
 
 function memoryStore(): NoydbStore {
@@ -235,5 +236,105 @@ describe('vault.at(ts) — encrypted mode round-trip', () => {
 
     const past = await vault.at(t1).collection<Invoice>('invoices').get('inv-1')
     expect(past).toEqual({ amount: 100, status: 'draft' })
+  })
+})
+
+/**
+ * #730 — time-machine reads must honor the same tier-0 invisibility law as
+ * `history()`/`getVersion()` (the #712 read-gate): an elevated live record's
+ * point-in-time view is invisible through `vault.at(ts)`, not an opaque
+ * AES-GCM throw. Also locks the pre-existing perRecordKeys bug: `get()` must
+ * route through the `_cek`-aware envelope-open helper so a perRecordKeys
+ * snapshot decrypts correctly even with no tiers involved.
+ */
+describe('vault.at(ts) — #730 tier gate', () => {
+  interface Doc { name: string }
+
+  it('elevated record: get() returns null (not an opaque decrypt throw), list() omits the id', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'pw-730-elevated',
+      tiersStrategy: withTiers(), historyStrategy: withHistory(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1], perRecordKeys: true })
+
+    // v1 is archived to `_history` once v2 overwrites it, so a query at `ts`
+    // (between v1 and v2) resolves to a REAL `_history` envelope — one whose
+    // `_cek` gets rewrapped to the tier-1 DEK by elevate()'s syncHistory.
+    // Pre-#730 this is exactly the case that decrypted-under-the-wrong-key
+    // and threw an opaque AES-GCM error instead of returning null.
+    await docs.put('d1', { name: 'v1' })
+    await tick()
+    const ts = new Date().toISOString()
+    await tick()
+    await docs.put('d1', { name: 'v2' })
+    await docs.elevate('d1', 1)
+
+    expect(await vault.at(ts).collection<Doc>('docs').get('d1')).toBeNull()
+    expect(await vault.at(ts).collection<Doc>('docs').list()).not.toContain('d1')
+  })
+
+  it('demoted back to tier 0: time-machine reads of an archived version work again', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'pw-730-demote',
+      tiersStrategy: withTiers(), historyStrategy: withHistory(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1], perRecordKeys: true })
+
+    // v1 is archived to `_history` once v2 overwrites it. elevate() rewraps
+    // that `_history` snapshot's `_cek` to the tier-1 DEK (invisible while
+    // elevated); demote() rewraps it back to tier-0 — the archived version
+    // must decrypt again afterward.
+    await docs.put('d2', { name: 'a' })
+    await tick()
+    const ts = new Date().toISOString()
+    await tick()
+    await docs.put('d2', { name: 'b' })
+    await docs.elevate('d2', 1)
+    await docs.demote('d2', 0)
+
+    expect(await vault.at(ts).collection<Doc>('docs').get('d2')).toEqual({ name: 'a' })
+    expect(await vault.at(ts).collection<Doc>('docs').list()).toContain('d2')
+  })
+
+  it('perRecordKeys collection, no tiers: at(ts).get() decrypts the historical body via the record CEK', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'pw-730-cek', historyStrategy: withHistory(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { perRecordKeys: true })
+
+    await docs.put('d3', { name: 'v1' })
+    await tick()
+    const ts = new Date().toISOString()
+    await tick()
+    await docs.put('d3', { name: 'v2' })
+
+    // Pre-#730: get() ignored `_cek` and decrypted directly under the
+    // collection DEK, which throws on a per-record-CEK-encrypted body.
+    expect(await vault.at(ts).collection<Doc>('docs').get('d3')).toEqual({ name: 'v1' })
+  })
+
+  it('a tier-0 (never-elevated) record is unaffected', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'pw-730-t0',
+      tiersStrategy: withTiers(), historyStrategy: withHistory(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1], perRecordKeys: true })
+
+    await docs.put('d4', { name: 'v1' })
+    await tick()
+    const ts = new Date().toISOString()
+    await tick()
+    await docs.put('d4', { name: 'v2' })
+
+    expect(await vault.at(ts).collection<Doc>('docs').get('d4')).toEqual({ name: 'v1' })
+    expect(await vault.at(ts).collection<Doc>('docs').list()).toContain('d4')
   })
 })

--- a/packages/hub/bundle-manifest.json
+++ b/packages/hub/bundle-manifest.json
@@ -1,41 +1,41 @@
 {
   "scenarios": {
     "floor": {
-      "minifiedBytes": 1494,
-      "gzippedBytes": 466
+      "minifiedBytes": 1522,
+      "gzippedBytes": 477
     },
     "lazy": {
-      "minifiedBytes": 1582,
-      "gzippedBytes": 540
+      "minifiedBytes": 1610,
+      "gzippedBytes": 551
     },
     "team": {
-      "minifiedBytes": 1716,
-      "gzippedBytes": 595
+      "minifiedBytes": 1744,
+      "gzippedBytes": 603
     },
     "broker": {
-      "minifiedBytes": 2606,
-      "gzippedBytes": 1094
+      "minifiedBytes": 2634,
+      "gzippedBytes": 1104
     },
     "history": {
-      "minifiedBytes": 6095,
-      "gzippedBytes": 2320
+      "minifiedBytes": 6571,
+      "gzippedBytes": 2454
     },
     "classified": {
-      "minifiedBytes": 2844,
-      "gzippedBytes": 1025
+      "minifiedBytes": 2872,
+      "gzippedBytes": 1036
     },
     "blobs": {
-      "minifiedBytes": 1584,
-      "gzippedBytes": 552
+      "minifiedBytes": 1612,
+      "gzippedBytes": 554
     },
     "analytics": {
-      "minifiedBytes": 2367,
-      "gzippedBytes": 899
+      "minifiedBytes": 2420,
+      "gzippedBytes": 915
     },
     "all-on": {
-      "minifiedBytes": 30626,
-      "gzippedBytes": 9431
+      "minifiedBytes": 31324,
+      "gzippedBytes": 9644
     }
   },
-  "updatedAt": "2026-07-13T18:26:17.668Z"
+  "updatedAt": "2026-07-17T17:35:27.841Z"
 }

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -26,7 +26,7 @@ import {
   type SealedShredSlot,
 } from './enclave/index.js'
 import { countLiveEnvelopes } from './lazy-count.js'
-import { liveRecordIsElevated, assertTierWritable } from './tier-visibility.js'
+import { liveRecordIsElevated, assertTierWritable, assertCutoverTierSafe } from './tier-visibility.js'
 import {
   classifySealedShred as classifySealedShredImpl, syncDerivedOutputs,
   type TiersContext,
@@ -2557,15 +2557,13 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   }
 
   /**
-   * @internal — bulk-rewrite every record through a cutover transform.
-   * Raw adapter path (bypasses the write gate + guards — the transform is
-   * trusted and runs only during the `migrating` phase). Bumps each
-   * record's `_v` and appends a ledger `op:'migration'` entry.
+   * @internal — bulk-rewrite every record through a cutover transform. Raw adapter path (bypasses the write gate + guards — the transform is trusted and runs only during the `migrating` phase). Bumps each record's `_v` and appends a ledger `op:'migration'` entry. #708: refuses BEFORE any rewrite if a live record is elevated (assertCutoverTierSafe) — demote it first.
    */
   async _applyCutoverTransform(
     transform: (doc: Record<string, unknown>) => Record<string, unknown>,
   ): Promise<number> {
     const ids = await this.adapter.list(this.vault, this.name)
+    await assertCutoverTierSafe(this.adapter, this.vault, this.name, this.tiers !== null)
     let count = 0
     for (const id of ids) {
       const env = await this.adapter.get(this.vault, this.name, id)
@@ -2666,6 +2664,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     }
     // #716: public deletes only — see assertTierWritable's doc + Step 5 investigation for `internal`.
     await assertTierWritable(this.adapter, this.vault, this.name, id, !internal && this.tiers !== null)
+    if (internal && this.tiers !== null && await liveRecordIsElevated(this.adapter, this.vault, this.name, id)) return // #718: internal cleanup treats an elevated record as nonexistent, same as tier-0 reads — skip, no marker; its derived state is the tier ops' job
 
     // Gate bus (Track A) — fires for ALL deletes (carrying `internal`), so a
     // gate handler can collect amendment changes on system-internal deletes

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -4507,7 +4507,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       codec: this.codec,
       cekCache: this.cekCache,
       syncCache: (id: string, e: { record: T; version: number } | null) => { if (e) this.cache.set(id, e); else this.cache.delete(id); this.lru?.remove(id) },
-      syncIndexes: (id: string, rec: T | null, version?: number) => syncTierIndexesImpl(this.indexingContext(), id, rec, version),
+      syncIndexes: (id: string, rec: T | null, version: number, priorEnvelope?: EncryptedEnvelope) => syncTierIndexesImpl(this.indexingContext(), id, rec, version, priorEnvelope),
       syncSearch: (id: string, rec: T | null, version?: number) => syncTierSearchImpl(this.searchContext(), id, rec, version),
       syncHistory: async (id: string, fromDek: EnclaveKey, toDek: EnclaveKey) => this.historyStrategy.rewrapHistory(this.adapter, this.vault, this.name, id, fromDek, toDek, await this.getDEK(this.name)),
       syncBlobs: (id: string, fromTier: number, toTier: number) => this.blobStrategy !== NO_BLOBS ? this.blob(id).rehomeForTier(fromTier, toTier, this.blobTierPolicy) : Promise.resolve(), // #724 I1: gate on blob storage enabled (not on declared blobFields) so undeclared-field blobs still rehome; rehomeForTier self-no-ops on an empty slot map

--- a/packages/hub/src/kernel/errors.ts
+++ b/packages/hub/src/kernel/errors.ts
@@ -732,15 +732,19 @@ export class TierNotGrantedError extends NoydbError {
  * in `tier-visibility.ts`), which throws nothing — elevated records
  * simply read as absent there. This is a write-path refusal, not a
  * read-path ghost.
+ *
+ * #708: also raised by the coordinated-cutover pre-check
+ * (`assertCutoverTierSafe`) — a bulk-rewrite is a third tier-0 write path,
+ * so it gets the same refusal with a `detail` override naming the record.
  */
 export class TierWriteRefusedError extends NoydbError {
   readonly tier: number
   readonly collection: string
 
-  constructor(collection: string, tier: number) {
+  constructor(collection: string, tier: number, detail?: string) {
     super(
       'TIER_WRITE_REFUSED',
-      `put()/delete() cannot write to record in collection "${collection}" — ` +
+      detail ?? `put()/delete() cannot write to record in collection "${collection}" — ` +
         `it is elevated to tier ${tier}. Use putAtTier()/elevate()/demote() instead.`,
     )
     this.name = 'TierWriteRefusedError'

--- a/packages/hub/src/kernel/tier-visibility.ts
+++ b/packages/hub/src/kernel/tier-visibility.ts
@@ -57,3 +57,23 @@ export async function assertTierWritable(
   const tier = await peekLiveTier(adapter, vault, name, id)
   if (tier > 0) throw new TierWriteRefusedError(name, tier)
 }
+
+/**
+ * #708: ALL-OR-NOTHING pre-check for a coordinated-cutover bulk-rewrite —
+ * scans every id's live tier BEFORE any record is transformed and refuses
+ * on the first elevated one found. `_applyCutoverTransform` re-encrypts at
+ * tier 0 with no gate of its own; without this, it would silently demote
+ * an elevated record. Same cost gate as `assertTierWritable` (no-op, no
+ * adapter call, when `tiersEnabled` is false).
+ */
+export async function assertCutoverTierSafe(
+  adapter: NoydbStore, vault: string, name: string, tiersEnabled: boolean,
+): Promise<void> {
+  if (!tiersEnabled) return
+  for (const id of await adapter.list(vault, name)) {
+    const tier = await peekLiveTier(adapter, vault, name, id)
+    if (tier > 0) {
+      throw new TierWriteRefusedError(name, tier, `Coordinated cutover on collection "${name}" refused — record "${id}" is elevated to tier ${tier}. Demote it before a coordinated cutover.`)
+    }
+  }
+}

--- a/packages/hub/src/kernel/tier-visibility.ts
+++ b/packages/hub/src/kernel/tier-visibility.ts
@@ -65,6 +65,17 @@ export async function assertTierWritable(
  * tier 0 with no gate of its own; without this, it would silently demote
  * an elevated record. Same cost gate as `assertTierWritable` (no-op, no
  * adapter call, when `tiersEnabled` is false).
+ *
+ * This pre-check guards against an ordinary `put()`/`delete()` racing the
+ * cutover, because those go through the schema fence (`SchemaFenceController`
+ * blocks concurrent writes during a coordinated cutover). It does NOT guard
+ * against `elevate()`/`demote()`/`putAtTier()` — those tier-move paths bypass
+ * the fence, so a tier move landing between this scan and the rewrite it
+ * gates is not excluded. Cutover callers are expected to hold the vault
+ * quiescent for tier moves on this collection for the duration of the call,
+ * the same tier-quiescence assumption the documented CAS-less caller
+ * (`with-shape/satellites/migrate-cek.ts`'s "No-quiesce precondition") makes
+ * explicit for concurrent writes generally.
  */
 export async function assertCutoverTierSafe(
   adapter: NoydbStore, vault: string, name: string, tiersEnabled: boolean,

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -81,10 +81,19 @@ export interface TiersContext<T> {
    * entries from that record. Call this BEFORE {@link syncCache} — the
    * implementation reads the pre-write cached value as "previous" to clean
    * up stale index buckets, so it must run while that entry is still live.
-   * `version` stamps a rebuilt side-car's own envelope version (ignored on
-   * purge).
+   * `version` stamps a rebuilt side-car's own envelope version — every
+   * caller has one in scope (the envelope it just wrote), including the
+   * purge (`null`) branches, which pass it along even though it's ignored
+   * there (#720: keeps the parameter honestly required, no dead default).
+   * `priorEnvelope` (#720) — the RAW envelope read BEFORE this call's own
+   * overwrite (already in scope as `existing`/`envelope` at every record-
+   * branch call site), so a lazy same-tier value change (a `putAtTier(0)`
+   * dropping an indexed field, a `demote(0)` off an elevated record) can
+   * still be tier-gate-decoded as "previous" once the live envelope itself
+   * has already moved past it. The `null`-record branches never pass one —
+   * see the implementation's doc comment for why they don't need to.
    */
-  syncIndexes(id: string, record: T | null, version?: number): Promise<void>
+  syncIndexes(id: string, record: T | null, version: number, priorEnvelope?: EncryptedEnvelope): Promise<void>
   /** Sync the collection's SEARCH artifacts after a tier move (#721). Both the
    *  lexical `_ftindex` blob and the `_vec/<id>` embedding are encrypted under
    *  the tier-0 DEK and hold the record's derived plaintext (full field text /
@@ -325,7 +334,7 @@ export async function putAtTier<T>(
   // reindex). syncIndexes runs first — it needs the pre-write cache entry
   // as "previous", which syncCache is about to overwrite/evict.
   if (tier > 0) {
-    await ctx.syncIndexes(id, null)
+    await ctx.syncIndexes(id, null, version)
     ctx.syncCache(id, null)
     // #729: the record lands above tier 0 — purge its tier-0-era plaintext
     // ledger deltas (irreversible; a tier-0 putAtTier(0) has nothing to purge).
@@ -349,7 +358,7 @@ export async function putAtTier<T>(
     )
   } else {
     const rec = await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
-    await ctx.syncIndexes(id, rec, envelope._v)
+    await ctx.syncIndexes(id, rec, envelope._v, existing ?? undefined)
     ctx.syncCache(id, rec !== null ? { record: rec, version: envelope._v } : null)
     // #722 Task 2: the record is written at tier 0 — restore its
     // contribution to every derived output (reuse the decode above, no
@@ -544,7 +553,7 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   // tier-0 record (same ordering as demote). #709: syncIndexes runs first —
   // it needs the pre-elevation cache entry as "previous" to clean the
   // eager index bucket; the persisted side-car purge is content-free.
-  await ctx.syncIndexes(id, null)
+  await ctx.syncIndexes(id, null, next._v)
   ctx.syncCache(id, null)
   // #721: same purge law as syncIndexes above — the record left tier 0, so
   // its _vec sidecar is purged and _ftindex is invalidated.
@@ -651,7 +660,7 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
   // it needs the pre-demote cache entry as "previous".
   if (toTier === 0) {
     const rec = await ctx.codec.decryptRecord(next, { id, sealedAsHandles: true })
-    await ctx.syncIndexes(id, rec, next._v)
+    await ctx.syncIndexes(id, rec, next._v, envelope)
     ctx.syncCache(id, rec !== null ? { record: rec, version: next._v } : null)
     // #721: reuse the decode above — no double-decrypt. The record is tier-0
     // again, so re-embed its _vec and invalidate _ftindex to include it.
@@ -660,7 +669,7 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
     // every derived output (reuse the decode above, no double-decrypt).
     await ctx.syncDerived(id, rec, false, next._v)
   } else {
-    await ctx.syncIndexes(id, null)
+    await ctx.syncIndexes(id, null, next._v)
     ctx.syncCache(id, null)
     // #721: still above tier 0 — purge _vec, invalidate _ftindex.
     await ctx.syncSearch(id, null)

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -24,10 +24,11 @@ export { withTiers } from './active.js'
 export { NO_TIERS, type TiersStrategy } from './strategy.js'
 export { TiersNotEnabledError } from '../../kernel/errors.js'
 import { encrypt, decrypt, unwrapCek, rewrapBodyToDek, isDeleteMarker, isTombstoneShape, type RecordCodec, type EnclaveKey, type SealedShredSlot } from '../../kernel/enclave/index.js'
-import { TierDemoteDeniedError } from '../../kernel/errors.js'
+import { TierDemoteDeniedError, UnsupportedTierCompositionError } from '../../kernel/errors.js'
 import { dekKey, assertTierAccess } from '../../with-party/team/tiers.js'
 import type { UnlockedKeyring } from '../../with-party/team/keyring.js'
 import type { Lru } from '../../kernel/cache/index.js'
+import type { BlobFieldsConfig } from '../../with-shape/blobs/blob-compaction.js'
 import {
   NOYDB_FORMAT_VERSION,
   type NoydbStore,
@@ -218,6 +219,77 @@ export function assertDeclaredTier<T>(ctx: TiersContext<T>, tier: number): void 
   if (!ctx.tiers || !ctx.tiers.has(tier)) {
     throw new Error(
       `Collection "${ctx.name}": tier ${tier} is not declared in { tiers: [...] }`,
+    )
+  }
+}
+
+/**
+ * Tier-composition guard (#724 / Arc 7 of the tier-invisibility campaign).
+ *
+ * Refuses `tiers` declared together with a derived-artifact feature whose
+ * crypto has not yet been made tier-aware — i.e. a feature `elevate()` /
+ * `demote()` does not re-key when a record moves tiers, so an elevated
+ * record's data for that feature would stay readable at tier 0.
+ *
+ * **Status:** the original call site (`Collection` constructor, beside
+ * `buildUniqueConstraintSet`) was removed by Arc 10 Task 1 (#724) — the
+ * `tiers + blobFields` refusal below was superseded by a runtime read gate
+ * on `collection.blob(id)` (`with-shape/blobs/blob-set.ts`), so this
+ * function currently has no caller. Relocated here from
+ * `with-lookup/indexing/unique-constraints.ts` (#733) so the tier-domain
+ * guard lives in the tier domain, rather than an indexing file it only
+ * borrowed for a grandfathered import specifier.
+ *
+ * ## #724 verified: `tiers + blobFields` leaks
+ *
+ * `collection.blob(id)` (`Collection.blob()`) never checks the live
+ * record's tier before returning a `BlobSet` handle, and `BlobSet`'s crypto
+ * is entirely orthogonal to the tier ladder:
+ *  - the slot map (`_blob_slots_{collection}/{id}`) is encrypted under the
+ *    collection's TIER-0 DEK (`getDEK(name)` ≡ `dekKey(name, 0)` — see
+ *    `dekKey` in `with-party/team/tiers.ts`), never a tier-N DEK;
+ *  - chunk content (`_blob_index` / `_blob_chunks`) is encrypted under the
+ *    vault-shared `_blob` DEK (`BLOB_COLLECTION`), which has no tier
+ *    dimension at all.
+ * `elevate()`/`demote()` (this file) rewrap only the live record body,
+ * `_history` snapshots (#712), and index side-cars — blob slots and chunks
+ * are untouched. A caller whose keyring never held the record's elevated
+ * tier DEK can still open `collection.blob(id).get(slot)` and read full
+ * plaintext, even though `collection.get(id)` correctly reports the same
+ * record as invisible. See `__tests__/tier-composition-guard.test.ts` for
+ * the reproduction.
+ *
+ * ## Safe today — no check needed here
+ *
+ * Field indexes, search (`textIndexes`/`embeddings`), `withHistory`
+ * (snapshot keys are rewrapped by `elevate()`/`demote()`, #712), and the
+ * decoded-record cache (evicted on tier moves) are already tier-safe. They
+ * are not enumerated below; only known-unsafe features are refused, so any
+ * combination not named here passes silently by default.
+ *
+ * ## Deliberately NOT handled here
+ *
+ * - `ledger` — `withHistory` threads a ledger writer onto every tiered
+ *   collection by default in shipped usage; refusing `tiers + ledger` would
+ *   break that default. A ledger-specific tier-rekey handler (rewrap ledger
+ *   entries, or scope ledger visibility to tier) is a separate arc.
+ * - materialized-view (MV) output — an MV's fanout spec lives on the
+ *   SOURCE collection, not on the MV collection's own config, so it is not
+ *   visible at `vault.collection()` registration time and this guard cannot
+ *   detect it structurally.
+ */
+export function assertTierComposition(
+  collectionName: string,
+  cfg: { readonly tiers: boolean; readonly blobFields: BlobFieldsConfig | undefined },
+): void {
+  if (!cfg.tiers) return
+  if (cfg.blobFields !== undefined && Object.keys(cfg.blobFields).length > 0) {
+    throw new UnsupportedTierCompositionError(
+      'blobs',
+      `Collection "${collectionName}": blobFields are not supported together with tiers (#724) — ` +
+        `blob chunk content is encrypted under a vault-shared DEK that elevate()/demote() do not ` +
+        `re-key, so an elevated record's blob attachments would remain readable at tier 0. Use a ` +
+        `non-tiered collection for blob-bearing records until a blob tier-rekey handler ships.`,
     )
   }
 }

--- a/packages/hub/src/with-commit/history/time-machine.ts
+++ b/packages/hub/src/with-commit/history/time-machine.ts
@@ -49,8 +49,9 @@
 import type { EncryptedEnvelope, NoydbStore } from '../../kernel/types.js'
 import type { LedgerStore } from './ledger/store.js'
 import { getHistory } from './history.js'
-import { decrypt, type EnclaveKey } from '../../kernel/enclave/index.js'
+import { openEnvelopeJson, type EnclaveKey } from '../../kernel/enclave/index.js'
 import { ReadOnlyAtInstantError } from '../../kernel/errors.js'
+import { liveRecordIsElevated } from '../../kernel/tier-visibility.js'
 
 /**
  * Narrow view of a {@link Vault}'s internals that
@@ -128,12 +129,22 @@ export class CollectionInstant<T = unknown> {
    * Return the record as it existed at the target timestamp, or
    * `null` if the record had not been created yet or had already been
    * deleted by then.
+   *
+   * Gated on the LIVE record's current tier — #730, mirroring the #712
+   * read-gate `history()`/`getVersion()` already apply: an elevated record
+   * is invisible through the whole time-machine surface, not just a
+   * decrypt failure. See {@link resolveVisibleEnvelope}.
+   *
+   * Decrypts through {@link openEnvelopeJson}, the `_cek`-aware envelope
+   * body opener — a snapshot from a `perRecordKeys` collection is encrypted
+   * under its own per-record CEK (wrapped in `_cek`), not the collection
+   * DEK directly.
    */
   async get(id: string): Promise<T | null> {
-    const envelope = await this.resolveEnvelope(id)
+    const envelope = await this.resolveVisibleEnvelope(id)
     if (!envelope) return null
     const plaintext = this.engine.encrypted
-      ? await decrypt(envelope._iv, envelope._data, await this.engine.getDEK(this.name))
+      ? await openEnvelopeJson(envelope, await this.engine.getDEK(this.name))
       : envelope._data
     return JSON.parse(plaintext) as T
   }
@@ -153,7 +164,7 @@ export class CollectionInstant<T = unknown> {
     const candidateIds = new Set<string>([...historyIds, ...liveIds])
     const alive: string[] = []
     for (const id of candidateIds) {
-      const env = await this.resolveEnvelope(id)
+      const env = await this.resolveVisibleEnvelope(id)
       if (env) alive.push(id)
     }
     return alive.sort()
@@ -172,6 +183,25 @@ export class CollectionInstant<T = unknown> {
   }
 
   // ── internals ─────────────────────────────────────────────────────
+
+  /**
+   * {@link resolveEnvelope}, additionally gated on the record's LIVE
+   * (current, not historical) tier — #730. Mirrors the #712 read-gate
+   * `history()`/`getVersion()` apply: history snapshots keep their
+   * tier-0-wrapped CEKs and carry no `_tier` of their own, so an elevated
+   * record's prior versions would otherwise stay tier-0-decryptable here.
+   * `null` for a resolved envelope carrying its own `_tier > 0` (a
+   * tier-aware snapshot reached some other way) or whose LIVE record is
+   * currently elevated — both `get()` and `list()` route through this so
+   * the invisibility law holds on the whole time-machine read surface, not
+   * just a decrypt failure.
+   */
+  private async resolveVisibleEnvelope(id: string): Promise<EncryptedEnvelope | null> {
+    const envelope = await this.resolveEnvelope(id)
+    if (!envelope || (envelope._tier ?? 0) > 0) return null
+    if (await liveRecordIsElevated(this.engine.adapter, this.engine.name, this.name, id)) return null
+    return envelope
+  }
 
   /**
    * Return the envelope that represents the record's state at

--- a/packages/hub/src/with-lookup/indexing/collection-facade.ts
+++ b/packages/hub/src/with-lookup/indexing/collection-facade.ts
@@ -20,7 +20,7 @@
  *
  * Internal service — not exported as a `@noy-db/hub/*` subpath.
  */
-import type { NoydbStore } from '../../kernel/types.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../kernel/types.js'
 import type { RecordCodec } from '../../kernel/enclave/index.js'
 import type { NoydbEventEmitter } from '../../kernel/events.js'
 import { IndexWriteFailureError } from '../../kernel/errors.js'
@@ -479,21 +479,55 @@ export async function purgePersistedIndexes<T>(ctx: IndexingContext<T>, id: stri
  * cleaned up rather than left as a false-positive hit. `version` stamps
  * the rebuilt side-car's own envelope version.
  *
+ * `priorEnvelope` (#720) — the RAW envelope the caller read BEFORE its own
+ * overwrite landed (`putAtTier`'s `existing` / `demote`'s pre-move
+ * `envelope`), for the `ctx.cache`-miss lazy case: by this call's time the
+ * adapter already holds the NEW envelope, so a `ctx.adapter.get()` here
+ * would only ever re-observe the write just made — useless for recovering
+ * what a same-tier `putAtTier` may have dropped. Optional: the null-record
+ * branches (elevate / demote-to-intermediate / putAtTier(tier>0)) never
+ * need it — their only prior-dependent step, the eager `indexes.remove`
+ * below, already has what it needs from `ctx.cache` (eager mode is
+ * unaffected by the raw-envelope overwrite; lazy mode has no eager mirror).
+ *
  * No-ops fast when the collection has neither index kind declared.
  */
 export async function syncTierIndexes<T>(
   ctx: IndexingContext<T>,
   id: string,
   record: T | null,
-  version?: number,
+  version: number,
+  priorEnvelope?: EncryptedEnvelope,
 ): Promise<void> {
   if (!ctx.indexes && !ctx.persistedIndexes) return
-  const prior = ctx.cache.get(id)?.record ?? null
+  const prior: T | null = await resolveTierSyncPrior(ctx, id, priorEnvelope)
   if (record === null) {
     await purgePersistedIndexes(ctx, id)
     if (prior) ctx.indexes?.remove(id, prior)
   } else {
-    await maintainPersistedIndexesOnPut(ctx, id, record, prior, version ?? 1)
+    await maintainPersistedIndexesOnPut(ctx, id, record, prior, version)
     ctx.indexes?.upsert(id, record, prior)
   }
+}
+
+/**
+ * Resolve the pre-write record `syncTierIndexes` needs as "previous" for
+ * index maintenance. `ctx.cache` (eager mode, or a lazy record a prior tier
+ * op already synced into it via `syncCache`) is checked first — cheap, no
+ * I/O. Lazy mode falls back to a TIER-GATED decode of the caller-supplied
+ * `priorEnvelope` (read before the caller's own overwrite, see the doc
+ * comment above): gating on `(env._tier ?? 0) > 0` before decoding — the
+ * campaign's standard "elevated ≡ missing" skip, never an ungated decode —
+ * means a prior that was itself elevated (a `demote(0)` off an
+ * `elevate()`-purged record) resolves to null cleanly instead of risking the
+ * warm-cekCache-succeeds/cold-session-throws asymmetry #709 eliminated
+ * elsewhere. No `priorEnvelope` (the null-record branches never pass one) or
+ * eager mode both resolve to null here — by design, per the doc comment
+ * above.
+ */
+async function resolveTierSyncPrior<T>(ctx: IndexingContext<T>, id: string, priorEnvelope: EncryptedEnvelope | undefined): Promise<T | null> {
+  const cached = ctx.cache.get(id)?.record
+  if (cached !== undefined) return cached
+  if (!ctx.lazy || !priorEnvelope || (priorEnvelope._tier ?? 0) > 0) return null
+  return await ctx.codec.decryptRecord(priorEnvelope, { skipValidation: true, id })
 }

--- a/packages/hub/src/with-lookup/indexing/unique-constraints.ts
+++ b/packages/hub/src/with-lookup/indexing/unique-constraints.ts
@@ -17,9 +17,8 @@
 
 import { readPath } from '../../kernel/query/predicate.js'
 import { canonicalGroupKey } from '../aggregate/canonical-key.js'
-import { UniqueConstraintError, UnsupportedIndexOptionError, UnsupportedTierCompositionError } from '../../kernel/errors.js'
+import { UniqueConstraintError, UnsupportedIndexOptionError } from '../../kernel/errors.js'
 import type { IndexDef } from './eager-indexes.js'
-import type { BlobFieldsConfig } from '../../with-shape/blobs/blob-compaction.js'
 
 interface Constraint {
   readonly fields: readonly string[]
@@ -163,73 +162,4 @@ export function buildUniqueConstraintSet(
     )
   }
   return new UniqueConstraintSet(collectionName, uniqueDefs)
-}
-
-/**
- * Tier-composition guard (#724 / Arc 7 of the tier-invisibility campaign).
- *
- * Refuses `tiers` declared together with a derived-artifact feature whose
- * crypto has not yet been made tier-aware — i.e. a feature `elevate()` /
- * `demote()` does not re-key when a record moves tiers, so an elevated
- * record's data for that feature would stay readable at tier 0. The check
- * runs once, at `vault.collection()` registration (called from the
- * `Collection` constructor beside `buildUniqueConstraintSet`, and kept in
- * this file rather than a `with-audit/tiers/` sibling so the already-
- * grandfathered spine→service import specifier is reused instead of adding
- * a new one — see `PRE_EXISTING_SPINE_SERVICE_IMPORTS` in
- * `scripts/check-architecture.mjs`), so the leak becomes a loud
- * `UnsupportedTierCompositionError` instead of silent at-rest plaintext.
- *
- * ## #724 verified: `tiers + blobFields` leaks
- *
- * `collection.blob(id)` (`Collection.blob()`) never checks the live
- * record's tier before returning a `BlobSet` handle, and `BlobSet`'s crypto
- * is entirely orthogonal to the tier ladder:
- *  - the slot map (`_blob_slots_{collection}/{id}`) is encrypted under the
- *    collection's TIER-0 DEK (`getDEK(name)` ≡ `dekKey(name, 0)` — see
- *    `dekKey` in `with-party/team/tiers.ts`), never a tier-N DEK;
- *  - chunk content (`_blob_index` / `_blob_chunks`) is encrypted under the
- *    vault-shared `_blob` DEK (`BLOB_COLLECTION`), which has no tier
- *    dimension at all.
- * `elevate()`/`demote()` (`with-audit/tiers/index.ts`) rewrap only the live
- * record body, `_history` snapshots (#712), and index side-cars — blob slots
- * and chunks are untouched. A caller whose keyring never held the record's
- * elevated tier DEK can still open `collection.blob(id).get(slot)` and read
- * full plaintext, even though `collection.get(id)` correctly reports the
- * same record as invisible. See `__tests__/tier-composition-guard.test.ts`
- * for the reproduction.
- *
- * ## Safe today — no check needed here
- *
- * Field indexes, search (`textIndexes`/`embeddings`), `withHistory`
- * (snapshot keys are rewrapped by `elevate()`/`demote()`, #712), and the
- * decoded-record cache (evicted on tier moves) are already tier-safe. They
- * are not enumerated below; only known-unsafe features are refused, so any
- * combination not named here passes silently by default.
- *
- * ## Deliberately NOT handled here
- *
- * - `ledger` — `withHistory` threads a ledger writer onto every tiered
- *   collection by default in shipped usage; refusing `tiers + ledger` would
- *   break that default. A ledger-specific tier-rekey handler (rewrap ledger
- *   entries, or scope ledger visibility to tier) is a separate arc.
- * - materialized-view (MV) output — an MV's fanout spec lives on the
- *   SOURCE collection, not on the MV collection's own config, so it is not
- *   visible at `vault.collection()` registration time and this guard cannot
- *   detect it structurally.
- */
-export function assertTierComposition(
-  collectionName: string,
-  cfg: { readonly tiers: boolean; readonly blobFields: BlobFieldsConfig | undefined },
-): void {
-  if (!cfg.tiers) return
-  if (cfg.blobFields !== undefined && Object.keys(cfg.blobFields).length > 0) {
-    throw new UnsupportedTierCompositionError(
-      'blobs',
-      `Collection "${collectionName}": blobFields are not supported together with tiers (#724) — ` +
-        `blob chunk content is encrypted under a vault-shared DEK that elevate()/demote() do not ` +
-        `re-key, so an elevated record's blob attachments would remain readable at tier 0. Use a ` +
-        `non-tiered collection for blob-bearing records until a blob tier-rekey handler ships.`,
-    )
-  }
 }

--- a/packages/hub/src/with-lookup/search/collection-facade.ts
+++ b/packages/hub/src/with-lookup/search/collection-facade.ts
@@ -242,10 +242,16 @@ export function buildPersistedIndexCallbacks<T>(provideCtx: () => SearchContext<
         return null
       }
     },
-    save: async (json, fp) => {
+    save: async (json, fp, isStale) => {
       const ctx = provideCtx()
       const body = JSON.stringify({ fp, idx: json })
       const env = await ctx.codec.encryptJsonString(body, fp.count)
+      // #725 review: a purge (removePersisted) can land while the encrypt above was
+      // in flight — check right before the write and skip it rather than resurrect a
+      // purged/forgotten record's blob. PersistedIndexStore's own post-save epoch
+      // check is the backstop for every other ordering (incl. a purge landing during
+      // this very put).
+      if (isStale()) return
       await ctx.adapter.put(ctx.vault, FT, ctx.name, env)
     },
     remove: async () => { const ctx = provideCtx(); await ctx.adapter.delete(ctx.vault, FT, ctx.name) },

--- a/packages/hub/src/with-lookup/search/persisted-index-store.ts
+++ b/packages/hub/src/with-lookup/search/persisted-index-store.ts
@@ -28,6 +28,11 @@ export class PersistedIndexStore implements IndexStore {
   private timer: ReturnType<typeof setTimeout> | null = null
   private lastBuild: (() => ReadonlyArray<IndexDoc>) | undefined
   private readonly debounceMs: number
+  /** Bumped by every purge (removePersisted). A save() captured under a since-stale
+   *  epoch undoes its own effect once it settles, however it interleaves with the
+   *  purge's own delete — a delete can never be overtaken by a save that was
+   *  scheduled before it (#725). */
+  private epoch = 0
 
   constructor(private readonly cb: PersistedIndexCallbacks) {
     this.debounceMs = cb.debounceMs ?? 1000
@@ -66,6 +71,7 @@ export class PersistedIndexStore implements IndexStore {
   /** Delete the persisted blob and drop the in-memory index (forget/erasure). */
   async removePersisted(): Promise<void> {
     if (this.timer) { clearTimeout(this.timer); this.timer = null }
+    this.epoch++ // any save() already in flight is now stale — it will self-undo
     this.index = undefined
     await this.cb.remove()
   }
@@ -79,8 +85,13 @@ export class PersistedIndexStore implements IndexStore {
     await this.persist()
   }
 
+  /** Persist the current index, then undo it if a purge (removePersisted) landed
+   *  while the save was in flight — a delete can never be overtaken by a save
+   *  that was scheduled before it (#725). */
   private async persist(): Promise<void> {
     if (this.index === undefined) return
+    const epoch = this.epoch
     await this.cb.save(serializeIndex(this.index), this.cb.currentFingerprint())
+    if (this.epoch !== epoch) await this.cb.remove()
   }
 }

--- a/packages/hub/src/with-lookup/search/persisted-index-store.ts
+++ b/packages/hub/src/with-lookup/search/persisted-index-store.ts
@@ -4,6 +4,20 @@
  * live (L1 behavior); persists an opaque snapshot via a debounced flush, and
  * validates a loaded blob against a {count,maxVersion} fingerprint so a stale
  * blob is never used — only rebuilt.
+ *
+ * #725: a debounced save (encrypt + adapter.put) racing a purge (removePersisted,
+ * called by elevate's tier purge and forget's erasure) is guarded by an epoch counter
+ * — see the `epoch` field doc for the mechanism and why it also closes the issue's
+ * variant (b) for free. Residual gap, structurally unavoidable without a durable
+ * write-ahead log: a process CRASH strictly between a stale save's `adapter.put`
+ * landing and its compensating `remove()` running (or between the compensating
+ * remove landing and `pendingCompensation` being persisted somewhere durable — it is
+ * in-memory only) leaves the resurrected blob at rest until the next natural
+ * rebuild-persist. This is on par with the gate-before-put optimization's own crash
+ * residual (a crash between `isStale()` returning false and the put landing) — both
+ * are eliminated only by making the purge and the save's commit point transactional
+ * with the store, which is out of scope for an in-memory debounce layer over an
+ * arbitrary opaque-blob backend.
  */
 import { InvertedIndex, type IndexDoc } from './inverted-index.js'
 import { serializeIndex, deserializeIndex } from './serialize.js'
@@ -13,7 +27,14 @@ export interface Fingerprint { readonly count: number; readonly maxVersion: numb
 
 export interface PersistedIndexCallbacks {
   load(): Promise<{ json: string; fingerprint: Fingerprint } | null>
-  save(json: string, fp: Fingerprint): Promise<void>
+  /** `isStale()` reflects whether a purge (removePersisted) has landed since this
+   *  save's epoch was captured — check it AFTER any async encrypt step and BEFORE
+   *  the actual adapter.put, skipping the write when true (#725 review: shrinks the
+   *  at-rest window for purge-beats-encrypt orderings to zero). Belt-and-suspenders:
+   *  PersistedIndexStore's own post-save epoch check (persist(), below) is the
+   *  backstop that catches every other ordering, including a purge landing during
+   *  the put itself. */
+  save(json: string, fp: Fingerprint, isStale: () => boolean): Promise<void>
   remove(): Promise<void>
   currentFingerprint(): Fingerprint
   debounceMs?: number
@@ -28,11 +49,44 @@ export class PersistedIndexStore implements IndexStore {
   private timer: ReturnType<typeof setTimeout> | null = null
   private lastBuild: (() => ReadonlyArray<IndexDoc>) | undefined
   private readonly debounceMs: number
-  /** Bumped by every purge (removePersisted). A save() captured under a since-stale
-   *  epoch undoes its own effect once it settles, however it interleaves with the
-   *  purge's own delete — a delete can never be overtaken by a save that was
-   *  scheduled before it (#725). */
+  /**
+   * Bumped by every purge (removePersisted). A save() captured under a since-stale
+   * epoch undoes its own effect once it settles, however it interleaves with the
+   * purge's own delete — a delete can never be overtaken by a save that was
+   * scheduled before it (#725).
+   *
+   * Subsumes the issue's variant (b) (a stale, pre-purge in-memory index getting
+   * paired with a live, post-purge fingerprint and TRUSTED by a cold load, defeating
+   * the fingerprint backstop) for free — no separate handling needed: removePersisted()
+   * always resets `index` to undefined in the SAME synchronous step that bumps the
+   * epoch (below), and the only two paths that can repopulate `index` (ensureBuilt's
+   * cold rebuild, rebuildAndPersist's rebuild) do so strictly from `lastBuild()`, which
+   * the collection wires to read its LIVE cache at call time — not a frozen snapshot.
+   * Cache eviction (the collection dropping the purged/forgotten record) always
+   * precedes removePersisted() in both the elevate and forget call paths (#721's
+   * syncCache eviction / forget's tombstone write both land before syncSearch /
+   * _purgeSearchIndex runs). So any rebuild that executes strictly after
+   * removePersisted() — the only way `index` becomes defined again post-purge —
+   * necessarily observes the post-purge cache, and any rebuild that predates
+   * removePersisted() has its `index` wiped by it. There is no ordering in which a
+   * stale (pre-purge) index survives to be skip-rebuilt and persisted under a
+   * matching live fingerprint. Regression-pinned in
+   * `search-persisted-index-store.test.ts` ("variant (b) is subsumed...").
+   */
   private epoch = 0
+  /**
+   * Set when a stale save's compensating remove() (persist(), below) itself fails.
+   * Unlike the routine best-effort swallow on the debounced flush path (markDirty's
+   * timer .catch(), below — safe there because the fingerprint backstop forces a
+   * rebuild on the next cold load), a failed COMPENSATION leaves a resurrected
+   * purged/forgotten blob at rest whose fingerprint can still match the live cache —
+   * a cold load would TRUST it, not rebuild past it. So this is never silently
+   * dropped: every subsequent store entrypoint (ensureBuilt, rebuildAndPersist,
+   * removePersisted) retries the remove first and refuses to proceed past it until it
+   * succeeds (#725 review). A crash between a landed put and its compensating remove
+   * (before this flag or a retry can run) is a residual gap — see the class doc.
+   */
+  private pendingCompensation = false
 
   constructor(private readonly cb: PersistedIndexCallbacks) {
     this.debounceMs = cb.debounceMs ?? 1000
@@ -41,6 +95,7 @@ export class PersistedIndexStore implements IndexStore {
   get built(): boolean { return this.index !== undefined }
 
   async ensureBuilt(build: () => ReadonlyArray<IndexDoc>): Promise<InvertedIndex> {
+    await this.retryPendingCompensation()
     this.lastBuild = build
     if (this.index !== undefined) return this.index
     const loaded = await this.cb.load()
@@ -58,6 +113,10 @@ export class PersistedIndexStore implements IndexStore {
     if (this.timer) clearTimeout(this.timer)
     this.timer = setTimeout(() => {
       this.timer = null
+      // Best-effort: an ordinary save failure here is fine (the fingerprint backstop
+      // forces a rebuild on the next cold load). A failed COMPENSATION is different —
+      // it sets pendingCompensation (see field doc) instead of relying on this
+      // swallow, and is retried — not dropped — by whichever store operation runs next.
       void this.rebuildAndPersist().catch(() => { /* best-effort flush; fingerprint backstop forces rebuild next load */ })
     }, this.debounceMs)
   }
@@ -71,6 +130,7 @@ export class PersistedIndexStore implements IndexStore {
   /** Delete the persisted blob and drop the in-memory index (forget/erasure). */
   async removePersisted(): Promise<void> {
     if (this.timer) { clearTimeout(this.timer); this.timer = null }
+    await this.retryPendingCompensation()
     this.epoch++ // any save() already in flight is now stale — it will self-undo
     this.index = undefined
     await this.cb.remove()
@@ -78,6 +138,7 @@ export class PersistedIndexStore implements IndexStore {
 
   /** Rebuild using the last known build thunk, then persist. */
   private async rebuildAndPersist(): Promise<void> {
+    await this.retryPendingCompensation()
     if (this.lastBuild === undefined) return
     if (this.index === undefined) {
       this.index = InvertedIndex.build(this.lastBuild())
@@ -87,11 +148,29 @@ export class PersistedIndexStore implements IndexStore {
 
   /** Persist the current index, then undo it if a purge (removePersisted) landed
    *  while the save was in flight — a delete can never be overtaken by a save
-   *  that was scheduled before it (#725). */
+   *  that was scheduled before it (#725). A failed undo does not silently vanish:
+   *  see `pendingCompensation`. */
   private async persist(): Promise<void> {
     if (this.index === undefined) return
     const epoch = this.epoch
-    await this.cb.save(serializeIndex(this.index), this.cb.currentFingerprint())
-    if (this.epoch !== epoch) await this.cb.remove()
+    await this.cb.save(serializeIndex(this.index), this.cb.currentFingerprint(), () => this.epoch !== epoch)
+    if (this.epoch !== epoch) await this.compensate()
+  }
+
+  /** Undo a stale save. Failure is sticky, not swallowed: see `pendingCompensation`. */
+  private async compensate(): Promise<void> {
+    try {
+      await this.cb.remove()
+      this.pendingCompensation = false
+    } catch (e) {
+      this.pendingCompensation = true
+      throw e
+    }
+  }
+
+  private async retryPendingCompensation(): Promise<void> {
+    if (!this.pendingCompensation) return
+    await this.cb.remove()
+    this.pendingCompensation = false
   }
 }

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -1743,7 +1743,7 @@ const PRE_EXISTING_BODY_ACCESS = new Map([
   ['packages/hub/src/with-cargo/extract-partition.ts', 26],
   ['packages/hub/src/with-commit/history/history.ts', 2],
   ['packages/hub/src/with-commit/history/ledger/store.ts', 11],
-  ['packages/hub/src/with-commit/history/time-machine.ts', 3],
+  ['packages/hub/src/with-commit/history/time-machine.ts', 1],
   ['packages/hub/src/with-commit/numbering/index.ts', 5],
   ['packages/hub/src/with-commit/sequence/index.ts', 5],
   ['packages/hub/src/with-formula/derivations/fanout-sidecar.ts', 6],


### PR DESCRIPTION
Closes #730. Closes #725. Closes #720. Closes #718. Closes #733. Resolves #708's in-scope sharp edge (issue closes separately with its documented-limitation write-down). Milestone-34 Batch D; plan (incl. recorded corrections): `docs/superpowers/plans/2026-07-17-m34-batch-d.md`.

## What

- **#730 — time-machine tier gate.** `vault.at(ts).get()/list()` honor the invisibility law: an elevated record's history returns `null`/is omitted (was: opaque AES-GCM throw + id-existence reveal via `list()`). Folded pre-existing fix: snapshots decrypt through `openEnvelopeJson`, so perRecordKeys history works (enclave-body-only grandfather ratcheted 3→1).
- **#725 — persisted-index flush race.** Layered epoch guard: gate-before-put (`isStale()` post-encrypt), compensate-after (a purge landing mid-save is undone), sticky compensation retry (a failed compensating remove is re-attempted by every store operation, never swallowed). Both race variants — including the trusted-fingerprint one — are test-locked via the elevate AND forget entry points; crash residuals documented honestly. Follow-up #764 (stuck-compensation blast radius).
- **#720 — lazy `putAtTier` prior.** The tier ops thread their pre-write envelope into index sync (an adapter read at sync time re-observes the new value — the deferred-fix analysis in the issue held); decode is the established tier-gated `skipValidation` primitive. Dropped-field sidecars now clear exactly like `put()`.
- **#718 + #708 — the machinery write ring.** Internal deletes SKIP elevated records (shared `peekLiveTier` primitive; no marker/history/ledger on skip) — the repro went through the real derivation cascade and showed the pre-fix behavior was silent erasure; the review also found the skip is load-bearing for warm-cache MV invalidation. Coordinated cutover REFUSES all-or-nothing (`TierWriteRefusedError`, demote-first guidance) instead of silently demoting; the fence-vs-tier-move race limitation is documented on the guard.
- **#733 —** `assertTierComposition` relocated to the tier domain — discovered dead (superseded by Arc 10's runtime read gate, zero call sites); kept as documented, superseded #724 leak analysis rather than deleted.

## Review trail

Per-task reviews Approved ×5 (two in-task hardening waves on #725); fable whole-branch review "with fixes" → docs-only corrections applied. New issues from this arc: #764; #761 items 8-9 (skip accounting; sidecar-orphan-after-demote). #728 got the tier-move version-chain-hole data point.

## Verification

Full hub suite 511 files / 4264 tests green; typecheck / lint / `check:architecture` clean; `collection.ts` 4547/4549, `vault.ts` at ceiling. Changeset `m34-batch-d.md` (hub patch) local-only per convention.