### PR TITLE
fix(hub): tier- and journal-aware partition extraction — skip elevated FK parents, carry _blob_intent, strip pendingRelease (#759, #767, #769)

### DIFF
--- a/packages/hub/__tests__/extract-partition.test.ts
+++ b/packages/hub/__tests__/extract-partition.test.ts
@@ -283,3 +283,72 @@ describe('extractPartition — #748: elevated records are structurally excluded'
     db.close()
   })
 })
+
+/**
+ * #759 — outbound completion must re-check a referenced parent's tier
+ * visibility before admitting it into the closure, the same way root
+ * selection / inbound expansion already do. Pre-fix, an elevated parent
+ * referenced by a selected tier-0 child's FK entered the closure and
+ * `reKeyClosure`'s #748 canary threw `PartitionExtractionError` on it.
+ * Post-fix: the parent is silently excluded (matches root/inbound
+ * semantics) and the resulting dangling FK is surfaced as a residue notice
+ * on `ExtractPartitionResult.danglingRefs`.
+ */
+describe('extractPartition — #759: elevated FK parent is excluded with a dangling-ref residue notice', () => {
+  interface Invoice { id: string; clientId: string }
+
+  it('does NOT crash on an elevated FK parent; excludes it and reports the dangling ref', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      cargoStrategy: withCargo(),
+      store,
+      user: 'alice',
+      secret: 'test-passphrase-1234',
+      tiersStrategy: withTiers(),
+    })
+    const company = await db.openVault('demo-co')
+    const clients = company.collection<Client>('clients', { tiers: [0, 1] })
+    const invoices = company.collection<Invoice>('invoices', { refs: { clientId: ref('clients') } })
+
+    await clients.putAtTier('c-1', { id: 'c-1', name: 'Redacted Co', operatorUserId: 'belle' }, 0)
+    await invoices.put('inv-1', { id: 'inv-1', clientId: 'c-1' })
+    // Elevate the parent AFTER the invoice's FK is established, so the
+    // outbound-completion phase is the one that has to notice.
+    await clients.elevate('c-1', 1)
+
+    const { bundleBytes, transferKey, danglingRefs } = await extractPartition(company, {
+      seeds: { invoices: () => true },
+    })
+
+    expect(danglingRefs).toEqual([
+      { collection: 'invoices', id: 'inv-1', field: 'clientId', target: 'clients', targetId: 'c-1' },
+    ])
+
+    const { dumpJson } = await readNoydbBundle(bundleBytes)
+    const { dump } = parseExtractedPartitionBody(dumpJson)
+    const backup = JSON.parse(dump) as { collections: Record<string, Record<string, EncryptedEnvelope>> }
+
+    // The elevated parent never entered the partition...
+    expect(backup.collections['clients']).toBeUndefined()
+    // ...but the tier-0 child DID, keeping its (now dangling) FK value.
+    expect(Object.keys(backup.collections['invoices'] ?? {})).toEqual(['inv-1'])
+
+    // Round-trips cleanly: adoption doesn't choke on the dangling FK either.
+    const dest = memory()
+    await adoptPartition(bundleBytes, { transferKey, destinationStore: dest, vaultName: 'fresh' })
+    await createOwnerOnAdoptedPartition(dest, 'fresh', {
+      userId: 'belle', passphrase: 'belle-pass-phrase-2026', transferKey,
+    })
+    const recipientDb = await createNoydb({
+      cargoStrategy: withCargo(), store: dest, user: 'belle', secret: 'belle-pass-phrase-2026',
+      tiersStrategy: withTiers(),
+    })
+    const recipientVault = await recipientDb.openVault('fresh')
+    expect(await recipientVault.collection<Client>('clients', { tiers: [0, 1] }).get('c-1')).toBeNull()
+    expect(await recipientVault.collection<Invoice>('invoices', { refs: { clientId: ref('clients') } }).get('inv-1'))
+      .toMatchObject({ id: 'inv-1', clientId: 'c-1' })
+
+    recipientDb.close()
+    db.close()
+  })
+})

