### PR TITLE
fix(hub): putAtTier registers the subject ref — a sensitive-from-birth record is reachable by forget() (#766)

### DIFF
--- a/packages/hub/__tests__/putattier-subject-index.test.ts
+++ b/packages/hub/__tests__/putattier-subject-index.test.ts
@@ -1,0 +1,124 @@
+/**
+ * #766 — `Collection.putAtTier` (`with-audit/tiers/index.ts`) writes via a
+ * raw `ctx.adapter.put`, bypassing `Collection.put()`'s write-hook pipeline
+ * (the `onAfterWrite` hook that registers a record's ref in the encrypted
+ * `_subject_index`). A record whose FIRST persistence is `putAtTier` — a
+ * record sensitive from birth, a documented legitimate use — never entered
+ * the subject index, so `vault.forget(subjectId)` silently never found it:
+ * an unforgettable record.
+ *
+ * `elevate()`/`demote()` always operate on an ALREADY-registered record
+ * (both throw `Record "<id>" not found` when no envelope exists yet), so
+ * they need no change — covered here by the put()+elevate() regression case.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, ConflictError } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+
+interface Invoice { id: string; buyerId: string; amount: number }
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+async function freshVault(subjects: Record<string, string>) {
+  const db = await createNoydb({
+    store: memoryStore(), secret: 'putattier-subject-index-pw', user: 'owner',
+    tiersStrategy: withTiers(),
+    historyStrategy: withHistory(),
+    forgetStrategy: withForgetCascade({ subjects }),
+  })
+  return db.openVault('v1')
+}
+
+describe('#766 — putAtTier registers the subject ref', () => {
+  it('a record whose FIRST write is putAtTier(tier>0) is reachable by forget()', async () => {
+    const vault = await freshVault({ invoices: 'buyerId' })
+    const invoices = vault.collection<Invoice>('invoices', { tiers: [0, 1] })
+    await invoices.putAtTier('r1', { id: 'r1', buyerId: 'B', amount: 10 }, 1)
+
+    const result = await vault.forget('B')
+
+    expect(result.recordsShredded).toBe(1)
+  })
+
+  it('a record whose FIRST write is putAtTier(tier 0) is also reachable by forget()', async () => {
+    const vault = await freshVault({ invoices: 'buyerId' })
+    const invoices = vault.collection<Invoice>('invoices', { tiers: [0, 1] })
+    await invoices.putAtTier('r1', { id: 'r1', buyerId: 'B', amount: 10 }, 0)
+
+    const result = await vault.forget('B')
+
+    expect(result.recordsShredded).toBe(1)
+  })
+
+  it('a repeat putAtTier on the same record does not corrupt the subject index', async () => {
+    const vault = await freshVault({ invoices: 'buyerId' })
+    const invoices = vault.collection<Invoice>('invoices', { tiers: [0, 1] })
+    await invoices.putAtTier('r1', { id: 'r1', buyerId: 'B', amount: 10 }, 1)
+    await invoices.putAtTier('r1', { id: 'r1', buyerId: 'B', amount: 20 }, 1)
+
+    const result = await vault.forget('B')
+
+    expect(result.recordsShredded).toBe(1)
+  })
+
+  it('no-ops when the collection has no declared forget-subject field', async () => {
+    // "invoices" is not declared in `subjects` — only an unrelated collection is.
+    const vault = await freshVault({ other: 'ownerId' })
+    const invoices = vault.collection<Invoice>('invoices', { tiers: [0, 1] })
+    await invoices.putAtTier('r1', { id: 'r1', buyerId: 'B', amount: 10 }, 1)
+
+    const result = await vault.forget('B')
+
+    expect(result.recordsShredded).toBe(0)
+  })
+
+  it('put() + elevate() still registers the subject ref (regression)', async () => {
+    const vault = await freshVault({ invoices: 'buyerId' })
+    const invoices = vault.collection<Invoice>('invoices', { tiers: [0, 1] })
+    await invoices.put('r1', { id: 'r1', buyerId: 'B', amount: 10 })
+    await invoices.elevate('r1', 1)
+
+    const result = await vault.forget('B')
+
+    expect(result.recordsShredded).toBe(1)
+  })
+})

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -289,6 +289,14 @@ export interface CollectionOpts<T> {
    * classified refusal matrix (R4: a digest-only field cannot be the subject key).
    */
   subjectKeyField?: string | undefined
+  /**
+   * Register a record's forget-subject ref directly (bypassing the write-hook
+   * pipeline), wired by the Vault when this collection declares a forget-
+   * subject field. Consumed by `putAtTier` (#766, via `TiersContext.addSubjectRef`)
+   * so a record whose first write is a tier write still enters `_subject_index`.
+   * `undefined` when no forget strategy declares this collection (no-op).
+   */
+  addSubjectRef?: ((id: string, record: unknown) => Promise<void>) | undefined
   /** — tree-shake seam for `collection.reveal()`. Defaults to `NO_CLASSIFIED`. */
   classifiedStrategy?: ClassifiedStrategy | undefined
   /**
@@ -1183,6 +1191,7 @@ export function resolveCollectionConfig<T>(opts: CollectionOpts<T>) {
     tierMode: opts.tierMode ?? 'invisibility',
     blobTierPolicy: opts.blobTierPolicy ?? 'isolate',
     onCrossTierAccess: opts.onCrossTierAccess,
+    addSubjectRef: opts.addSubjectRef,
     deterministicFields,
     sensitiveFields,
     vdigFields,

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -506,10 +506,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   private readonly addSubjectRef: ((id: string, record: unknown) => Promise<void>) | undefined // #766: putAtTier's first-write subject-index registration (wired by the Vault; undefined ⇒ no forget-subject field declared)
 
   /**
-   * Optional reference to the vault-level hash-chained audit
-   * log. When present, every successful `put()` and `delete()` appends
-   * an entry to the ledger AFTER the adapter write succeeds (so a
-   * failed adapter write never produces an orphan ledger entry).
+   * Optional reference to the vault-level hash-chained audit log. When present, every successful `put()` and `delete()` appends an entry to the ledger AFTER the adapter write succeeds (so a failed adapter write never produces an orphan ledger entry).
    *
    * The ledger is always a vault-wide singleton — all
    * collections in the same vault share the same LedgerStore.

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -503,6 +503,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   private readonly tiers: ReadonlySet<number> | null
   private readonly tierMode: TierMode
   private readonly onCrossTierAccess: ((event: CrossTierAccessEvent) => void) | undefined
+  private readonly addSubjectRef: ((id: string, record: unknown) => Promise<void>) | undefined // #766: putAtTier's first-write subject-index registration (wired by the Vault; undefined ⇒ no forget-subject field declared)
 
   /**
    * Optional reference to the vault-level hash-chained audit
@@ -706,6 +707,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     this.tiers = cfg.tiers
     this.tierMode = cfg.tierMode
     this.onCrossTierAccess = cfg.onCrossTierAccess
+    this.addSubjectRef = cfg.addSubjectRef
     this.deterministicFields = cfg.deterministicFields
     this.sensitiveFields = cfg.sensitiveFields
     this.perRecordCek = cfg.perRecordCek
@@ -4518,6 +4520,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       tierMode: this.tierMode,
       getDEK: (key: string) => this.getDEK(key),
       emitCrossTierEvent: (event) => this.emitCrossTierEvent(event),
+      addSubjectRef: (id: string, record: T) => this.addSubjectRef?.(id, record) ?? Promise.resolve(),
     }
   }
 

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -71,7 +71,7 @@ import type { VaultInstant } from '../with-commit/history/time-machine.js'
 import { NO_HISTORY, type HistoryStrategy } from '../with-commit/history/strategy.js'
 import { NO_FORGET, type ForgetStrategy, type ForgetResult } from '../with-audit/forget/strategy.js'
 import {
-  addSubjectRef,
+  addSubjectRef, readDottedPath, coerceSubjectId,
   removeSubjectRef,
   lookupSubject,
   rebuildSubjectIndex as rebuildSubjectIndexImpl,
@@ -1090,6 +1090,7 @@ export class Vault {
         // Classified refusal matrix R4: a digest-only field cannot be the
         // forget-subject key (the subject index would hold the plaintext).
         collOpts.subjectKeyField = subjectKey
+        collOpts.addSubjectRef = async (id, record) => { const value = readDottedPath(record as Record<string, unknown>, subjectKey); if (value !== undefined && value !== null) await this._addSubjectRef(coerceSubjectId(value), { collection: collectionName, id }) } // #766: putAtTier's raw write bypasses onAfterWrite — register the first-write subject ref directly
       }
       if (options?.provenance !== undefined) collOpts.provenance = options.provenance
       if (options?.ramCiphertext !== undefined) collOpts.ramCiphertext = options.ramCiphertext

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -1070,9 +1070,7 @@ export class Vault {
       if (options?.sensitive !== undefined) {
         collOpts.sensitive = options.sensitive
       }
-      if (options?.perRecordKeys !== undefined) {
-        collOpts.perRecordKeys = options.perRecordKeys
-      }
+      if (options?.perRecordKeys !== undefined) collOpts.perRecordKeys = options.perRecordKeys
       // A collection declared in `withForgetCascade({ subjects })` MUST
       // use per-record CEKs: crypto-shred can only guarantee erasure of a body
       // keyed off a per-record CEK. Force it on (and warn if the caller

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -200,6 +200,17 @@ export interface TiersContext<T> {
   getDEK(key: string): Promise<EnclaveKey>
   /** Fire a cross-tier access event (sink stays collection-resident). */
   emitCrossTierEvent(event: CrossTierAccessEvent): void
+  /**
+   * Register this record's ref in the encrypted `_subject_index` (#766).
+   * `putAtTier`'s raw `ctx.adapter.put` bypasses `Collection.put()`'s write-
+   * hook pipeline — the `onAfterWrite` hook that normally does this — so a
+   * record whose FIRST persistence is `putAtTier` (sensitive from birth, a
+   * documented legitimate use) would otherwise never enter the index and
+   * stay unreachable by `vault.forget()`. Idempotent (safe on every call,
+   * including a repeat write of an already-registered record) and a no-op
+   * when the collection declares no forget-subject field.
+   */
+  addSubjectRef(id: string, record: T): Promise<void>
 }
 
 export function assertTiersEnabled<T>(ctx: TiersContext<T>): void {
@@ -399,6 +410,11 @@ export async function putAtTier<T>(
   }
 
   await ctx.adapter.put(ctx.vault, ctx.name, id, envelope)
+
+  // #766: putAtTier bypasses Collection.put()'s onAfterWrite hook — register
+  // the subject ref directly so a sensitive-from-birth first write stays
+  // reachable by vault.forget(). No-op when no forget-subject field is declared.
+  await ctx.addSubjectRef(id, record)
 
   // #702/#709: keep the record cache AND indexes coherent with the raw
   // write — same law as elevate/demote (#691): tier > 0 → invisible on

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -758,7 +758,14 @@ const KERNEL_SURFACE_BUDGET = {
   // money) needs — plus doc comments on both and the widened
   // `LazyQuerySource` literal (`getRawRecord`/`decodeRecord`/`via` replacing
   // `getRecord`).
-  'packages/hub/src/kernel/collection.ts': 4549,
+  // Bumped 4549→4551 (2026-07-18, #766: putAtTier subject-index registration):
+  // `addSubjectRef` private field + ctor assignment + `tiersContext()` wiring
+  // (a thin pass-through callback the Vault wires when a forget-subject field
+  // is declared). Closes the gap where a record's FIRST write via `putAtTier`
+  // bypassed `Collection.put()`'s onAfterWrite subject-index registration
+  // hook, leaving it unreachable by `vault.forget()`. Registration logic
+  // itself lives in vault.ts / with-audit/tiers/index.ts.
+  'packages/hub/src/kernel/collection.ts': 4551,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -1009,7 +1016,11 @@ const KERNEL_SURFACE_BUDGET = {
   // `via/lookup/registry.ts`, reached through the existing lookup-strategy port import.
   // Bumped 3958→3959 (2026-07-15, #693: tab-coordination fallback for the marker-set gate):
   // one `tabCoordinated: () => this.noydb._tabWritesRelayed` line threaded into collOpts.
-  'packages/hub/src/kernel/vault.ts': 3959,
+  // Bumped 3959→3960 (2026-07-18, #766: putAtTier subject-index registration): one line
+  // wiring `collOpts.addSubjectRef` inside the existing forget-subject-declared branch
+  // (dense one-liner, trailing comment) — the closure itself just calls the existing
+  // `this._addSubjectRef`; no new orchestration logic added to this file.
+  'packages/hub/src/kernel/vault.ts': 3960,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -758,14 +758,13 @@ const KERNEL_SURFACE_BUDGET = {
   // money) needs — plus doc comments on both and the widened
   // `LazyQuerySource` literal (`getRawRecord`/`decodeRecord`/`via` replacing
   // `getRecord`).
-  // Bumped 4549→4551 (2026-07-18, #766: putAtTier subject-index registration):
-  // `addSubjectRef` private field + ctor assignment + `tiersContext()` wiring
-  // (a thin pass-through callback the Vault wires when a forget-subject field
-  // is declared). Closes the gap where a record's FIRST write via `putAtTier`
-  // bypassed `Collection.put()`'s onAfterWrite subject-index registration
-  // hook, leaving it unreachable by `vault.forget()`. Registration logic
-  // itself lives in vault.ts / with-audit/tiers/index.ts.
-  'packages/hub/src/kernel/collection.ts': 4551,
+  // #766 (2026-07-18, putAtTier subject-index registration): funded IN PLACE, no bump.
+  // The +3 lines (`addSubjectRef` private field, ctor assignment, `tiersContext()` wiring —
+  // a thin pass-through callback the Vault wires when a forget-subject field is declared)
+  // were paid for by reflowing the adjacent 4-line `ledger` field JSDoc's first paragraph
+  // (byte-preserving — same wording, joined onto one line) to a single line, a −3 net.
+  // Net zero versus pre-#766: the file lands back at the exact same line count.
+  'packages/hub/src/kernel/collection.ts': 4549,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -1016,11 +1015,14 @@ const KERNEL_SURFACE_BUDGET = {
   // `via/lookup/registry.ts`, reached through the existing lookup-strategy port import.
   // Bumped 3958→3959 (2026-07-15, #693: tab-coordination fallback for the marker-set gate):
   // one `tabCoordinated: () => this.noydb._tabWritesRelayed` line threaded into collOpts.
-  // Bumped 3959→3960 (2026-07-18, #766: putAtTier subject-index registration): one line
-  // wiring `collOpts.addSubjectRef` inside the existing forget-subject-declared branch
-  // (dense one-liner, trailing comment) — the closure itself just calls the existing
-  // `this._addSubjectRef`; no new orchestration logic added to this file.
-  'packages/hub/src/kernel/vault.ts': 3960,
+  // #766 (2026-07-18, putAtTier subject-index registration): funded IN PLACE, no bump.
+  // The +1 line wiring `collOpts.addSubjectRef` inside the existing forget-subject-declared
+  // branch (dense one-liner, trailing comment — the closure itself just calls the existing
+  // `this._addSubjectRef`) was paid for by folding the adjacent 3-line
+  // `if (options?.perRecordKeys !== undefined) { ... }` block to this file's own one-line
+  // `if (...) collOpts.x = ...` style (matches the block immediately above it) — a −2 net,
+  // leaving the file 1 line UNDER ceiling.
+  'packages/hub/src/kernel/vault.ts': 3959,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
Closes #766. Milestone-34 candor/completeness follow-up (HIGH, pre-existing — surfaced during the #753 review).

## Problem

`Collection.putAtTier` writes via a raw `adapter.put`, bypassing `Collection.put()`'s write-hook pipeline — including the `onAfterWrite` hook that registers a record in `_subject_index`. So a record whose **first** persistence is `putAtTier(id, rec, tier)` (the sensitive-from-birth pattern — a legitimate, documented use) never enters the subject index, and `vault.forget(subjectId)` silently never finds it: an **unforgettable record**, a GDPR-erasure gap.

## Fix

`putAtTier` registers the subject ref through a new `TiersContext.addSubjectRef` seam, wired from `vault.ts` **only** inside the `withForgetCascade`-declared branch, delegating to the same `vault._addSubjectRef` (same `readDottedPath`/`coerceSubjectId` coercion, same dedup-idempotent index) the hook uses. No new metadata exposure: `SubjectRef` carries only `{collection, id}` (never tier), and the ref matches what the existing `put()`+`elevate()` flow already leaves in the tier-0 index. `elevate()`/`demote()` need no change — both throw on a missing envelope, so neither can be a first write.

## Verification

RED reproduced (putAtTier first-write → `forget()` can't find it); 5 new tests (first-write at tier N and tier 0, idempotent repeat, `put()`+`elevate()` regression). Full hub suite green (516 files / 4315); typecheck / lint / `check:architecture` clean. Both kernel ceilings held at their original values (`vault.ts` 3959, `collection.ts` 4549) — the seam was funded **in place** (shrink-first), no ceiling bump. Changeset `766-putattier-subject-index.md` (hub patch) local-only.

## Review trail

Reviewed Approved on correctness (seam, idempotency, dotted-path parity, no tier leak, elevate/demote analysis, RED); the initial ceiling bumps were reverted per the campaign's fund-in-place convention and re-verified.