### PR TITLE
fix(hub): stuck search-index compensation is a typed error surfaced as tier-move residue — no elevate/demote abort (#764)

### DIFF
--- a/packages/hub/__tests__/blob-rehome-journal.test.ts
+++ b/packages/hub/__tests__/blob-rehome-journal.test.ts
@@ -731,7 +731,7 @@ describe('#746 review Critical 2 — the "already moved" reconstruction is tier-
     // (a dedup-retained object IS erasable, just left in place), and then
     // unwrapped its `_cek` under `toBlobDEK` (tier 1) — a DEK mismatch,
     // throwing uncaught and leaving resume permanently stuck.
-    await expect(docsResume.elevate('r1', 2)).resolves.toBeUndefined()
+    await expect(docsResume.elevate('r1', 2)).resolves.toEqual({ searchResidue: false })
 
     expect(await store.list(VAULT, '_blob_intent')).toEqual([]) // no dangling marker
 
@@ -773,7 +773,7 @@ describe('elevate() resumes a pending SHRED marker first — nothing left to reh
     const db = await createNoydb({ store, secret: SECRET, user: 'owner', tiersStrategy: withTiers(), blobStrategy: withBlobs() })
     const vault = await db.openVault(VAULT)
     const docs = vault.collection<Doc>('docs', { tiers: [0, 1], perRecordKeys: true })
-    await expect(docs.elevate('r', 1)).resolves.toBeUndefined()
+    await expect(docs.elevate('r', 1)).resolves.toEqual({ searchResidue: false })
 
     // The blob is ERASED (shredded), not moved: no destination object at
     // tier 1, the original object gone, no slot map row.

--- a/packages/hub/__tests__/root-barrel-surface.golden.json
+++ b/packages/hub/__tests__/root-barrel-surface.golden.json
@@ -145,6 +145,7 @@
     "PathEscapeError",
     "PeriodClosedError",
     "PermissionDeniedError",
+    "PersistedIndexCompensationError",
     "PodVersionConflictError",
     "PolicyDeniedError",
     "PolicyEnforcer",

--- a/packages/hub/__tests__/search-compensation-residue.test.ts
+++ b/packages/hub/__tests__/search-compensation-residue.test.ts
@@ -1,0 +1,187 @@
+/**
+ * #764 — stuck search-index compensation ergonomics (a follow-up to #725's
+ * re-review). Two asks:
+ *
+ * (a) A permanently stuck `PersistedIndexStore` compensation (a compensating
+ *     `remove()` of a stale `_ftindex` blob, or `removePersisted()`'s own
+ *     purge, that keeps failing) must be a DISTINGUISHABLE typed error
+ *     (`PersistedIndexCompensationError`, cause = the raw adapter error) —
+ *     not an indistinguishable raw adapter error rethrown forever. Callers
+ *     that still don't opt into resilience (`retrieve()`/`warmIndex()`/
+ *     `flushIndex()`) keep throwing, but now throw the typed error.
+ *
+ * (b) `elevate()`/`demote()` must NOT abort mid-flight when the search
+ *     compensation is stuck — the record's tier-move `put` has already
+ *     landed by the time `syncTierSearch` runs, so an uncaught throw there
+ *     would strand `syncLedger`/`syncDerived`/`syncHistory`/`syncBlobs`
+ *     behind an already-moved record (a partial-completion hazard recurring
+ *     on every future tier move for the collection). The move must complete;
+ *     only the search-index purge is deferred/residual — surfaced via
+ *     `searchResidue: true` on the result, mirroring `forget()`'s
+ *     `indexResidue` posture.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withSearch, ConflictError, PersistedIndexCompensationError } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, CrossTierAccessEvent } from '../src/index.js'
+
+interface Doc { id: string; body: string }
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+/** Wrap a store so `delete(vault, '_ftindex', collection)` ALWAYS throws — a
+ *  genuinely permanent failure (store read-only), the #764 scenario. */
+function readOnlyFtindexDelete(store: NoydbStore): NoydbStore {
+  return {
+    ...store,
+    async delete(v, c, id) {
+      if (c === '_ftindex') throw new Error('simulated permanent store read-only failure')
+      return store.delete(v, c, id)
+    },
+  }
+}
+
+const SECRET = 'search-compensation-residue-passphrase-764'
+
+describe('#764 (a) a stuck compensation is a distinguishable typed error', () => {
+  it('flushIndex() throws PersistedIndexCompensationError — not the raw adapter error — once the compensation is permanently stuck; the cause is the original error', async () => {
+    const store = readOnlyFtindexDelete(memoryStore())
+    const db = await createNoydb({
+      store, user: 'owner', secret: SECRET,
+      searchStrategy: withSearch(), tiersStrategy: withTiers(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, textIndexes: ['body'], textIndexPersist: true,
+    })
+
+    await docs.put('e1', { id: 'e1', body: 'topsecret-alpha' })
+    await docs.flushIndex() // initial persist is a PUT, not a delete — uninterrupted
+
+    // elevate() drives removePersisted() — its own purge fails against the
+    // read-only store. elevate() itself is resilient to this (part b) and
+    // resolves, but the failure is sticky (pendingCompensation) and retried
+    // by the NEXT store entrypoint.
+    const result = await docs.elevate('e1', 1)
+    expect(result).toEqual({ searchResidue: true })
+
+    // flushIndex() has NOT been given the same resilience — it still throws —
+    // but now throws the DISTINGUISHABLE typed error, catchable deliberately,
+    // with the raw adapter error preserved as `cause`.
+    let caught: unknown
+    try { await docs.flushIndex() } catch (e) { caught = e }
+    expect(caught).toBeInstanceOf(PersistedIndexCompensationError)
+    expect((caught as PersistedIndexCompensationError).cause).toBeInstanceOf(Error)
+    expect(((caught as PersistedIndexCompensationError).cause as Error).message)
+      .toBe('simulated permanent store read-only failure')
+  })
+})
+
+describe('#764 (b) elevate()/demote() surface a stuck compensation as residue, not an abort', () => {
+  it('elevate() completes the tier move (put lands, cross-tier event fires past syncLedger/syncDerived) and returns searchResidue: true instead of throwing', async () => {
+    const store = readOnlyFtindexDelete(memoryStore())
+    const db = await createNoydb({
+      store, user: 'owner', secret: SECRET,
+      searchStrategy: withSearch(), tiersStrategy: withTiers(),
+    })
+    const vault = await db.openVault('v1')
+    const events: CrossTierAccessEvent[] = []
+    vault.onCrossTierAccess((e) => events.push(e))
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, textIndexes: ['body'], textIndexPersist: true,
+    })
+
+    await docs.put('e1', { id: 'e1', body: 'topsecret-alpha' })
+    await docs.flushIndex()
+
+    // Pre-#764 this threw the raw adapter error out of elevate(), mid-flight —
+    // after the record put but before syncLedger/syncDerived/emitCrossTierEvent/
+    // syncHistory/syncBlobs. It must now resolve, with the move fully completed.
+    await expect(docs.elevate('e1', 1)).resolves.toEqual({ searchResidue: true })
+
+    // The record actually moved: the raw envelope carries the new tier.
+    const env = await store.get('v1', 'docs', 'e1')
+    expect(env?._tier).toBe(1)
+
+    // emitCrossTierEvent (which runs AFTER syncLedger/syncDerived, BEFORE
+    // syncHistory/syncBlobs) fired — proves the function ran past the search
+    // catch to (at least) that point rather than aborting at syncSearch.
+    const elev = events.find((e) => e.op === 'elevate')
+    expect(elev).toMatchObject({ id: 'e1', tier: 1, authorization: 'elevation' })
+
+    // getAtTier still resolves the record's content at the new tier — proves
+    // syncHistory/syncBlobs (which run LAST) didn't themselves throw either.
+    expect(await docs.getAtTier('e1')).toEqual({ id: 'e1', body: 'topsecret-alpha' })
+  })
+
+  it('demote() has the same resilience', async () => {
+    const store = readOnlyFtindexDelete(memoryStore())
+    const db = await createNoydb({
+      store, user: 'owner', secret: SECRET,
+      searchStrategy: withSearch(), tiersStrategy: withTiers(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, textIndexes: ['body'], textIndexPersist: true,
+    })
+
+    // Plain put() (tier 0) never calls removePersisted() — only markDirty() —
+    // so this lands fine even against the read-only-for-_ftindex-delete store.
+    await docs.put('e1', { id: 'e1', body: 'topsecret-beta' })
+    // elevate() to tier 1 (resilient, part b above) — sets up a tier-1 record
+    // to demote back down, without going through putAtTier's own unwrapped
+    // syncSearch call (out of this issue's scope).
+    await docs.elevate('e1', 1)
+
+    const events: CrossTierAccessEvent[] = []
+    vault.onCrossTierAccess((e) => events.push(e))
+
+    await expect(docs.demote('e1', 0)).resolves.toEqual({ searchResidue: true })
+
+    const env = await store.get('v1', 'docs', 'e1')
+    expect(env?._tier).toBeUndefined() // tier 0 omits `_tier`
+
+    const dem = events.find((e) => e.op === 'demote')
+    expect(dem).toMatchObject({ id: 'e1', tier: 1 })
+
+    // Landed back at tier 0 — plain get() must work (proves syncCache/
+    // syncIndexes/syncHistory/syncBlobs all ran, not just the put).
+    expect(await docs.get('e1')).toEqual({ id: 'e1', body: 'topsecret-beta' })
+  })
+})

--- a/packages/hub/__tests__/search-persisted-index-store.test.ts
+++ b/packages/hub/__tests__/search-persisted-index-store.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect } from 'vitest'
 import { PersistedIndexStore, type Fingerprint } from '../src/with-lookup/search/persisted-index-store.js'
 import type { IndexDoc } from '../src/with-lookup/search/inverted-index.js'
+import { PersistedIndexCompensationError } from '../src/kernel/errors.js'
 
 const docs: IndexDoc[] = [{ id: 'a', fields: [{ field: 'd', text: 'invoice' }] }]
 
@@ -189,7 +190,13 @@ describe('PersistedIndexStore epoch-guarded flush/purge race (#725)', () => {
     expect(state.blob).toBeNull()
 
     release() // the stale save lands, then its own compensation (call #2) fails
-    await expect(flushPromise).rejects.toThrow('simulated remove failure')
+    // #764: the raw adapter error is wrapped in PersistedIndexCompensationError
+    // (a caller can catch it deliberately), the original error surviving as `cause`.
+    let caught: unknown
+    try { await flushPromise } catch (e) { caught = e }
+    expect(caught).toBeInstanceOf(PersistedIndexCompensationError)
+    expect((caught as PersistedIndexCompensationError).cause).toBeInstanceOf(Error)
+    expect(((caught as PersistedIndexCompensationError).cause as Error).message).toBe('simulated remove failure')
     // The debounced-flush path would swallow this exact failure via its
     // `.catch(() => {})` — here it propagates because flush() is awaited
     // directly, but the RESIDUE (a resurrected blob) is identical either way.

--- a/packages/hub/__tests__/tiers-blobs.test.ts
+++ b/packages/hub/__tests__/tiers-blobs.test.ts
@@ -249,7 +249,7 @@ describe('#724 solo blob at-rest isolation', () => {
     const docs = vault.collection<Doc>('docs', { tiers: [0, 1] })
 
     await docs.putAtTier('d1', { id: 'd1', title: 'Invoice', body: 'x' }, 0)
-    await expect(docs.elevate('d1', 1)).resolves.toBeUndefined()
+    await expect(docs.elevate('d1', 1)).resolves.toEqual({ searchResidue: false })
     // Ordinary elevated-record behavior, unaffected by the no-op.
     await expect(docs.get('d1')).resolves.toBeNull()
   })
@@ -1088,7 +1088,7 @@ describe('#724 empty-but-present slot map (re-review High)', () => {
     await docs.blob('d2').delete('slot')
     await docs.elevate('d2', 1)
 
-    await expect(docs.demote('d2', 0)).resolves.toBeUndefined()
+    await expect(docs.demote('d2', 0)).resolves.toEqual({ searchResidue: false })
   })
 
   it('vault.forget() does not throw and completes after put→delete(last slot)→elevate', async () => {
@@ -1130,8 +1130,8 @@ describe('#724 empty-but-present slot map (re-review High)', () => {
     })
     await docs.put('d3', { id: 'd3', title: 'C', body: 'z' })
 
-    await expect(docs.elevate('d3', 1)).resolves.toBeUndefined()
-    await expect(docs.demote('d3', 0)).resolves.toBeUndefined()
+    await expect(docs.elevate('d3', 1)).resolves.toEqual({ searchResidue: false })
+    await expect(docs.demote('d3', 0)).resolves.toEqual({ searchResidue: false })
     await expect(vault.forget('d3')).resolves.toBeDefined()
     const env = await store.get('v1', 'docs', 'd3')
     expect(env).not.toBeNull()

--- a/packages/hub/__tests__/tiers-derived.test.ts
+++ b/packages/hub/__tests__/tiers-derived.test.ts
@@ -245,7 +245,7 @@ describe('#722 elevate removes the source from derived outputs', () => {
 
     await docs.put('d1', { id: 'd1', title: 'Public' })
 
-    await expect(docs.elevate('d1', 1)).resolves.toBeUndefined()
+    await expect(docs.elevate('d1', 1)).resolves.toEqual({ searchResidue: false })
     expect(await docs.getAtTier('d1')).toEqual({ id: 'd1', title: 'Public' })
   })
 })
@@ -578,7 +578,7 @@ describe('#722 whole-branch review: pre-move decode must be tier-aware (not just
     await sales.putAtTier('s1', { id: 's1', buyerId: 'b1', total: 100 }, 1)
     expect((await buyers.get('b1'))?.totalSpent).toBe(200) // s1 never contributed (born above tier 0)
 
-    await expect(sales.elevate('s1', 2)).resolves.toBeUndefined()
+    await expect(sales.elevate('s1', 2)).resolves.toEqual({ searchResidue: false })
 
     // s1 stays excluded — no crash, no double-count, no corruption of the
     // sibling's contribution.
@@ -610,7 +610,7 @@ describe('#722 whole-branch review: pre-move decode must be tier-aware (not just
     await sales.putAtTier('s1', { id: 's1', buyerId: 'b1', total: 100 }, 1)
     expect((await buyers.get('b1'))?.totalSpent).toBe(200)
 
-    await expect(sales.elevate('s1', 2)).resolves.toBeUndefined()
+    await expect(sales.elevate('s1', 2)).resolves.toEqual({ searchResidue: false })
 
     expect((await buyers.get('b1'))?.totalSpent).toBe(200)
   })
@@ -674,7 +674,7 @@ describe('#722 whole-branch review: pre-move decode must be tier-aware (not just
     // demote() to an INTERMEDIATE tier (still > 0) is the buggy site: it
     // must decrypt the fromTier(=2) envelope, not the collection's
     // default (tier-0) DEK.
-    await expect(sales.demote('s1', 1)).resolves.toBeUndefined()
+    await expect(sales.demote('s1', 1)).resolves.toEqual({ searchResidue: false })
 
     // s1 stays elevated (tier 1 > 0) — still excluded from the rollup.
     expect((await buyers.get('b1'))?.totalSpent).toBe(200)

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -1165,3 +1165,6 @@ export type { RetrieveOptions, RetrieveHit } from './with-lookup/search/index.js
 export { withSearch, NO_SEARCH } from './with-lookup/search/index.js'
 export type { SearchStrategy } from './with-lookup/search/index.js'
 export { SearchNotEnabledError } from './kernel/errors.js'
+// #764: a stuck persisted search-index compensation (a failed compensating
+// remove() of a stale _ftindex blob) — callers can catch this deliberately.
+export { PersistedIndexCompensationError } from './kernel/errors.js'

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -29,7 +29,7 @@ import { countLiveEnvelopes } from './lazy-count.js'
 import { liveRecordIsElevated, assertTierWritable, assertCutoverTierSafe } from './tier-visibility.js'
 import {
   classifySealedShred as classifySealedShredImpl, syncDerivedOutputs,
-  type TiersContext,
+  type TiersContext, type TierMoveResult,
 } from '../with-audit/tiers/index.js'
 import type { TiersStrategy } from '../with-audit/tiers/strategy.js'
 import {
@@ -4449,13 +4449,13 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     return this.tiersStrategy.listAtTier(this.tiersContext())
   }
 
-  /** elevate a record to a higher tier — gated behind `withTiers()`. */
-  elevate(id: string, toTier: number): Promise<void> {
+  /** elevate a record to a higher tier — gated behind `withTiers()`. `searchResidue: true` = stuck search compensation (#764); the move itself always completes. */
+  elevate(id: string, toTier: number): Promise<TierMoveResult> {
     return this.tiersStrategy.elevate(this.tiersContext(), id, toTier)
   }
 
-  /** demote a record to a lower tier — gated behind `withTiers()`. */
-  demote(id: string, toTier: number): Promise<void> {
+  /** demote a record to a lower tier — gated behind `withTiers()`. Same `searchResidue` posture as {@link elevate} (#764). */
+  demote(id: string, toTier: number): Promise<TierMoveResult> {
     return this.tiersStrategy.demote(this.tiersContext(), id, toTier)
   }
 

--- a/packages/hub/src/kernel/errors.ts
+++ b/packages/hub/src/kernel/errors.ts
@@ -1316,6 +1316,34 @@ export class IndexWriteFailureError extends NoydbError {
 }
 
 /**
+ * Thrown when `PersistedIndexStore`'s compensating `remove()` — the undo of a
+ * stale debounced `_ftindex` save that raced a purge (#725) — itself fails.
+ * That failure is sticky (`pendingCompensation`) and retried-first by every
+ * subsequent store entrypoint (`ensureBuilt`/`rebuildAndPersist`/
+ * `removePersisted`) rather than silently dropped, but was previously
+ * rethrown as the RAW adapter error indefinitely — indistinguishable from
+ * any other adapter failure, so a caller could not catch it deliberately the
+ * way `forget()` catches `_purgeSearchIndex` into `indexResidue` (#764).
+ *
+ * `cause` is the underlying adapter error. Callers that want stuck-
+ * compensation resilience instead of an abort (e.g. `elevate()`/`demote()`,
+ * #764) catch this type specifically and surface it as residue.
+ */
+export class PersistedIndexCompensationError extends NoydbError {
+  override readonly cause: unknown
+
+  constructor(cause: unknown) {
+    super(
+      'PERSISTED_INDEX_COMPENSATION_STUCK',
+      'Persisted search-index compensation is stuck — a compensating remove() of a stale ' +
+        '_ftindex blob failed and is being retried by every subsequent store call.',
+    )
+    this.name = 'PersistedIndexCompensationError'
+    this.cause = cause
+  }
+}
+
+/**
  * Thrown by `.where()` / `.orderBy()` / `.aggregate()` (via the Via
  * pipeline's `postureFor`/`wrapReducers`) when the field is covered by a Via
  * feature whose declared posture is `queryable: 'none'` — e.g. a `blobFields`

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -24,7 +24,7 @@ export { withTiers } from './active.js'
 export { NO_TIERS, type TiersStrategy } from './strategy.js'
 export { TiersNotEnabledError } from '../../kernel/errors.js'
 import { encrypt, decrypt, unwrapCek, rewrapBodyToDek, isDeleteMarker, isTombstoneShape, type RecordCodec, type EnclaveKey, type SealedShredSlot } from '../../kernel/enclave/index.js'
-import { TierDemoteDeniedError, UnsupportedTierCompositionError } from '../../kernel/errors.js'
+import { TierDemoteDeniedError, UnsupportedTierCompositionError, PersistedIndexCompensationError } from '../../kernel/errors.js'
 import { dekKey, assertTierAccess } from '../../with-party/team/tiers.js'
 import type { UnlockedKeyring } from '../../with-party/team/keyring.js'
 import type { Lru } from '../../kernel/cache/index.js'
@@ -585,12 +585,44 @@ export async function listAtTier<T>(ctx: TiersContext<T>): Promise<Array<{ id: s
 }
 
 /**
+ * Result of a completed `elevate()`/`demote()` (#764). The record move
+ * (put + indexes/cache/ledger/derived/history/blobs sync) always completes —
+ * `searchResidue: true` means only the search-index side (`_vec`/`_ftindex`)
+ * was left in a needs-retry state (a stuck `PersistedIndexCompensationError`),
+ * mirroring `forget()`'s `indexResidue` posture rather than aborting the move.
+ */
+export interface TierMoveResult {
+  readonly searchResidue: boolean
+}
+
+/**
+ * Run {@link TiersContext.syncSearch} with #764 resilience: a permanently
+ * stuck compensation (`PersistedIndexCompensationError`, thrown by
+ * `PersistedIndexStore` when its compensating `remove()` of a stale
+ * `_ftindex` blob keeps failing) must not abort `elevate()`/`demote()` — the
+ * record's tier-move `put` has already landed, and aborting here would leave
+ * `syncLedger`/`syncDerived`/`syncHistory`/`syncBlobs` unsynced behind it (the
+ * partial-completion hazard #764 names). Same posture `forget()` takes for
+ * `_purgeSearchIndex` (`vault.ts`'s `indexResidue`) — everything else (a
+ * genuinely unexpected search-hook error) still aborts, undisturbed.
+ */
+async function syncSearchResilient<T>(ctx: TiersContext<T>, id: string, record: T | null, version?: number): Promise<boolean> {
+  try {
+    await ctx.syncSearch(id, record, version)
+    return false
+  } catch (e) {
+    if (e instanceof PersistedIndexCompensationError) return true
+    throw e
+  }
+}
+
+/**
  * elevate a record to a higher tier. Re-encrypts with the target tier's DEK.
  * The caller must hold DEKs for both the current tier (to decrypt) and the
  * target tier (to re-encrypt). Stamps `_elevatedBy` with the caller id so
  * `demote()` can check the reverse operation.
  */
-export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: number): Promise<void> {
+export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: number): Promise<TierMoveResult> {
   assertTiersEnabled(ctx)
   assertDeclaredTier(ctx, toTier)
   assertTierAccess(ctx.keyring, ctx.name, toTier)
@@ -600,7 +632,7 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
     throw new Error(`Record "${id}" not found in collection "${ctx.name}"`)
   }
   const fromTier = envelope._tier ?? 0
-  if (toTier === fromTier) return
+  if (toTier === fromTier) return { searchResidue: false }
   if (toTier < fromTier) {
     throw new Error(`Use demote() to lower the tier of "${id}" from ${fromTier} to ${toTier}`)
   }
@@ -644,8 +676,10 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   await ctx.syncIndexes(id, null, next._v)
   ctx.syncCache(id, null)
   // #721: same purge law as syncIndexes above — the record left tier 0, so
-  // its _vec sidecar is purged and _ftindex is invalidated.
-  await ctx.syncSearch(id, null)
+  // its _vec sidecar is purged and _ftindex is invalidated. #764: a
+  // permanently stuck compensation must not abort the move — the record put
+  // above already landed — so it is caught and surfaced as residue instead.
+  const searchResidue = await syncSearchResilient(ctx, id, null)
   // #729: elevate always lands the record at tier > 0 — purge its
   // tier-0-era plaintext ledger deltas (irreversible; entry metadata stays).
   await ctx.syncLedger(id)
@@ -682,13 +716,14 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   // #724: rehome any solo-owned blob attachments to the target tier's
   // `_blob` DEK — same at-rest law as syncHistory above.
   await ctx.syncBlobs(id, fromTier, toTier)
+  return { searchResidue }
 }
 
 /**
  * demote a record to a lower tier. Allowed only for the user who performed the
  * last elevation or an owner.
  */
-export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number): Promise<void> {
+export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number): Promise<TierMoveResult> {
   assertTiersEnabled(ctx)
   if (toTier < 0) throw new Error(`Cannot demote to negative tier ${toTier}`)
 
@@ -697,7 +732,7 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
     throw new Error(`Record "${id}" not found in collection "${ctx.name}"`)
   }
   const fromTier = envelope._tier ?? 0
-  if (toTier === fromTier) return
+  if (toTier === fromTier) return { searchResidue: false }
   if (toTier > fromTier) {
     throw new Error(`Use elevate() to raise the tier of "${id}" from ${fromTier} to ${toTier}`)
   }
@@ -746,13 +781,17 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
   // + purges: the record stays above tier 0 and must remain invisible on
   // tier-0 surfaces, unindexed. syncIndexes runs first in both branches —
   // it needs the pre-demote cache entry as "previous".
+  // #764: a permanently stuck search-index compensation must not abort the
+  // move — the record put above already landed — so it is caught in both
+  // branches and surfaced as residue on the return value instead.
+  let searchResidue: boolean
   if (toTier === 0) {
     const rec = await ctx.codec.decryptRecord(next, { id, sealedAsHandles: true })
     await ctx.syncIndexes(id, rec, next._v, envelope)
     ctx.syncCache(id, rec !== null ? { record: rec, version: next._v } : null)
     // #721: reuse the decode above — no double-decrypt. The record is tier-0
     // again, so re-embed its _vec and invalidate _ftindex to include it.
-    await ctx.syncSearch(id, rec, next._v)
+    searchResidue = await syncSearchResilient(ctx, id, rec, next._v)
     // #722 Task 2: the record rejoined tier 0 — restore its contribution to
     // every derived output (reuse the decode above, no double-decrypt).
     await ctx.syncDerived(id, rec, false, next._v)
@@ -760,7 +799,7 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
     await ctx.syncIndexes(id, null, next._v)
     ctx.syncCache(id, null)
     // #721: still above tier 0 — purge _vec, invalidate _ftindex.
-    await ctx.syncSearch(id, null)
+    searchResidue = await syncSearchResilient(ctx, id, null)
     // #722 Task 2: still elevated (an intermediate tier) — the source's
     // derived outputs stay recompute-as-removed, same law as elevate()
     // above. `envelope` is the PRE-move envelope captured at function
@@ -797,6 +836,7 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
   // #724: rehome any solo-owned blob attachments the same direction as the
   // live body — restores tier-0 (or intermediate-tier) readability at rest.
   await ctx.syncBlobs(id, fromTier, toTier)
+  return { searchResidue }
 }
 
 /**

--- a/packages/hub/src/with-audit/tiers/strategy.ts
+++ b/packages/hub/src/with-audit/tiers/strategy.ts
@@ -8,7 +8,7 @@
  * @internal
  */
 import type { GhostRecord } from '../../kernel/types.js'
-import type { TiersContext } from './index.js'
+import type { TiersContext, TierMoveResult } from './index.js'
 import { TiersNotEnabledError } from '../../kernel/errors.js'
 
 export interface TiersStrategy {
@@ -21,8 +21,8 @@ export interface TiersStrategy {
   ): Promise<void>
   getAtTier<T>(ctx: TiersContext<T>, id: string): Promise<T | GhostRecord | null>
   listAtTier<T>(ctx: TiersContext<T>): Promise<Array<{ id: string; tier: number; readable: boolean }>>
-  elevate<T>(ctx: TiersContext<T>, id: string, toTier: number): Promise<void>
-  demote<T>(ctx: TiersContext<T>, id: string, toTier: number): Promise<void>
+  elevate<T>(ctx: TiersContext<T>, id: string, toTier: number): Promise<TierMoveResult>
+  demote<T>(ctx: TiersContext<T>, id: string, toTier: number): Promise<TierMoveResult>
 }
 
 /**

--- a/packages/hub/src/with-lookup/search/persisted-index-store.ts
+++ b/packages/hub/src/with-lookup/search/persisted-index-store.ts
@@ -22,6 +22,7 @@
 import { InvertedIndex, type IndexDoc } from './inverted-index.js'
 import { serializeIndex, deserializeIndex } from './serialize.js'
 import type { IndexStore } from './index-store.js'
+import { PersistedIndexCompensationError } from '../../kernel/errors.js'
 
 export interface Fingerprint { readonly count: number; readonly maxVersion: number }
 
@@ -75,16 +76,20 @@ export class PersistedIndexStore implements IndexStore {
    */
   private epoch = 0
   /**
-   * Set when a stale save's compensating remove() (persist(), below) itself fails.
-   * Unlike the routine best-effort swallow on the debounced flush path (markDirty's
-   * timer .catch(), below — safe there because the fingerprint backstop forces a
-   * rebuild on the next cold load), a failed COMPENSATION leaves a resurrected
-   * purged/forgotten blob at rest whose fingerprint can still match the live cache —
+   * Set when a compensating/purging remove() (`compensate()` undoing a stale
+   * save, or `removePersisted()`'s own purge, #764) fails. Unlike the routine
+   * best-effort swallow on the debounced flush path (markDirty's timer
+   * .catch(), below — safe there because the fingerprint backstop forces a
+   * rebuild on the next cold load), a failed removal leaves a resurrected or
+   * un-purged blob at rest whose fingerprint can still match the live cache —
    * a cold load would TRUST it, not rebuild past it. So this is never silently
    * dropped: every subsequent store entrypoint (ensureBuilt, rebuildAndPersist,
-   * removePersisted) retries the remove first and refuses to proceed past it until it
-   * succeeds (#725 review). A crash between a landed put and its compensating remove
-   * (before this flag or a retry can run) is a residual gap — see the class doc.
+   * removePersisted) retries the remove first and refuses to proceed past it
+   * until it succeeds (#725 review), and the raw adapter error is wrapped in
+   * {@link PersistedIndexCompensationError} (#764) so a caller can catch a
+   * stuck removal deliberately instead of an indistinguishable adapter error.
+   * A crash between a landed put and its compensating remove (before this
+   * flag or a retry can run) is a residual gap — see the class doc.
    */
   private pendingCompensation = false
 
@@ -127,13 +132,23 @@ export class PersistedIndexStore implements IndexStore {
     await this.rebuildAndPersist()
   }
 
-  /** Delete the persisted blob and drop the in-memory index (forget/erasure). */
+  /** Delete the persisted blob and drop the in-memory index (forget/erasure/tier
+   *  move). A failed purge is wrapped in {@link PersistedIndexCompensationError}
+   *  (#764) and left sticky (`pendingCompensation`) so the next store entrypoint
+   *  retries it — never silently dropped, same posture #725 established for a
+   *  stale save's own compensating remove. */
   async removePersisted(): Promise<void> {
     if (this.timer) { clearTimeout(this.timer); this.timer = null }
     await this.retryPendingCompensation()
     this.epoch++ // any save() already in flight is now stale — it will self-undo
     this.index = undefined
-    await this.cb.remove()
+    try {
+      await this.cb.remove()
+      this.pendingCompensation = false
+    } catch (e) {
+      this.pendingCompensation = true
+      throw new PersistedIndexCompensationError(e)
+    }
   }
 
   /** Rebuild using the last known build thunk, then persist. */
@@ -157,20 +172,30 @@ export class PersistedIndexStore implements IndexStore {
     if (this.epoch !== epoch) await this.compensate()
   }
 
-  /** Undo a stale save. Failure is sticky, not swallowed: see `pendingCompensation`. */
+  /** Undo a stale save. Failure is sticky, not swallowed: see `pendingCompensation`.
+   *  Wraps the raw adapter error in {@link PersistedIndexCompensationError} (#764) so
+   *  a caller (e.g. the tier ops' `syncTierSearch`) can catch a stuck compensation
+   *  deliberately instead of treating it as an indistinguishable adapter failure. */
   private async compensate(): Promise<void> {
     try {
       await this.cb.remove()
       this.pendingCompensation = false
     } catch (e) {
       this.pendingCompensation = true
-      throw e
+      throw new PersistedIndexCompensationError(e)
     }
   }
 
+  /** Retries a sticky compensation before any store entrypoint proceeds. Failure
+   *  re-wraps the raw adapter error the same way `compensate()` does (#764) — the
+   *  flag stays set (untouched here) so the NEXT entrypoint retries again. */
   private async retryPendingCompensation(): Promise<void> {
     if (!this.pendingCompensation) return
-    await this.cb.remove()
-    this.pendingCompensation = false
+    try {
+      await this.cb.remove()
+      this.pendingCompensation = false
+    } catch (e) {
+      throw new PersistedIndexCompensationError(e)
+    }
   }
 }


### PR DESCRIPTION
Closes #764. Milestone-34 follow-up (from the #725 re-review).

## Problem

#725's sticky `pendingCompensation` retry (a failed compensating `remove()` is never silent — correct) rethrew the **raw adapter error** uncaught, with no distinguishable type. A genuinely permanent failure (e.g. read-only store) therefore rethrew forever — and because `syncTierSearch` → `removePersisted()` was uncaught in the tier ops, it **aborted `elevate()`/`demote()` mid-flight** (after the record's tier-move write landed, before ledger/derived sync), recurring on every future move for that collection. `forget()` alone degraded gracefully.

## Fix

- **(a) Distinguishable error:** stuck compensation now throws `PersistedIndexCompensationError` (raw adapter error preserved as `cause`), so callers can catch it deliberately.
- **(b) Tier-move resilience:** `elevate()`/`demote()` wrap the search purge in `syncSearchResilient`, which catches **only** `PersistedIndexCompensationError` (anything else still aborts) and threads the result through a new `TierMoveResult { searchResidue: boolean }`. The move now **completes** — put, indexes, cache, ledger, derived, history, blobs all land — with only the search-index purge left residual and reported, instead of aborting.

## Verification

RED (permanent-stuck compensation → elevate abort) reproduced; new `search-compensation-residue.test.ts` (3 tests) + 9 pre-existing assertions updated for the new return type (none weakened). Full hub suite green (517 files / 4318); typecheck / lint / `check:architecture` clean; `collection.ts` net-zero (4547/4549), `vault.ts` untouched. Changeset local-only.

## Review trail

Reviewed Approved — residue-channel correctness verified by code trace (move completes, only search residual; narrow catch; boolean faithfully surfaced). Follow-up filed: `putAtTier()` has the identical unwrapped-`syncSearch` hazard (out of this issue's named scope).