### PR TITLE
fix(hub): decryptResponse unwraps the per-blob CEK, is tier-aware, verifies the content address — no silent substitution (#757)

### DIFF
--- a/packages/hub/__tests__/blob-set.test.ts
+++ b/packages/hub/__tests__/blob-set.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, NoydbBundleStore } from '../src/kernel/types.js'
-import { ConflictError, BundleVersionConflictError, ValidationError } from '../src/kernel/errors.js'
+import { ConflictError, BundleVersionConflictError, ValidationError, TamperedError } from '../src/kernel/errors.js'
 import { createNoydb } from '../src/kernel/noydb.js'
 import { withBlobs } from '../src/via/blob/index.js'
 import { withTeam } from '../src/with-party/team/index.js'
+import { encryptBytesWithAAD, type EnclaveKey } from '../src/kernel/enclave/index.js'
 import {
   BLOB_INDEX_COLLECTION,
   BLOB_CHUNKS_COLLECTION,
@@ -927,5 +928,92 @@ describe('detectMimeType', () => {
     expect(isPreCompressed('application/gzip')).toBe(true)
     expect(isPreCompressed('application/pdf')).toBe(false)
     expect(isPreCompressed('text/plain')).toBe(false)
+  })
+})
+
+// ─── #757: decryptResponse — CEK-aware, tier-aware, content-address verified ──
+
+describe('#757 decryptResponse()', () => {
+  let store: NoydbStore
+
+  beforeEach(() => {
+    store = makeStore()
+  })
+
+  it('round-trips an ERASABLE (perRecordKeys) blob — was broken (decrypt failure) before the _cek unwrap fix', async () => {
+    const db = await createNoydb({ store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const docs = vault.collection<{ id: string }>('docs', { perRecordKeys: true })
+    await docs.put('d1', { id: 'd1' })
+    const blobs = docs.blob('d1')
+    await blobs.put('file.bin', textBytes('erasable blob content'), { compress: false })
+
+    const info = (await blobs.blobInfo('file.bin'))!
+    expect(info._cek).toBeDefined() // confirms this is genuinely erasable (per-blob CEK), not the legacy flat path
+    expect(info.chunkCount).toBe(1)
+
+    // The caller-fetched ciphertext response, as `presignedUrl()` + a raw
+    // fetch would hand back — a JSON envelope of the raw chunk row.
+    const chunkEnv = await store.get(VAULT, BLOB_CHUNKS_COLLECTION, `${info.eTag}_0`)
+    const cipherResponse = new Response(JSON.stringify({ _iv: chunkEnv!._iv, _data: chunkEnv!._data }))
+
+    const plainResponse = await blobs.decryptResponse('file.bin', cipherResponse)
+    expect(plainResponse).not.toBeNull()
+    const recovered = new Uint8Array(await plainResponse!.arrayBuffer())
+    expect(new TextDecoder().decode(recovered)).toBe('erasable blob content')
+
+    db.close()
+  })
+
+  it('rejects a substituted ciphertext (correct key + correct AAD, wrong plaintext) with TamperedError instead of returning attacker bytes', async () => {
+    const db = await createNoydb({ store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const docs = vault.collection<{ id: string }>('docs') // legacy: no perRecordKeys — flat DEK IS the chunk key
+    await docs.put('d1', { id: 'd1' })
+    const blobs = docs.blob('d1')
+    await blobs.put('file.bin', textBytes('true secret bytes'), { compress: false })
+
+    const info = (await blobs.blobInfo('file.bin'))!
+    const victimETag = info.eTag
+
+    // Attacker: holds the flat `_blob` DEK (same threat model as the
+    // #747/#749 review I1 forged-row attack — any co-tenant/holder of the
+    // flat DEK with store write access) and crafts fresh ciphertext whose
+    // AAD matches the VICTIM's own eTag/chunkIndex/chunkCount, so AES-GCM
+    // auth alone can't distinguish it from an honest chunk — only
+    // content-address re-verification catches the plaintext substitution.
+    const getDEK = (vault as unknown as { getDEK(name: string): Promise<EnclaveKey> }).getDEK
+    const blobDEK = await getDEK('_blob')
+    const forgedAAD = new TextEncoder().encode(`${victimETag}:0:1`)
+    const { iv, data } = await encryptBytesWithAAD(textBytes('forged attacker bytes'), blobDEK, forgedAAD)
+    const forgedResponse = new Response(JSON.stringify({ _iv: iv, _data: data }))
+
+    await expect(blobs.decryptResponse('file.bin', forgedResponse)).rejects.toThrow(TamperedError)
+
+    db.close()
+  })
+
+  it('refuses a multi-chunk blob loudly (ValidationError) instead of silently decrypting/returning only chunk 0', async () => {
+    const db = await createNoydb({ store, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const docs = vault.collection<{ id: string }>('docs')
+    await docs.put('d1', { id: 'd1' })
+    const blobs = docs.blob('d1')
+    await blobs.put('file.bin', randomBytes(500), { compress: false, chunkSize: 128 })
+
+    const info = (await blobs.blobInfo('file.bin'))!
+    expect(info.chunkCount).toBe(4)
+
+    // presignedUrl() already refuses to mint a URL for this blob (chunkCount
+    // !== 1 → null); decryptResponse must refuse just as loudly if handed a
+    // ciphertext Response for it some other way.
+    expect(await blobs.presignedUrl('file.bin')).toBeNull()
+
+    const chunkEnv = await store.get(VAULT, BLOB_CHUNKS_COLLECTION, `${info.eTag}_0`)
+    const cipherResponse = new Response(JSON.stringify({ _iv: chunkEnv!._iv, _data: chunkEnv!._data }))
+
+    await expect(blobs.decryptResponse('file.bin', cipherResponse)).rejects.toThrow(ValidationError)
+
+    db.close()
   })
 })

--- a/packages/hub/__tests__/tiers-blobs.test.ts
+++ b/packages/hub/__tests__/tiers-blobs.test.ts
@@ -1372,6 +1372,35 @@ describe('#749 blob(id).atTier() — sanctioned cleared-read path', () => {
     expect(await docs.blob('d1').get('attachment')).toBeNull()
   })
 
+  it('#757: decryptResponse() on a cleared (atTier()) clone of an elevated record works with the tier DEK', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, secret: 'pw', user: 'owner',
+      tiersStrategy: withTiers(), blobStrategy: withBlobs(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, blobFields: { attachment: {} },
+    })
+
+    await docs.putAtTier('d1', { id: 'd1', title: 'Invoice', body: 'x' }, 0)
+    await docs.blob('d1').put('attachment', new TextEncoder().encode('cleared-view decryptResponse bytes'))
+    await docs.elevate('d1', 1)
+
+    // The uncleared (tier-0) surface refuses, same as get().
+    expect(await docs.blob('d1').decryptResponse('attachment', new Response('{}'))).toBeNull()
+
+    const cleared = await docs.blob('d1').atTier()
+    const info = (await cleared.blobInfo('attachment'))!
+    const chunkEnv = await store.get('v1', BLOB_CHUNKS_COLLECTION, `${info.eTag}_0`)
+    const cipherResponse = new Response(JSON.stringify({ _iv: chunkEnv!._iv, _data: chunkEnv!._data }))
+
+    const plainResponse = await cleared.decryptResponse('attachment', cipherResponse)
+    expect(plainResponse).not.toBeNull()
+    const recovered = new Uint8Array(await plainResponse!.arrayBuffer())
+    expect(new TextDecoder().decode(recovered)).toBe('cleared-view decryptResponse bytes')
+  })
+
   it('an ungranted operator session\'s atTier() rejects with TierNotGrantedError and mints no junk DEK', async () => {
     const db = await createNoydb({
       store: memoryStore(), secret: 'pw', user: 'owner',

--- a/packages/hub/src/with-shape/blobs/blob-set.ts
+++ b/packages/hub/src/with-shape/blobs/blob-set.ts
@@ -3015,22 +3015,63 @@ export class BlobSet {
     const result = await this.loadBlobObject(slot.eTag)
     if (!result) return null
 
-    // Parse the envelope from the ciphertext response
+    // #757: `presignedUrl()` only ever mints a URL (and this method only ever
+    // receives one caller-fetched ciphertext Response) for a single-chunk
+    // blob — a multi-chunk object can't be assembled from that one Response.
+    // Refuse loudly instead of silently decrypting/returning only chunk 0.
+    if (result.blob.chunkCount !== 1) {
+      throw new ValidationError(
+        `decryptResponse() does not support multi-chunk blobs (slot "${slotName}" has ` +
+          `${result.blob.chunkCount} chunks) — presignedUrl() only mints URLs for single-chunk blobs (#757)`,
+      )
+    }
+
+    // #757: tier-aware DEK, mirroring get()/response() post-#749 — the
+    // index envelope's `_cek` (if any) is wrapped under the tier that
+    // actually opened it (`result.atTier`), not necessarily this record's
+    // live/flat tier.
+    const blobDEK = this.encrypted ? await this.getDEK(dekKey(BLOB_COLLECTION, result.atTier)) : null
+    if (!blobDEK) {
+      return this.buildResponse(slot, result.blob, { inline: true })
+    }
+
+    // Parse the envelope from the caller-provided ciphertext response
     const text = await cipherResponse.text()
     const envelope = JSON.parse(text) as { _iv: string; _data: string }
 
-    const blobDEK = this.encrypted ? await this.getDEK('_blob') : null
-    if (!blobDEK) {
+    // #757: unwrap the per-blob content CEK when present (mirrors
+    // fetchAllChunks/resolveChunkKey) instead of decrypting chunk bytes
+    // directly under the flat DEK — an erasable (perRecordKeys) blob's
+    // chunks are never keyed that way.
+    const chunkKey = await this.resolveChunkKey(result.blob, blobDEK)
+    if (!chunkKey) {
+      // Unreachable: resolveChunkKey only returns null for an unencrypted
+      // vault, already handled by the blobDEK guard above.
       return this.buildResponse(slot, result.blob, { inline: true })
     }
 
     // Decrypt the single chunk
     const aad = chunkAAD(slot.eTag, 0, result.blob.chunkCount)
-    const { decryptBytesWithAAD: decryptAAD } = await import('../../kernel/enclave/index.js')
-    const decrypted = await decryptAAD(envelope._iv, envelope._data, blobDEK, aad)
+    const decrypted = await decryptBytesWithAAD(envelope._iv, envelope._data, chunkKey, aad)
     const plaintext = result.blob.compression === 'gzip'
       ? await decompressBytes(decrypted)
       : decrypted
+
+    // #757: content-address verification. Unlike the store-driven read
+    // paths, `decryptResponse` decrypts a CALLER-PROVIDED ciphertext (the
+    // `cipherResponse` a caller fetched from a presigned URL) — GCM auth
+    // alone doesn't catch a self-consistent forgery planted under a DEK the
+    // attacker also holds. Recompute the same content address every write
+    // path mints (`hmacSha256Hex(blobDEK, plaintext)` — `writeBlobContent`'s
+    // Step 1, unconditional on `_cek`; mirrors `fetchAllChunks`'s
+    // `verifyFlatETag` block) and refuse silently-wrong bytes.
+    const recomputed = await hmacSha256Hex(blobDEK, plaintext)
+    if (recomputed !== slot.eTag) {
+      throw new TamperedError(
+        `Blob content for eTag "${slot.eTag}" failed content-address verification in decryptResponse() ` +
+          '— the caller-provided ciphertext does not match the requested content address (#757)',
+      )
+    }
 
     const body = new ReadableStream<Uint8Array>({
       start(controller) {


### PR DESCRIPTION
Closes #757. Milestone-34 follow-up (pre-existing blob bug with a security dimension; surfaced during the #749 review).

## Problem

`BlobSet.decryptResponse()` decrypted chunks directly under the flat `_blob` DEK and never unwrapped `blob._cek`, so it was:
1. **Broken for every erasable blob** — `_cek`-bearing chunks are under a per-blob content CEK, not the flat DEK.
2. **Tier-blind** — used `getDEK('_blob')`, not the tier-scoped DEK.
3. **A silent substitution side door** — it decrypts *caller-provided* ciphertext (the `cipherResponse` arg) with no content-address check, so a flat-DEK holder could feed forged, self-consistent bytes (correct AAD, correct DEK) and have them returned as genuine content — the one blob read path #749's `verifyFlatETag` defense didn't cover.

## Fix

Mirrors the established `get()`/`fetchAllChunks` machinery exactly: `resolveChunkKey` (unwraps `_cek`); blob DEK resolved at the owner/cleared tier (`dekKey(BLOB_COLLECTION, atTier)` — cleared `atTier()` works, uncleared caller on an elevated record still returns null); and a content-address recheck — `hmacSha256Hex(blobDEK, plaintext)` vs the requested eTag → `TamperedError` on mismatch. Multi-chunk (which this single-Response API can't carry) is refused loudly, matching `presignedUrl()`.

## Verification

Both REDs reproduced (erasable-blob decrypt failure; silent substitution returning attacker bytes); full hub suite green (517 files / 4334); typecheck / lint / `check:architecture` clean (no new raw-envelope reads). Changeset local-only. Reviewed **Approved** — the security crux (verification DEK matches the eTag-minting DEK) traced to `writeBlobContent` and confirmed correct-by-construction.