### PR TITLE
fix(hub): MV erasure candor + same-collection data-loss fix (#762, #761 items 1/2/4/8)

### DIFF
--- a/packages/hub/__tests__/materialized-views/correctness.test.ts
+++ b/packages/hub/__tests__/materialized-views/correctness.test.ts
@@ -314,6 +314,80 @@ describe('MV correctness (#152)', () => {
       })
       await db.openVault('demo')
     })
+
+    it('ordinary delete() of one source row does not wipe OTHER source rows at rest (#762)', async () => {
+      const mv = withMaterializedView<Disbursement>({
+        name: 'pp30-aggregate',
+        query: (db) => db.collection<Disbursement>('disbursements')
+          .query()
+          .where('type', 'in', ['vatSales', 'vatPurchase', 'vatCredit']),
+        rowKey: (r) => `pp30|${r.period}|${r.id}`,
+        refresh: 'eager',
+        output: { collection: 'disbursements', partition: { field: 'type', value: 'pp30' } },
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-762-tombstone-passphrase-2026',
+        materializedViewStrategies: [mv],
+      })
+      const vault = await db.openVault('demo')
+      const coll = vault.collection<Disbursement>('disbursements')
+      await coll.put('d1', { id: 'd1', type: 'vatSales', period: '2026-05', amount: 1000 })
+      await coll.put('d2', { id: 'd2', type: 'vatPurchase', period: '2026-05', amount: 500 })
+      expect(await coll.get('pp30|2026-05|d1')).not.toBeNull()
+      expect(await coll.get('pp30|2026-05|d2')).not.toBeNull()
+
+      // Ordinary delete() of d1 fires the eager MV refresh (onEmpty: 'delete', the default).
+      // Before the fix, the tombstone diff (`listOutputIds` with no ownership filter) wipes
+      // EVERY id in the output collection absent from the new result set — including d2, an
+      // untouched USER source row that still matches the MV's own query.
+      await coll.delete('d1')
+
+      expect(await coll.get('d2')).not.toBeNull() // #762 — the data-loss RED this test pins
+      expect((await coll.get('d2'))?.amount).toBe(500)
+    })
+
+    it('manual MV sharing an output collection with an invalidated sibling keeps its rows (#761 item 2)', async () => {
+      interface Order extends Record<string, unknown> { id: string; amount: number }
+      interface Invoice extends Record<string, unknown> { id: string; amount: number }
+      const mvA = withMaterializedView<Order>({
+        name: 'orders-report',
+        query: (db) => db.collection<Order>('orders').query(),
+        rowKey: (r) => `orders|${r.id}`,
+        refresh: 'lazy',
+        output: { collection: 'reports' },
+      })
+      const mvB = withMaterializedView<Invoice>({
+        name: 'invoices-report',
+        query: (db) => db.collection<Invoice>('invoices').query(),
+        rowKey: (r) => `invoices|${r.id}`,
+        refresh: 'manual',
+        output: { collection: 'reports' },
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-sibling-passphrase-2026',
+        materializedViewStrategies: [mvA, mvB],
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<Order>('orders').put('o1', { id: 'o1', amount: 10 })
+      await vault.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 20 })
+
+      // Materialize mvA lazily (a read triggers resolve-on-read) and mvB explicitly (manual).
+      expect(await vault.collection('reports').get('orders|o1')).not.toBeNull()
+      await vault.refreshView('invoices-report')
+      expect(await vault.collection('reports').get('invoices|i1')).not.toBeNull()
+
+      // Deleting mvA's source row invalidates mvA's OWN stamped output row at rest
+      // (`invalidateMVAtRest`). mvB's row — a manual sibling sharing the SAME output
+      // collection — must survive: the stamp-scoped discipline in `invalidateMVAtRest`
+      // must never collaterally wipe a sibling MV's rows (#761 item 2).
+      await vault.collection<Order>('orders').delete('o1')
+      expect(await vault.collection('reports').get('orders|o1')).toBeNull()
+      expect(await vault.collection('reports').get('invoices|i1')).not.toBeNull()
+    })
   })
 
   describe('strict-mode rollback', () => {

--- a/packages/hub/__tests__/tier-write-ring.test.ts
+++ b/packages/hub/__tests__/tier-write-ring.test.ts
@@ -231,10 +231,10 @@ describe('#718: internal deletes skip elevated records (the write ring covers ma
     await docs.elevate('d1', 1)
 
     // `_internalDelete`'s own prior-read sees a live envelope before `_doDelete`'s
-    // skip fires, so it still reports `true` — a residual accounting gap (the
-    // record is genuinely untouched, verified below; not a confidentiality
-    // issue, but the caller can't tell "skipped" from "erased" from this alone).
-    expect(await docs._internalDelete('d1')).toBe(true)
+    // skip fires, but `_doDelete` itself now reports the skip (#761 item 8) — the
+    // record is genuinely untouched (verified below), and the caller CAN tell
+    // "skipped" from "erased" via this return value.
+    expect(await docs._internalDelete('d1')).toBe(false)
     expect((await store.get('v1', 'docs', 'd1'))!._tier).toBe(1)
 
     expect(await docs._internalDelete('d2')).toBe(true) // ordinary internal cleanup unaffected

--- a/packages/hub/__tests__/via/forget-fanout.test.ts
+++ b/packages/hub/__tests__/via/forget-fanout.test.ts
@@ -106,6 +106,38 @@ describe('forget() fanout to derived residue (#622)', () => {
     expect(result.recordsShredded).toBe(1)
   })
 
+  it('forget × lazy MV: derivedRecordsErased counts the at-rest purge, not just the eager leg (#761 item 1)', async () => {
+    interface Person extends Record<string, unknown> { id: string; subjectId: string; name: string }
+    const mv = withMaterializedView<Person>({
+      name: 'people-mirror-lazy',
+      query: (db) => db.collection<Person>('people').query(),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'forget-fanout-lazy-mv-count-passphrase-2026',
+      materializedViewStrategies: [mv],
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { people: 'subjectId' } }),
+    })
+    const vault = await db.openVault('firm')
+    const people = vault.collection<Person>('people')
+    const mirror = vault.collection<Person>('people-mirror-lazy')
+    await people.put('p1', { id: 'p1', subjectId: 'subj-1', name: 'Ada' })
+    // Materialize the lazy MV via a read — its output row now exists at rest.
+    expect(await mirror.get('p1')).not.toBeNull()
+
+    const result = await vault.forget('subj-1')
+
+    // The lazy MV's row lives in a collection NOT configured as a forget subject
+    // (only 'people' is), so its removal can ONLY come from
+    // dispatchMaterializedViewsOnDelete's invalidateMVAtRest purge — not subject-index.
+    expect(await mirror.get('p1')).toBeNull()
+    // #761 item 1 — before the fix, invalidateMVAtRest's purge count was dropped on
+    // the floor; derivedRecordsErased only ever summed the eager executor's leg.
+    expect(result.derivedRecordsErased).toBeGreaterThanOrEqual(1)
+  })
+
   it('forget × same-collection MV: forget() reaches a same-collection partition MV (#761 item 4)', async () => {
     // refresh: 'manual' (not 'eager') deliberately — it routes dispatchMaterializedViewsOnDelete
     // into invalidateMVAtRest's stamp-scoped AT-REST purge instead of re-running the eager

--- a/packages/hub/__tests__/via/forget-fanout.test.ts
+++ b/packages/hub/__tests__/via/forget-fanout.test.ts
@@ -106,6 +106,52 @@ describe('forget() fanout to derived residue (#622)', () => {
     expect(result.recordsShredded).toBe(1)
   })
 
+  it('forget × same-collection MV: forget() reaches a same-collection partition MV (#761 item 4)', async () => {
+    // refresh: 'manual' (not 'eager') deliberately — it routes dispatchMaterializedViewsOnDelete
+    // into invalidateMVAtRest's stamp-scoped AT-REST purge instead of re-running the eager
+    // executor's query. Re-running the query is orthogonal here (same-collection Query-form MVs
+    // copy the whole source row verbatim, so a stale stamped row can satisfy the MV's own filter
+    // on a later refresh — a separate, out-of-scope concern from #761 item 4). The manual-mode
+    // purge gives an unconfounded signal: d2's OWN MV row (subjectId 'subj-2', untouched by the
+    // forgotten 'subj-1' subject-index match) is only removed if dispatch actually reached the
+    // MV via the same-collection edge this commit fixes.
+    interface Disbursement extends Record<string, unknown> {
+      id: string; type: 'vatSales' | 'pp30'; subjectId: string; period: string; amount: number
+    }
+    const mv = withMaterializedView<Disbursement>({
+      name: 'pp30-aggregate',
+      query: (db) => db.collection<Disbursement>('disbursements').query().where('type', '==', 'vatSales'),
+      rowKey: (r) => `pp30|${r.period}|${r.id}`,
+      refresh: 'manual',
+      output: { collection: 'disbursements', partition: { field: 'type', value: 'pp30' } },
+    })
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'forget-fanout-same-collection-mv-passphrase-2026',
+      materializedViewStrategies: [mv],
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { disbursements: 'subjectId' } }),
+    })
+    const vault = await db.openVault('firm')
+    const coll = vault.collection<Disbursement>('disbursements')
+    await coll.put('d1', { id: 'd1', type: 'vatSales', subjectId: 'subj-1', period: '2026-05', amount: 1000 })
+    await coll.put('d2', { id: 'd2', type: 'vatSales', subjectId: 'subj-2', period: '2026-05', amount: 500 })
+    await vault.refreshView('pp30-aggregate')
+    expect(await coll.get('pp30|2026-05|d1')).not.toBeNull()
+    expect(await coll.get('pp30|2026-05|d2')).not.toBeNull()
+
+    await vault.forget('subj-1')
+
+    // #761 item 4: forgetting d1 must reach the same-collection MV's manual-mode invalidation
+    // (a blanket, stamp-scoped purge of every row this MV emitted). Before the fix,
+    // `forgetDerivedFanout`'s MV arm never fired for this collection — `registry.edges()` drops
+    // the partition-disjoint same-collection edge — so BOTH stamped rows would survive forget()
+    // untouched, including d2's, which has nothing to do with the forgotten subject.
+    expect(await coll.get('pp30|2026-05|d1')).toBeNull()
+    expect(await coll.get('pp30|2026-05|d2')).toBeNull()
+    expect(await coll.get('d1')).toBeNull()
+    expect(await coll.get('d2')).not.toBeNull()
+  })
+
   it('forget × optional derivation with no emitted row: derivedRecordsErased counts only REAL erasures (#622 review Finding 1)', async () => {
     // RCT-TRIGGER-001-style optional output: the derivation edge exists (allocations →
     // receipts), but `derive` returns null for THIS record, so no receipt row was ever

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -2653,17 +2653,16 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         priorEnvelope: prior,
       })
     }