--- a/packages/hub/__tests__/extractpartition-blobs.test.ts
+++ b/packages/hub/__tests__/extractpartition-blobs.test.ts
@@ -16,9 +16,10 @@ import { withCargo } from '../src/index.js'
 import { ref } from '../src/kernel/refs.js'
 import { ConflictError } from '../src/kernel/errors.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, KeyringFile } from '../src/kernel/types.js'
-import { decrypt, unwrapCek } from '../src/kernel/enclave/index.js'
+import { decrypt, encrypt, unwrapCek, openEnvelopeJson } from '../src/kernel/enclave/index.js'
 import { withBlobs } from '../src/via/blob/index.js'
-import { BLOB_INDEX_COLLECTION, BLOB_CHUNKS_COLLECTION } from '../src/with-shape/blobs/blob-set.js'
+import { BLOB_INDEX_COLLECTION, BLOB_CHUNKS_COLLECTION, BLOB_SLOTS_PREFIX } from '../src/with-shape/blobs/blob-set.js'
+import { BLOB_INTENT_COLLECTION, createIntent, getIntent, type BlobIntent } from '../src/with-shape/blobs/blob-intent.js'
 import { extractPartition } from '../src/with-cargo/extract-partition.js'
 import {
   adoptPartition,
@@ -313,6 +314,138 @@ describe('extractPartition blob carriage — refCount + no-blob', () => {
     expect(await vault.collection<Doc>('docs').get('d1')).toMatchObject({ id: 'd1', title: 'No blobs here' })
     expect(await vault.collection<Doc>('docs').blob('d1').get('cover.png')).toBeNull()
     recipientDb.close()
+    db.close()
+  })
+})
+
+/**
+ * #767 — extract-partition must carry an in-flight `_blob_intent` marker for
+ * a carried record. A partition extracted mid-shred/mid-rehome without the
+ * marker would restore the blob rows without it, reproducing the ambiguous-
+ * refCount state the journal exists to prevent. Mirrors `dumpVault`'s
+ * backup allowlist, which already carries `_blob_intent` for the same
+ * reason (`with-pod/backup.ts`).
+ */
+describe('extractPartition blob carriage — #767: carries in-flight `_blob_intent` markers', () => {
+  it('an in-flight `_blob_intent` marker for a carried record travels, re-keyed under the destination DEK', async () => {
+    const src = memory()
+    const db = await createNoydb({ cargoStrategy: withCargo(), store: src, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs', { perRecordKeys: true })
+    await docs.put('d1', { id: 'd1', title: 'Report' })
+    await docs.blob('d1').put('cover.png', bytes('cover bytes'))
+
+    // Simulate a crashed mid-flight shred: plant a `_blob_intent` marker for
+    // d1 directly (mirrors blob-shred-journal.test.ts's use of `createIntent`
+    // for the same crash-recovery journal).
+    const { getDEK } = company._introspectState()
+    const intent: BlobIntent = { op: 'shred', opId: 'op-1', holds: [{ eTag: 'e1', n: 1, chunkCount: 1 }] }
+    await createIntent(src, 'demo-co', 'docs', 'd1', getDEK, intent)
+
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { docs: (r) => r['id'] === 'd1' },
+    })
+
+    const dest = memory()
+    await adoptPartition(bundleBytes, { transferKey, destinationStore: dest, vaultName: 'fresh' })
+    // The marker travelled at its stable `{collection}::{recordId}` key.
+    expect(await dest.get('fresh', BLOB_INTENT_COLLECTION, 'docs::d1')).not.toBeNull()
+
+    await createOwnerOnAdoptedPartition(dest, 'fresh', {
+      userId: 'belle', passphrase: 'belle-pass-phrase-2026', transferKey,
+    })
+    const recipientDb = await createNoydb({ cargoStrategy: withCargo(), store: dest, user: 'belle', secret: 'belle-pass-phrase-2026', blobStrategy: withBlobs() })
+    const recipientVault = await recipientDb.openVault('fresh')
+    const rState = recipientVault._introspectState()
+    // Round-trip: readable through the public marker reader under the
+    // recipient's own (re-keyed) DEK — resume-on-touch would heal it.
+    const recovered = await getIntent(rState.adapter, rState.name, 'docs', 'd1', rState.getDEK)
+    expect(recovered).toEqual(intent)
+
+    recipientDb.close()
+    db.close()
+  })
+
+  it('no in-flight marker → nothing carried (the normal case)', async () => {
+    const src = memory()
+    const db = await createNoydb({ cargoStrategy: withCargo(), store: src, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs', { perRecordKeys: true })
+    await docs.put('d1', { id: 'd1', title: 'Report' })
+    await docs.blob('d1').put('cover.png', bytes('cover bytes'))
+
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { docs: (r) => r['id'] === 'd1' },
+    })
+
+    const dest = memory()
+    await adoptPartition(bundleBytes, { transferKey, destinationStore: dest, vaultName: 'fresh' })
+    expect(await dest.get('fresh', BLOB_INTENT_COLLECTION, 'docs::d1')).toBeNull()
+    db.close()
+  })
+})
+
+/**
+ * #769 — `reKeyBlobs` must strip the internal `SlotRecord.pendingRelease`
+ * breadcrumb (#746's slot-CAS→release strand marker) when re-serializing a
+ * slot map into a partition: it names a source-vault-LOCAL eTag awaiting
+ * release that may be absent from the destination vault. Contrast with a
+ * full-vault `backup()`, which restores into the SAME vault and therefore
+ * CARRIES the breadcrumb unchanged (resumable there) — the asymmetry is
+ * documented in `with-pod/backup.ts`.
+ */
+describe('extractPartition blob carriage — #769: strips `pendingRelease` (backup retains it)', () => {
+  it('extract-partition strips SlotRecord.pendingRelease; a full-vault backup of the same vault retains it', async () => {
+    const src = memory()
+    const db = await createNoydb({ cargoStrategy: withCargo(), store: src, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs', { perRecordKeys: true })
+    await docs.put('d1', { id: 'd1', title: 'Report' })
+    await docs.blob('d1').put('cover.png', bytes('cover bytes'))
+
+    // Plant a `pendingRelease` breadcrumb directly on the raw slot record —
+    // mirrors a crash between a rehome's slot-CAS and its old-eTag release
+    // landing (#746).
+    const { adapter, name: vaultName, getDEK } = company._introspectState()
+    const slotsCollection = `${BLOB_SLOTS_PREFIX}docs`
+    const slotEnv = (await adapter.get(vaultName, slotsCollection, 'd1'))!
+    const dek = await getDEK('docs')
+    const slots = JSON.parse(await openEnvelopeJson(slotEnv, dek)) as Record<string, { eTag: string; pendingRelease?: string }>
+    slots['cover.png']!.pendingRelease = 'stale-etag-awaiting-release'
+    const reEncrypted = await encrypt(JSON.stringify(slots), dek)
+    await adapter.put(vaultName, slotsCollection, 'd1', { ...slotEnv, _iv: reEncrypted.iv, _data: reEncrypted.data }, slotEnv._v)
+
+    // ── extract-partition: STRIPS it (cross-vault; breadcrumb is meaningless there) ──
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { docs: (r) => r['id'] === 'd1' },
+    })
+    const dest = memory()
+    await adoptPartition(bundleBytes, { transferKey, destinationStore: dest, vaultName: 'fresh' })
+    await createOwnerOnAdoptedPartition(dest, 'fresh', {
+      userId: 'belle', passphrase: 'belle-pass-phrase-2026', transferKey,
+    })
+    const recipientDb = await createNoydb({ cargoStrategy: withCargo(), store: dest, user: 'belle', secret: 'belle-pass-phrase-2026', blobStrategy: withBlobs() })
+    const recipientVault = await recipientDb.openVault('fresh')
+    const rState = recipientVault._introspectState()
+    const carriedSlotEnv = (await rState.adapter.get('fresh', slotsCollection, 'd1'))!
+    const carriedSlots = JSON.parse(
+      await openEnvelopeJson(carriedSlotEnv, await rState.getDEK('docs')),
+    ) as Record<string, { eTag: string; pendingRelease?: string }>
+    expect(carriedSlots['cover.png']!.pendingRelease).toBeUndefined()
+    // The eTag itself still travels — only the breadcrumb is stripped.
+    expect(carriedSlots['cover.png']!.eTag).toBe(slots['cover.png']!.eTag)
+    recipientDb.close()
+
+    // ── backup: CARRIES it unchanged (same-vault-resumable) ──────────────
+    const backupJson = await company.dump()
+    const backup = JSON.parse(backupJson) as { _internal?: Record<string, Record<string, EncryptedEnvelope>> }
+    const backedUpSlotEnv = backup._internal?.[slotsCollection]?.['d1']
+    expect(backedUpSlotEnv).toBeDefined()
+    const backedUpSlots = JSON.parse(
+      await openEnvelopeJson(backedUpSlotEnv!, dek),
+    ) as Record<string, { eTag: string; pendingRelease?: string }>
+    expect(backedUpSlots['cover.png']!.pendingRelease).toBe('stale-etag-awaiting-release')
+
     db.close()
   })
 })

