### PR TITLE
fix(hub): describe-extraction preview parity + putAtTier search-compensation resilience (#772, #774)

### DIFF
--- a/packages/hub/__tests__/describe-extraction.test.ts
+++ b/packages/hub/__tests__/describe-extraction.test.ts
@@ -15,6 +15,7 @@ import { ref } from '../src/kernel/refs.js'
 import { ConflictError } from '../src/kernel/errors.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
 import { describeExtraction } from '../src/with-cargo/describe-extraction.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
 
 function memory(): NoydbStore {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -143,5 +144,38 @@ describe('describeExtraction', () => {
   it('is exported from the @noy-db/hub/bundle subpath', async () => {
     const mod = await import('../src/legacy/bundle.js')
     expect(typeof mod.describeExtraction).toBe('function')
+  })
+
+  /**
+   * #772: pre-fix, describeExtraction destructured only `{ closure, graph }`
+   * from walkClosure and never surfaced `danglingRefs` — a parent excluded by
+   * #759's elevated-parent skip (e.g. `clients`) gave the preview ZERO signal
+   * that `extractPartition` would later report a dangling FK. Mirrors the
+   * walk-closure.test.ts / extract-partition.test.ts #759 scenario.
+   */
+  it('#772: surfaces danglingRefs for a tier-elevated outbound FK parent excluded from the preview', async () => {
+    const tieredDb = await createNoydb({
+      store: memory(), user: 'alice', secret: 'test-passphrase-1234', tiersStrategy: withTiers(),
+    })
+    const company = await tieredDb.openVault('demo-co')
+    const clients = company.collection<Client>('clients', { tiers: [0, 1] })
+    const bills = company.collection<Bill>('bills', { refs: { clientId: ref('clients') } })
+
+    await clients.putAtTier('c-1', { id: 'c-1', name: 'Redacted Co', operatorUserId: 'belle' }, 0)
+    await bills.put('b-1', { id: 'b-1', clientId: 'c-1', amount: 10 })
+    // Elevate the parent AFTER the FK is established — c-1 is now invisible
+    // to the tier-gated read surface, same as the #759 extraction scenario.
+    await clients.elevate('c-1', 1)
+
+    const preview = await describeExtraction(company, {
+      seeds: { bills: () => true },
+    })
+
+    // The elevated parent never appears in byCollection at all — the ONLY
+    // signal an FK will dangle is danglingRefs.
+    expect(preview.byCollection.map((c) => c.name)).toEqual(['bills'])
+    expect(preview.danglingRefs).toEqual([
+      { collection: 'bills', id: 'b-1', field: 'clientId', target: 'clients', targetId: 'c-1', reason: 'elevated' },
+    ])
   })
 })

--- a/packages/hub/__tests__/extract-partition.test.ts
+++ b/packages/hub/__tests__/extract-partition.test.ts
@@ -321,7 +321,7 @@ describe('extractPartition — #759: elevated FK parent is excluded with a dangl
     })
 
     expect(danglingRefs).toEqual([
-      { collection: 'invoices', id: 'inv-1', field: 'clientId', target: 'clients', targetId: 'c-1' },
+      { collection: 'invoices', id: 'inv-1', field: 'clientId', target: 'clients', targetId: 'c-1', reason: 'elevated' },
     ])
 
     const { dumpJson } = await readNoydbBundle(bundleBytes)

--- a/packages/hub/__tests__/search-compensation-residue.test.ts
+++ b/packages/hub/__tests__/search-compensation-residue.test.ts
@@ -185,3 +185,43 @@ describe('#764 (b) elevate()/demote() surface a stuck compensation as residue, n
     expect(await docs.get('e1')).toEqual({ id: 'e1', body: 'topsecret-beta' })
   })
 })