-    await this._doDelete(id, true)
-    return true
+    return await this._doDelete(id, true)
   }
 
-  private async _doDelete(id: string, internal: boolean): Promise<void> {
+  private async _doDelete(id: string, internal: boolean): Promise<boolean> {
     if (!hasWritePermission(this.keyring, this.name)) {
       throw new ReadOnlyError()
     }
     // #716: public deletes only — see assertTierWritable's doc + Step 5 investigation for `internal`.
     await assertTierWritable(this.adapter, this.vault, this.name, id, !internal && this.tiers !== null)
-    if (internal && this.tiers !== null && await liveRecordIsElevated(this.adapter, this.vault, this.name, id)) return // #718: internal cleanup treats an elevated record as nonexistent, same as tier-0 reads — skip, no marker; its derived state is the tier ops' job
+    if (internal && this.tiers !== null && await liveRecordIsElevated(this.adapter, this.vault, this.name, id)) return false // #718: internal cleanup treats an elevated record as nonexistent, same as tier-0 reads — skip, no marker, not counted as erased (#761 item 8)
 
     // Gate bus (Track A) — fires for ALL deletes (carrying `internal`), so a
     // gate handler can collect amendment changes on system-internal deletes
@@ -2744,7 +2743,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       // converges on pull (a bare adapter.delete is invisible to other pullers).
       // No-op if there is no live record to delete (already marked / shredded).
       const live = previousEnvelope
-      if (!live || isTombstone(live, this.storeCiphertext) || isDeleteMarker(live)) return
+      if (!live || isTombstone(live, this.storeCiphertext) || isDeleteMarker(live)) return false
       markerVersion = live._v + 1
       await this.adapter.put(this.vault, this.name, id, buildDeleteMarker(markerVersion, this.keyring.userId))
       this.markerIds.add(id) // #606: this id now carries a marker — the #589 continuity gate should consult it on re-create
@@ -2817,6 +2816,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       // removed from the store/cache above).
       if (existing) await this.dispatchRollupsOnDelete(id, existing.record)
     }
+    return true
   }
 
   /**
@@ -2925,9 +2925,10 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   /**
    * Mirror of {@link dispatchMaterializedViews} for the delete/forget path — no `_materializedFrom`
    * skip (record's gone); the `internal` gate at `_doDelete` is the recursion guard. Returns the
-   * row count TOMBSTONED across every eager MV sourced here (#638 T6 — `forgetDerivedFanout`'s
-   * `derivedRecordsErased`); lazy/manual MVs also purge their persisted output rows at rest
-   * (#736) — lazy persists a stale mark for cold-session recompute; manual serves empty until `refreshView()`.
+   * row count TOMBSTONED across EVERY MV sourced here (#638 T6 — `forgetDerivedFanout`'s
+   * `derivedRecordsErased`) — eager AND lazy/manual `invalidateMVAtRest` purges both contribute now
+   * (#761 item 1, previously eager-only); lazy persists a stale mark for cold-session recompute;
+   * manual serves empty until `refreshView()`.
    * @internal
    */
   async dispatchMaterializedViewsOnDelete(id: string): Promise<number> {
@@ -2954,7 +2955,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         if (staleHelpers === null) {
           staleHelpers = await import('../with-formula/materialized-views/stale.js')
         }
-        await staleHelpers.invalidateMVAtRest(this.materializedViewSource, reg, mode)
+        deleted += await staleHelpers.invalidateMVAtRest(this.materializedViewSource, reg, mode)
       }
     }
     return deleted