--- a/packages/hub/__tests__/walk-closure.test.ts
+++ b/packages/hub/__tests__/walk-closure.test.ts
@@ -17,6 +17,7 @@ import { ref } from '../src/kernel/refs.js'
 import { ConflictError, PartitionExtractionError } from '../src/kernel/errors.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
 import { walkClosure } from '../src/with-cargo/walk-closure.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
 
 function memory(): NoydbStore {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -188,6 +189,32 @@ describe('walkClosure', () => {
     await expect(
       walkClosure(company, { seeds: { clients: () => true } }),
     ).rejects.toThrow(PartitionExtractionError)
+  })
+
+  it('#759: excludes a tier-elevated outbound parent instead of admitting it, and records a dangling-ref notice', async () => {
+    const tieredDb = await createNoydb({
+      store: memory(), user: 'alice', secret: 'test-passphrase-1234', tiersStrategy: withTiers(),
+    })
+    const company = await tieredDb.openVault('demo-co')
+    const clients = company.collection<Client>('clients', { tiers: [0, 1] })
+    const bills = company.collection<Bill>('bills', { refs: { clientId: ref('clients') } })
+
+    await clients.putAtTier('c-1', { id: 'c-1', name: 'Redacted Co', operatorUserId: 'belle' }, 0)
+    await bills.put('b-1', { id: 'b-1', clientId: 'c-1', amount: 10 })
+    // Elevate the parent AFTER the FK is established — c-1 is now invisible
+    // to the tier-gated read surface the way root selection / inbound
+    // expansion already treat an elevated record.
+    await clients.elevate('c-1', 1)
+
+    const { closure, danglingRefs } = await walkClosure(company, {
+      seeds: { bills: () => true },
+    })
+
+    expect([...(closure.get('bills') ?? [])]).toEqual(['b-1']) // child keeps its FK value
+    expect(closure.get('clients')).toBeUndefined() // elevated parent NOT admitted
+    expect(danglingRefs).toEqual([
+      { collection: 'bills', id: 'b-1', field: 'clientId', target: 'clients', targetId: 'c-1' },
+    ])
   })
 
   it('is exported from the @noy-db/hub/bundle subpath', async () => {

--- a/packages/hub/src/legacy/bundle.ts
+++ b/packages/hub/src/legacy/bundle.ts
@@ -49,7 +49,7 @@ export type {
 
 // ─── Partition extraction → @noy-db/hub/cargo ─────────────
 export { walkClosure } from '../with-cargo/walk-closure.js'
-export type { WalkClosureOptions, ClosureResult } from '../with-cargo/walk-closure.js'
+export type { WalkClosureOptions, ClosureResult, DanglingRefNotice } from '../with-cargo/walk-closure.js'
 export { describeExtraction } from '../with-cargo/describe-extraction.js'
 export type { ExtractionPreview } from '../with-cargo/describe-extraction.js'
 export { extractPartition } from '../with-cargo/extract-partition.js'

--- a/packages/hub/src/with-cargo/extract-partition.ts
+++ b/packages/hub/src/with-cargo/extract-partition.ts
@@ -13,6 +13,7 @@ import {
   decrypt,
   encrypt,
   openEnvelopeJson,
+  writeEnvelopeBody,
   generateDEK,
   bufferToBase64,
   encryptBytesWithAAD,
@@ -28,8 +29,9 @@ import {
   BLOB_SLOTS_PREFIX,
   BLOB_VERSIONS_PREFIX,
 } from '../with-shape/blobs/blob-set.js'
+import { BLOB_INTENT_COLLECTION } from '../with-shape/blobs/blob-intent.js'
 import { PartitionExtractionError } from '../kernel/errors.js'
-import { walkClosure, type WalkClosureOptions } from './walk-closure.js'
+import { walkClosure, type WalkClosureOptions, type DanglingRefNotice } from './walk-closure.js'
 import { generateULID } from '../with-pod/ulid.js'
 import { SCHEMAS_COLLECTION } from '../with-shape/persisted-schemas/storage.js'
 import { NOYDB_FORMAT_VERSION } from '../kernel/types.js'
@@ -337,6 +339,22 @@ export async function reKeyBlobs(
     // Slots: one envelope per record, a `{ slotName: SlotRecord }` map.
     const slotsCollection = `${BLOB_SLOTS_PREFIX}${collectionName}`
     for (const id of ids) {
+      // #767: carry any in-flight `_blob_intent` marker for this record,
+      // re-keyed under the SAME destination DEK as its owning collection
+      // (mirrors `dumpVault`'s backup allowlist, which carries `_blob_intent`
+      // for the identical crash-recovery reason — a partition extracted
+      // mid-shred/mid-rehome must carry the marker so resume-on-touch heals
+      // it post-restore). Checked independently of the slot-map fetch below:
+      // a marker can be present even when the slot map has already been
+      // touched or removed by the in-flight operation.
+      const intentId = `${collectionName}::${id}`
+      const intentEnv = await adapter.get(vaultName, BLOB_INTENT_COLLECTION, intentId)
+      if (intentEnv) {
+        const intentPlain = await openEnvelopeJson(intentEnv, srcDek)
+        const intentBody = await writeEnvelopeBody(intentPlain, destDek)
+        place(BLOB_INTENT_COLLECTION, intentId, { ...intentEnv, ...intentBody })
+      }
+
       const env = await adapter.get(vaultName, slotsCollection, id)
       if (!env) continue
       // #748 defense-in-depth canary — see the matching one in `reKeyClosure`:
@@ -355,7 +373,17 @@ export async function reKeyBlobs(
       const kept: Record<string, SlotRecord> = {}
       for (const [slotName, slot] of Object.entries(slots)) {
         if (proj && !proj.has(slotName)) continue
-        kept[slotName] = slot
+        // #769: strip the internal `pendingRelease` resume breadcrumb before
+        // it travels. It is a SOURCE-VAULT-LOCAL rehome marker (see
+        // `SlotRecord.pendingRelease`'s doc comment) pointing at an old eTag
+        // awaiting release — meaningless, and potentially misleading, once
+        // detached from the source vault (the eTag it names may be absent
+        // from the destination). Unlike `_blob_intent` above (carried, so
+        // resume-on-touch heals it post-restore), this breadcrumb must NOT
+        // travel into a cross-vault partition.
+        const { pendingRelease, ...strippedSlot } = slot
+        void pendingRelease
+        kept[slotName] = strippedSlot
         addRef(slot.eTag)
       }
       if (Object.keys(kept).length === 0) continue
@@ -489,6 +517,14 @@ export interface ExtractPartitionResult {
   /** Raw 32-byte transfer key — deliver out-of-band; required to adopt. */
   readonly transferKey: Uint8Array
   readonly sealId: string
+  /**
+   * #759: outbound FK edges whose referenced parent was excluded from the
+   * partition (missing, or tier-elevated and therefore invisible). The
+   * child record still carries its FK value; the parent did not travel —
+   * callers should surface this to the operator rather than assume
+   * referential completeness.
+   */
+  readonly danglingRefs: ReadonlyArray<DanglingRefNotice>
 }
 
 /**
@@ -556,7 +592,7 @@ export async function extractPartitionCore(
   // reKeySchemas silently drops the row. Drain BEFORE reKeySchemas reads.
   if (opts.carrySchemas) await vault._drainPendingSchemaWrites()
 
-  const { closure } = await walkClosure(vault, opts)
+  const { closure, danglingRefs } = await walkClosure(vault, opts)
   const { collections, deks } = await reKeyClosure(vault, closure, opts.fieldProjection)
 
   // carryLedger: mint a fresh _ledger DEK, build the carried chain, and
@@ -641,5 +677,5 @@ export async function extractPartitionCore(
     },
   })
 
-  return { bundleBytes, transferKey, sealId: seal.sealId }
+  return { bundleBytes, transferKey, sealId: seal.sealId, danglingRefs }
 }

--- a/packages/hub/src/with-cargo/walk-closure.ts
+++ b/packages/hub/src/with-cargo/walk-closure.ts
@@ -8,9 +8,10 @@
  *   1. INBOUND expansion: from selected records, pull every record
  *      that references them (children travel with parents), to a
  *      fixed point.
- *   2. OUTBOUND completion: pull every parent the selected set
- *      references (no dangling FKs), transitively, WITHOUT
- *      re-expanding inbound from those parents (bounds the closure).
+ *   2. OUTBOUND completion: pull every VISIBLE parent the selected set
+ *      references, transitively, WITHOUT re-expanding inbound from those
+ *      parents (bounds the closure). A tier-elevated (or missing) parent is
+ *      excluded rather than admitted — see `danglingRefs` on the result.
  *
  * The FK graph is auto-derived from the vault's existing RefRegistry
  * (the `ref('target')` declarations on collections) — no hand-written
@@ -31,6 +32,27 @@ export interface WalkClosureOptions {
   readonly maxDepth?: number
 }
 
+/**
+ * #759: an outbound FK edge whose referenced parent was excluded from the
+ * closure — either because it doesn't exist, or because it is tier-elevated
+ * and therefore invisible (same "elevated ≡ missing" semantics as root
+ * selection / inbound expansion). The child keeps its FK value; the parent
+ * does not travel. Callers (extract-partition) surface this as a residue
+ * notice rather than silently dropping it.
+ */
+export interface DanglingRefNotice {
+  /** Collection of the child record that holds the dangling FK. */
+  readonly collection: string
+  /** Id of the child record. */
+  readonly id: string
+  /** FK field on the child that references the missing/elevated parent. */
+  readonly field: string
+  /** Target collection the FK points at. */
+  readonly target: string
+  /** Id of the missing/elevated parent. */
+  readonly targetId: string
+}
+
 export interface ClosureResult {
   /** collection → set of record ids that travel together. */
   readonly closure: Map<string, Set<string>>
@@ -40,6 +62,8 @@ export interface ClosureResult {
     /** True if an edge pointed back to an already-selected node. */
     readonly cyclesDetected: boolean
   }
+  /** #759: outbound FK edges whose parent was excluded (missing or elevated). */
+  readonly danglingRefs: ReadonlyArray<DanglingRefNotice>
 }
 
 export async function walkClosure(
@@ -142,6 +166,8 @@ export async function walkClosure(
   let outboundFrontier: Array<[string, string]> = []
   for (const [c, ids] of closure) for (const id of ids) outboundFrontier.push([c, id])
 
+  const danglingRefs: DanglingRefNotice[] = []
+
   while (outboundFrontier.length > 0) {
     const next: Array<[string, string]> = []
     for (const [collectionName, id] of outboundFrontier) {
@@ -155,6 +181,23 @@ export async function walkClosure(
         // Only scalar FK values reference a parent id; skip null/objects.
         if (typeof rawId !== 'string' && typeof rawId !== 'number') continue
         const parentId = String(rawId)
+        // #759: verify the referenced parent is visible through the SAME
+        // tier-gated primitive root selection / inbound expansion use
+        // (`Collection.get()` → `#getRaw`, which returns null for both a
+        // missing record and a tier-elevated one). An elevated parent must
+        // be excluded exactly like an elevated root or inbound target —
+        // "elevated ≡ invisible" — rather than admitted into the closure,
+        // where `reKeyClosure`'s raw adapter read would later hit it and
+        // fail loud (the #748 canary). Record the resulting dangling FK
+        // instead of silently dropping it.
+        const parentColl = vault.collection<Record<string, unknown>>(descriptor.target)
+        const parentRecord = await parentColl.get(parentId)
+        if (!parentRecord) {
+          danglingRefs.push({
+            collection: collectionName, id, field, target: descriptor.target, targetId: parentId,
+          })
+          continue
+        }
         // Reaching an already-selected parent here is normal DAG
         // convergence (a child referencing its in-scope parent), not a
         // cycle — so do NOT flag cyclesDetected in the outbound phase.
@@ -173,5 +216,5 @@ export async function walkClosure(
 
   const depth = Math.max(inboundDepth, outboundDepth)
 
-  return { closure, graph: { depth, cyclesDetected } }
+  return { closure, graph: { depth, cyclesDetected }, danglingRefs }
 }

--- a/packages/hub/src/with-pod/backup.ts
+++ b/packages/hub/src/with-pod/backup.ts
@@ -115,6 +115,17 @@ export async function dumpVault(ctx: BackupContext): Promise<string> {
     // today (a pre-existing, separate gap) — observed here, tracked on
     // #761, not fixed in this pass.
     '_blob_intent',
+    // #769: `_blob_slots_<c>` envelopes travel verbatim (raw ciphertext,
+    // same DEK, same vault) — including any `SlotRecord.pendingRelease`
+    // resume breadcrumb they carry. This is INTENTIONALLY the opposite of
+    // `extract-partition`'s `reKeyBlobs`, which STRIPS `pendingRelease`:
+    // a full-vault backup restores into the SAME vault it was taken from,
+    // so a breadcrumb taken mid-rehome (together with its `_blob_intent`
+    // marker, carried above) is resumable on restore — carry-and-resume is
+    // correct here. A partition extraction crosses vaults: the breadcrumb's
+    // old eTag may not exist in the destination, so it must be stripped
+    // there instead. Asymmetry: backup = same-vault-resumable = carry;
+    // partition = cross-vault = strip-breadcrumb-carry-marker.
     ...Object.keys(snapshot).flatMap((c) => [`_blob_slots_${c}`, `_blob_versions_${c}`]),
   ]
   for (const internalName of internalNames) {


### PR DESCRIPTION
Closes #759. Closes #767. Closes #769. Milestone-34 cargo/extraction-seam follow-ups (surfaced during the tiers×blobs campaign; all in `with-cargo`/`with-pod`).

## Fixes

- **#759 — walkClosure outbound completion admits an elevated FK parent.** The outbound-completion phase now re-checks a referenced parent's tier visibility via the same tier-gated `Collection.get()` root/inbound already use. An elevated (or missing) parent is **skipped** — matching "elevated ≡ invisible" — instead of being admitted and crashing `reKeyClosure`'s decode. The dangling FK is surfaced as `ExtractPartitionResult.danglingRefs`. (Decision: skip-with-residue, not refuse.)
- **#767 — carry `_blob_intent`.** An extracted partition carries any in-flight crash-recovery marker (re-keyed under the destination DEK, per-record), so resume-on-touch heals a mid-shred/mid-rehome record after restore.
- **#769 — strip `pendingRelease` (partition) / carry (backup).** The per-slot resume breadcrumb is source-vault-local — stripped from partition slot records, retained by full-vault `dump()` (same-vault-resumable). Asymmetry documented.

## Verification

New tests per issue; full hub suite green (515 files / 4315); typecheck / lint / `check:architecture` clean (marker re-key via the `writeEnvelopeBody` barrel); knip byte-identical pre/post. Changeset local-only. Reviewed Approved. Follow-up filed: #772 (describe-extraction preview parity).