+
+describe('#774 putAtTier() has the same resilience as elevate()/demote()', () => {
+  it('putAtTier(tier>0) completes the write (put lands, cross-tier event fires) and returns searchResidue: true instead of throwing', async () => {
+    const store = readOnlyFtindexDelete(memoryStore())
+    const db = await createNoydb({
+      store, user: 'owner', secret: SECRET,
+      searchStrategy: withSearch(), tiersStrategy: withTiers(),
+    })
+    const vault = await db.openVault('v1')
+    const events: CrossTierAccessEvent[] = []
+    vault.onCrossTierAccess((e) => events.push(e))
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, textIndexes: ['body'], textIndexPersist: true,
+    })
+
+    await docs.put('e1', { id: 'e1', body: 'topsecret-alpha' })
+    await docs.flushIndex()
+
+    // Pre-#774 putAtTier's own unwrapped `ctx.syncSearch` call threw the raw
+    // adapter error mid-flight — after the record put but before the
+    // cross-tier emit / syncHistory / syncBlobs. It must now resolve, with
+    // the write fully completed, mirroring elevate()/demote()'s #764 fix.
+    await expect(docs.putAtTier('e1', { id: 'e1', body: 'topsecret-alpha-v2' }, 1))
+      .resolves.toEqual({ searchResidue: true })
+
+    // The record actually moved: the raw envelope carries the new tier.
+    const env = await store.get('v1', 'docs', 'e1')
+    expect(env?._tier).toBe(1)
+
+    // The cross-tier `put` event (emitted AFTER syncSearch, BEFORE
+    // syncHistory/syncBlobs) fired — proves execution ran past the search
+    // catch instead of aborting at syncSearch.
+    const putEv = events.find((e) => e.op === 'put')
+    expect(putEv).toMatchObject({ id: 'e1', tier: 1, authorization: 'inherent' })
+
+    // getAtTier still resolves the record's content at the new tier — proves
+    // syncHistory/syncBlobs (which run LAST) didn't themselves throw either.
+    expect(await docs.getAtTier('e1')).toEqual({ id: 'e1', body: 'topsecret-alpha-v2' })
+  })
+})

--- a/packages/hub/__tests__/tiers-derived.test.ts
+++ b/packages/hub/__tests__/tiers-derived.test.ts
@@ -641,7 +641,7 @@ describe('#722 whole-branch review: pre-move decode must be tier-aware (not just
 
     // putAtTier's OWN pre-write decode of the pre-existing tier-1 envelope
     // is the buggy site under test here.
-    await expect(sales.putAtTier('s1', { id: 's1', buyerId: 'b1', total: 150 }, 2)).resolves.toBeUndefined()
+    await expect(sales.putAtTier('s1', { id: 's1', buyerId: 'b1', total: 150 }, 2)).resolves.toEqual({ searchResidue: false })
 
     expect((await buyers.get('b1'))?.totalSpent).toBe(200)
   })
@@ -747,6 +747,6 @@ describe('#737 hasDerivedOutputs is source-grained', () => {
 
     // GREEN: source-grained — `docs` has no derivation of its own, so the
     // gated decode is skipped and the corrupted body is never read.
-    await expect(docs.putAtTier('d1', { id: 'd1', title: 'Renamed' }, 1)).resolves.toBeUndefined()
+    await expect(docs.putAtTier('d1', { id: 'd1', title: 'Renamed' }, 1)).resolves.toEqual({ searchResidue: false })
   })
 })

--- a/packages/hub/__tests__/walk-closure.test.ts
+++ b/packages/hub/__tests__/walk-closure.test.ts
@@ -213,7 +213,26 @@ describe('walkClosure', () => {
     expect([...(closure.get('bills') ?? [])]).toEqual(['b-1']) // child keeps its FK value
     expect(closure.get('clients')).toBeUndefined() // elevated parent NOT admitted
     expect(danglingRefs).toEqual([
-      { collection: 'bills', id: 'b-1', field: 'clientId', target: 'clients', targetId: 'c-1' },
+      { collection: 'bills', id: 'b-1', field: 'clientId', target: 'clients', targetId: 'c-1', reason: 'elevated' },
+    ])
+  })
+
+  it('#772: reports reason "missing" for a genuinely-absent outbound parent (no tiers involved)', async () => {
+    const company = await db.openVault('demo-co')
+    // 'warn' mode (not the default 'strict') so put() doesn't itself reject
+    // the dangling FK — we want to reach walkClosure's own detection.
+    const bills = company.collection<Bill>('bills', { refs: { clientId: ref('clients', 'warn') } })
+
+    // clientId references an id that was never created — no tier boundary,
+    // just a genuine data-integrity gap.
+    await bills.put('b-1', { id: 'b-1', clientId: 'c-ghost', amount: 10 })
+
+    const { danglingRefs } = await walkClosure(company, {
+      seeds: { bills: () => true },
+    })
+
+    expect(danglingRefs).toEqual([
+      { collection: 'bills', id: 'b-1', field: 'clientId', target: 'clients', targetId: 'c-ghost', reason: 'missing' },
     ])
   })
 

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -4435,8 +4435,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
 
   // ─── Hierarchical Access ──────────────────────────
 