--- a/packages/hub/src/kernel/via/dispatch.ts
+++ b/packages/hub/src/kernel/via/dispatch.ts
@@ -309,11 +309,24 @@ export async function forgetDerivedFanout(
   stats: ForgetFanoutStats,
   lookupCompareKeys: ReadonlyMap<string, string | undefined>,
 ): Promise<void> {
-  const edges = vault.graph.derivedArtifactsOf(ref.collection)
-  if (edges.length === 0) return
-
   const coll = vault._getCollection(ref.collection)
-  if (!coll) return
+
+  // #761 item 4 — drive the MV arm off `dispatchMaterializedViewsOnDelete` UNCONDITIONALLY,
+  // ABOVE the `edges` check below: `registry.edges()` drops the same-collection
+  // partition-disjoint MV edge (registry.ts's `sources.length === 0 → continue`), so a
+  // same-collection MV's source collection never appears in `vault.graph`'s derived-artifact
+  // edges even though the MV IS registered — forget() would otherwise never reach it.
+  // `dispatchMaterializedViewsOnDelete` self-guards O(1) via `mvsForSource` (a no-op when
+  // this collection isn't an MV source), so this is safe to call unconditionally. Safe to
+  // route through the eager executor's tombstone leg ONLY because that leg is now
+  // stamp-scoped (#762) — before that fix this would have opened a NEW forget-time
+  // data-loss path into the unscoped tombstone diff.
+  if (coll) {
+    stats.recordsErased += await coll.dispatchMaterializedViewsOnDelete(ref.id)
+  }
+
+  const edges = vault.graph.derivedArtifactsOf(ref.collection)
+  if (edges.length === 0 || !coll) return
 
   // #650 Task 5 (#648) — 'ref' cascade/nullify propagate ADDITIVELY, here, AFTER the shred
   // (restrict already refused BEFORE any shred — the caller's pre-tombstone check, spec §4).
@@ -337,9 +350,6 @@ export async function forgetDerivedFanout(
     stats.lookupReferencesResidue.push(...residue)
   }
 
-  if (edges.some((e) => e.kind === 'mv')) {
-    stats.recordsErased += await coll.dispatchMaterializedViewsOnDelete(ref.id)
-  }
   if (edges.some((e) => e.kind === 'derivation')) {
     // #622 review Finding 1: count REAL erasures (dispatchArrayDerivationsOnDelete's own
     // `_internalDelete`-backed tally), not the derivation EDGE count — an edge exists whenever

--- a/packages/hub/src/with-formula/materialized-views/executor.ts
+++ b/packages/hub/src/with-formula/materialized-views/executor.ts
@@ -324,6 +324,21 @@ export const MaterializedViewExecutor = {
       const priorIds = await listOutputIds(outputColl)
       for (const priorId of priorIds) {
         if (newIds.has(priorId)) continue
+        // #762 — a same-collection partition MV (`output: { collection: <source>, partition }`,
+        // the DERIV-PP30-001 shape) writes INTO its own source collection, so `listOutputIds`
+        // also returns untouched USER source rows here. Decode each candidate and only
+        // tombstone rows THIS MV stamped via `_materializedFrom.mvName` — the exact discipline
+        // `invalidateMVAtRest` uses (stale.ts:151-162). An unstamped row, or one stamped by a
+        // different MV, is never this MV's to delete.
+        const priorEnvelope = await adapter.get(vaultName, reg.outputCollection, priorId)
+        if (priorEnvelope === null) continue
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const priorDecoded = await (outputColl as any)._decodeEnvelope(priorEnvelope, priorId)
+        const priorStampedBy =
+          priorDecoded !== null && typeof priorDecoded === 'object'
+            ? (priorDecoded as Record<string, unknown>)._materializedFrom as { mvName?: string } | undefined
+            : undefined
+        if (priorStampedBy?.mvName !== spec.name) continue
         try {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const outAny = outputColl as any

--- a/packages/hub/src/with-formula/materialized-views/stale.ts
+++ b/packages/hub/src/with-formula/materialized-views/stale.ts
@@ -130,16 +130,21 @@ async function hydratePersistedStaleMarkers(accessor: MVStaleAccessor, registry:
  * so another registered MV sharing this output collection keeps its own rows intact:
  * no cross-MV re-marking is needed here, only `reg` itself is marked stale.
  *
+ * Returns the count of rows actually `_internalDelete`d (#761 item 1) — folded by the
+ * caller into `dispatchMaterializedViewsOnDelete`'s `deleted` so `ForgetResult.derivedRecordsErased`
+ * counts lazy/manual purges too, not just the eager executor's tombstone leg.
+ *
  * @internal
  */
 export async function invalidateMVAtRest(
   accessor: MVStaleAccessor,
   reg: RegisteredMV,
   mode: 'lazy' | 'manual',
-): Promise<void> {
+): Promise<number> {
   const outputColl = accessor.getCollection(reg.outputCollection)
   const txCtx = accessor.getActiveTxContext()
   const { adapter, vault } = storeOf(accessor, reg.outputCollection)
+  let deleted = 0
   for (const id of await adapter.list(vault, reg.outputCollection)) {
     // A same-collection partition MV (`output: { collection: <source>, partition }`,
     // the DERIV-PP30-001 shape) writes INTO its own source collection — `adapter.list`
@@ -158,7 +163,7 @@ export async function invalidateMVAtRest(
         : undefined
     if (stampedBy?.mvName !== reg.spec.name) continue
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (outputColl as any)._internalDelete(id, txCtx)
+    if (await (outputColl as any)._internalDelete(id, txCtx)) deleted++
   }
 
   // `mode: 'manual'` gets the purge only (erasure wins, no auto-recompute promise);
@@ -170,6 +175,7 @@ export async function invalidateMVAtRest(
     markMVStale(registry, reg.spec.name)
     await writeMVStaleMarker(adapter, vault, reg.spec.name)
   }
+  return deleted
 }
 
 /**


### PR DESCRIPTION
Closes #762. Closes #761. Milestone-34 MV/derivation candor set. Plan: `docs/superpowers/plans/2026-07-18-mv-candor-arc-d.md`. Three commits in a **mandatory order** (a correctness constraint — see below).

## Commit 1 — #762 (priority-high DATA LOSS)

The eager MV executor's `onEmpty:'delete'` tombstone-diff used `listOutputIds` with no ownership filter, so for a **same-collection partition MV** it tombstoned USER source rows on every refresh (ordinary `delete()`, source write, lazy read, `refreshView`). Now it decodes each candidate and tombstones only rows stamped `_materializedFrom.mvName === spec.name` — the exact discipline `invalidateMVAtRest` already uses. (RED: an ordinary `delete()` wiping a sibling user row — reproduced, fixed.)

## Commit 2 — #761 item 4 (erasure gap; ordering-critical, AFTER commit 1)

`forgetDerivedFanout` gated its MV arm on `vault.graph` edges, but `registry.edges()` drops the partition-disjoint same-collection edge — so `forget()` never invalidated a same-collection MV, and its output row retained the forgotten subject's contribution at rest. Now it fires `dispatchMaterializedViewsOnDelete` unconditionally (self-guards O(1)). **Safe only because commit 1 scoped the tombstone leg** — reversing the order would route forget into the unscoped diff and wipe user rows (documented at the call site). (RED reproduced, fixed.)

## Commit 3 — #761 items 1 + 8 (candor accounting)

- **Item 1:** `invalidateMVAtRest` returns its purge count → folded into `ForgetResult.derivedRecordsErased`, which previously ignored lazy/manual purges.
- **Item 8:** `_doDelete` → `Promise<boolean>` (returns `false` at the #718 elevated-skip, before any deletion) so a skipped elevated row no longer over-reports as erased. Also improves the already-tombstoned re-delete count.

## Verification

Full hub suite green (4327); typecheck / lint / `check:architecture` clean; `collection.ts` at **4548/4549** (funded in place, no bump); `vault.ts` untouched. Changeset `mv-candor.md` (hub patch) local-only.

## Review trail & follow-ups

Whole-arc review **Approved** — ownership decode verified (no under-delete of stale MV rows, no user-row wipe), ordering constraint verified real-and-satisfied, item-6 split verified to introduce no new silent hole. Item 2 (manual-sibling survival) landed as a test. Follow-ups filed: **#776** (item 6 undecodable-stamped residue notice — split at the ceiling; + the eager leg's honest-count extension), **#777** (same-collection Query-form MV self-perpetuation — pre-existing, eager-ordinary-delete path). Items 3/7/9 remain deferred per the plan.