-  /** tier-aware put — gated behind `tiersStrategy: withTiers()`. */
-  putAtTier(id: string, record: T, tier: number, opts?: { elevation?: { reason: string; fromTier: number }; source?: string; sourceTs?: string }): Promise<void> {
+  /** tier-aware put — gated behind `tiersStrategy: withTiers()`. `searchResidue: true` = stuck search compensation (#774, mirroring #764's elevate/demote posture); the write itself always completes. */
+  putAtTier(id: string, record: T, tier: number, opts?: { elevation?: { reason: string; fromTier: number }; source?: string; sourceTs?: string }): Promise<TierMoveResult> {
     return this.tiersStrategy.putAtTier(this.tiersContext(), id, record, tier, opts)
   }
 

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -375,7 +375,7 @@ export async function putAtTier<T>(
   record: T,
   tier: number,
   opts?: { elevation?: { reason: string; fromTier: number }; source?: string; sourceTs?: string },
-): Promise<void> {
+): Promise<TierMoveResult> {
   assertTiersEnabled(ctx)
   assertDeclaredTier(ctx, tier)
   assertTierAccess(ctx.keyring, ctx.name, tier)
@@ -456,8 +456,11 @@ export async function putAtTier<T>(
   // #721: search artifacts follow the same tier > 0 → purge / tier 0 →
   // re-embed law as syncIndexes above. No ordering dependency on syncCache —
   // the _ftindex rebuild is deferred to the next retrieve() and _vec re-embed
-  // reads `record` directly, not the cache.
-  await ctx.syncSearch(id, tier > 0 ? null : record, envelope._v)
+  // reads `record` directly, not the cache. #774: a permanently stuck
+  // compensation must not abort the write — the record put above already
+  // landed — so it is caught and surfaced as residue instead, same as
+  // elevate()/demote() (#764).
+  const searchResidue = await syncSearchResilient(ctx, id, tier > 0 ? null : record, envelope._v)
 
   if (tier > 0) {
     ctx.emitCrossTierEvent({
@@ -490,6 +493,7 @@ export async function putAtTier<T>(
     // #724: this putAtTier moved the record's tier — rehome its blobs too.
     await ctx.syncBlobs(id, existing?._tier ?? 0, tier)
   }
+  return { searchResidue }
 }
 
 /**

--- a/packages/hub/src/with-audit/tiers/strategy.ts
+++ b/packages/hub/src/with-audit/tiers/strategy.ts
@@ -18,7 +18,7 @@ export interface TiersStrategy {
     record: T,
     tier: number,
     opts?: { elevation?: { reason: string; fromTier: number }; source?: string; sourceTs?: string },
-  ): Promise<void>
+  ): Promise<TierMoveResult>
   getAtTier<T>(ctx: TiersContext<T>, id: string): Promise<T | GhostRecord | null>
   listAtTier<T>(ctx: TiersContext<T>): Promise<Array<{ id: string; tier: number; readable: boolean }>>
   elevate<T>(ctx: TiersContext<T>, id: string, toTier: number): Promise<TierMoveResult>

--- a/packages/hub/src/with-cargo/describe-extraction.ts
+++ b/packages/hub/src/with-cargo/describe-extraction.ts
@@ -7,7 +7,7 @@
  * @module
  */
 import type { Vault } from '../kernel/vault.js'
-import { walkClosure, type WalkClosureOptions } from './walk-closure.js'
+import { walkClosure, type WalkClosureOptions, type DanglingRefNotice } from './walk-closure.js'
 
 export interface ExtractionPreview {
   readonly totalRecords: number
@@ -24,13 +24,21 @@ export interface ExtractionPreview {
   readonly graph: { readonly depth: number; readonly cyclesDetected: boolean }
   /** Records the walk reached but whose envelope couldn't be read. */
   readonly inaccessible: ReadonlyArray<{ readonly collection: string; readonly id: string }>
+  /**
+   * #772: outbound FK edges whose referenced parent was excluded from the
+   * closure (missing, or tier-elevated and therefore invisible) — mirrors
+   * `ExtractPartitionResult.danglingRefs` (#759) so a preview/extract pair
+   * gives the SAME signal. A parent excluded this way never appears in
+   * `byCollection` at all; this is the only preview-time indicator.
+   */
+  readonly danglingRefs: ReadonlyArray<DanglingRefNotice>
 }
 
 export async function describeExtraction(
   vault: Vault,
   opts: WalkClosureOptions,
 ): Promise<ExtractionPreview> {
-  const { closure, graph } = await walkClosure(vault, opts)
+  const { closure, graph, danglingRefs } = await walkClosure(vault, opts)
 
   const { name: vaultName, adapter } = vault._introspectState()
   const encoder = new TextEncoder()
@@ -84,5 +92,6 @@ export async function describeExtraction(
     byCollection,
     graph,
     inaccessible,
+    danglingRefs,
   })
 }

--- a/packages/hub/src/with-cargo/walk-closure.ts
+++ b/packages/hub/src/with-cargo/walk-closure.ts
@@ -51,6 +51,12 @@ export interface DanglingRefNotice {
   readonly target: string
   /** Id of the missing/elevated parent. */
   readonly targetId: string
+  /**
+   * #772: distinguishes an intentional tier boundary (`'elevated'` — the
+   * parent exists but is above the caller's readable tier) from a genuine
+   * data-integrity gap (`'missing'` — no envelope for `targetId` at all).
+   */
+  readonly reason: 'missing' | 'elevated'
 }
 
 export interface ClosureResult {
@@ -109,7 +115,7 @@ export async function walkClosure(
     }
   }
 
-  const { refRegistry } = vault._introspectState()
+  const { refRegistry, adapter, name: vaultName } = vault._introspectState()
   const maxDepth = opts.maxDepth ?? 16
   let cyclesDetected = false
 
@@ -193,8 +199,15 @@ export async function walkClosure(
         const parentColl = vault.collection<Record<string, unknown>>(descriptor.target)
         const parentRecord = await parentColl.get(parentId)
         if (!parentRecord) {
+          // #772: a raw (tier-unaware) read distinguishes the two cases the
+          // tier-gated `Collection.get()` above collapses to the same null —
+          // an envelope present with `_tier > 0` is an intentional tier
+          // boundary; no envelope at all is a genuine data-integrity gap.
+          const rawParentEnv = await adapter.get(vaultName, descriptor.target, parentId)
+          const reason: 'missing' | 'elevated' =
+            rawParentEnv && (rawParentEnv._tier ?? 0) > 0 ? 'elevated' : 'missing'
           danglingRefs.push({
-            collection: collectionName, id, field, target: descriptor.target, targetId: parentId,
+            collection: collectionName, id, field, target: descriptor.target, targetId: parentId, reason,
           })
           continue
         }


### PR DESCRIPTION
Closes #772. Closes #774. Milestone-34 follow-ups.

- **#772** — the `describeExtraction` dry-run preview now surfaces `danglingRefs` (added by #759) with a `reason: 'missing' | 'elevated'` discriminant. A caller who previews a partition whose child FK-references an elevated/absent parent now sees the dangling ref, matching what `extractPartition` reports (both compute it from the same `walkClosure` call, so they can't drift). `reason` reads only ciphertext `_tier` metadata — no decrypt, zero-knowledge boundary intact.
- **#774** — `putAtTier()` routes its search-index purge through the same `syncSearchResilient` helper `elevate()`/`demote()` use (#764), so a permanently-stuck `PersistedIndexCompensationError` no longer aborts the write mid-flight; the record lands and the deferred purge is reported via `TierMoveResult { searchResidue }`. Verified the `vault.elevate(...).collection().put()` path inherits this for free (routes through the same `putAtTier`); a residual observability-only gap (that convenience path discards the residue signal) is filed separately.

## Verification

Both REDs reproduced (preview `danglingRefs` undefined; putAtTier abort on stuck compensation); full hub suite green (517 files / 4330); typecheck / lint / `check:architecture` clean; `collection.ts` 4548/4549, `vault.ts` untouched. Changeset local-only. Reviewed **Approved** (the `_elevatedPut` residual ruled a non-issue for the abort hazard).