### PR TITLE
fix(hub): MV self-perpetuation fix + erasure candor (#777, #776)

### DIFF
--- a/packages/hub/__tests__/materialized-views/correctness.test.ts
+++ b/packages/hub/__tests__/materialized-views/correctness.test.ts
@@ -11,6 +11,7 @@ import {
 import { withAggregate } from '../../src/with-lookup/aggregate/index.js'
 import { sum, count } from '../../src/with-lookup/aggregate/reducers.js'
 import { withTransactions } from '../../src/with-commit/tx/index.js'
+import { withTiers } from '../../src/with-audit/tiers/index.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../src/kernel/types.js'
 
 function memory(): NoydbStore {
@@ -228,6 +229,47 @@ describe('MV correctness (#152)', () => {
       const second = await vault.refreshView('red-items')
       expect(second.written).toBe(1) // 'b' re-emitted
       expect(second.deleted).toBe(1) // 'a' tombstoned
+    })
+
+    it('tombstone leg counts honestly: a #718 elevated-skip on the output row is NOT counted as deleted (#776 part b)', async () => {
+      // The tombstone loop uses `_internalDelete`, which returns `false` (no
+      // erasure) when the target record is elevated above tier 0 on a tiered
+      // collection (#718). Before the fix, the loop still incremented
+      // `deleted` unconditionally after calling it.
+      const mv = withMaterializedView<Item>({
+        name: 'red-items',
+        query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+        rowKey: (r) => r.id,
+        refresh: 'manual',
+        output: { collection: 'red-items-out' },
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-776b-eager-count-passphrase-2026',
+        tiersStrategy: withTiers(),
+        materializedViewStrategies: [mv],
+      })
+      const vault = await db.openVault('demo')
+      // Declare tiers on the OUTPUT collection BEFORE the first refresh
+      // constructs it untiered (first-construction-wins, same discipline as
+      // tiers-derived.test.ts / mv-tier-staleness.test.ts).
+      const out = vault.collection<Item>('red-items-out', { tiers: [0, 1], perRecordKeys: true })
+      await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+      const first = await vault.refreshView('red-items')
+      expect(first.written).toBe(1)
+
+      // Elevate the OUTPUT row directly — same session, so the executor's
+      // ownership decode below still succeeds (the CEK cache is warm from the
+      // elevate call itself), but `_internalDelete` is #718-gated.
+      await out.elevate('a', 1)
+
+      // Flip the source's tag so it no longer matches the MV's filter — the
+      // next refresh must attempt to tombstone the (now-elevated) output row.
+      await vault.collection<Item>('items').put('a', { id: 'a', tag: 'blue' })
+      const second = await vault.refreshView('red-items')
+
+      expect(second.deleted).toBe(0) // #776 part b — the over-count RED this test pins
     })
   })
 

--- a/packages/hub/__tests__/materialized-views/correctness.test.ts
+++ b/packages/hub/__tests__/materialized-views/correctness.test.ts
@@ -348,6 +348,41 @@ describe('MV correctness (#152)', () => {
       expect((await coll.get('d2'))?.amount).toBe(500)
     })
 
+    it('does not self-perpetuate: a stale stamped output row is excluded from the MV\'s own input scan (#777)', async () => {
+      // Same-collection Query-form MV whose input filter is on a field DISJOINT
+      // from the partition field ('type'). The output row is a VERBATIM copy of
+      // the source row, so it still carries `type: 'vatSales'` — meaning it
+      // itself satisfies the MV's own input filter. A fixed rowKey means the
+      // recomputed id always lands on the SAME output row. Before the fix, once
+      // the true source (d1) is deleted, the next eager refresh's input scan
+      // still picks up the stale stamped output row (it matches the filter),
+      // re-derives it under the same id, and it lands back in `newIds` — the
+      // row survives the tombstone diff and self-perpetuates forever.
+      const mv = withMaterializedView<Disbursement>({
+        name: 'vatSales-summary',
+        query: (db) => db.collection<Disbursement>('disbursements').query().where('type', '==', 'vatSales'),
+        rowKey: () => 'summary',
+        refresh: 'eager',
+        output: { collection: 'disbursements', partition: { field: 'type', value: 'pp30' } },
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-777-self-perpetuation-passphrase-2026',
+        materializedViewStrategies: [mv],
+      })
+      const vault = await db.openVault('demo')
+      const coll = vault.collection<Disbursement>('disbursements')
+      await coll.put('d1', { id: 'd1', type: 'vatSales', period: '2026-05', amount: 1000 })
+      expect(await coll.get('summary')).not.toBeNull()
+
+      // Delete the true source. The next eager refresh must NOT re-select the
+      // stale stamped 'summary' output row as if it were live source input.
+      await coll.delete('d1')
+
+      expect(await coll.get('summary')).toBeNull() // #777 — the self-perpetuation RED this test pins
+    })
+
     it('manual MV sharing an output collection with an invalidated sibling keeps its rows (#761 item 2)', async () => {
       interface Order extends Record<string, unknown> { id: string; amount: number }
       interface Invoice extends Record<string, unknown> { id: string; amount: number }

--- a/packages/hub/__tests__/via/forget-fanout.test.ts
+++ b/packages/hub/__tests__/via/forget-fanout.test.ts
@@ -11,6 +11,7 @@ import { createNoydb, withRollup, withMaterializedView, withDerivation } from '.
 import { withForgetCascade } from '../../src/with-audit/forget/index.js'
 import { withHistory } from '../../src/with-commit/history/index.js'
 import { withPeriods } from '../../src/with-audit/periods/index.js'
+import { withTiers } from '../../src/with-audit/tiers/index.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../src/kernel/types.js'
 
 function memory(): NoydbStore {
@@ -285,20 +286,63 @@ describe('forget() fanout to derived residue (#622)', () => {
     expect(result.lookupReferencesCascaded).toBe(0)
     expect(result.lookupReferencesNullified).toBe(0)
     expect(result.lookupReferencesResidue).toEqual([])
+    // Additive #776 field defaults to empty when nothing was undecodable.
+    expect(result.derivedResidueUndecodable).toEqual([])
     // Snapshot the full key set — a byte-shape regression on an EXISTING field
     // would silently pass value assertions above but fail this key list.
     // #650 Task 5 — lookupReferencesCascaded/lookupReferencesNullified are new,
     // additive fields (see lookup-forget-ref.test.ts); lookupReferencesResidue is
-    // additive too (#650 Task 5 review, Important fix); every pre-existing key
-    // below is unchanged.
+    // additive too (#650 Task 5 review, Important fix); derivedResidueUndecodable
+    // is additive too (#776); every pre-existing key below is unchanged.
     expect(Object.keys(result).sort()).toEqual([
       'blobResidueCollections', 'blobsRetainedShared', 'blobsShredded', 'collections',
-      'derivedAggregatesRecomputed', 'derivedRecordsErased', 'derivedResidueFrozen',
+      'derivedAggregatesRecomputed', 'derivedRecordsErased', 'derivedResidueFrozen', 'derivedResidueUndecodable',
       'historyVersionsShredded', 'indexPostingsPurged', 'indexResidue', 'ledgerDeltaResidue',
       'ledgerDeltasPurged', 'ledgerEntry',
       'lookupReferencesCascaded', 'lookupReferencesNullified', 'lookupReferencesResidue',
       'recordsShredded', 'scopedPurgeResidue', 'sealedCekEnvelopesPurged', 'sealedCekResidue', 'sealedFieldsShredded',
       'sealedResidue', 'subject', 'unmigratedRecords',
     ])
+  })
+
+  it('forget × lazy MV with a TIERED output: an elevated, undecodable output row is surfaced as residue, not silently skipped (#776 part a)', async () => {
+    interface Person extends Record<string, unknown> { id: string; subjectId: string; name: string }
+    const mv = withMaterializedView<Person>({
+      name: 'people-mirror-tiered',
+      query: (db) => db.collection<Person>('people').query(),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const store = memory()
+    const open = async () => {
+      const db = await createNoydb({
+        store, user: 'alice', secret: 'forget-fanout-776a-passphrase-2026',
+        materializedViewStrategies: [mv],
+        historyStrategy: withHistory(),
+        forgetStrategy: withForgetCascade({ subjects: { people: 'subjectId' } }),
+        tiersStrategy: withTiers(),
+      })
+      const vault = await db.openVault('firm')
+      // Declare tiers on the OUTPUT collection BEFORE the first lazy
+      // materialize constructs it untiered (first-construction-wins).
+      const mirror = vault.collection<Person>('people-mirror-tiered', { tiers: [0, 1], perRecordKeys: true })
+      return { vault, people: vault.collection<Person>('people'), mirror }
+    }
+
+    const { people, mirror } = await open()
+    await people.put('p1', { id: 'p1', subjectId: 'subj-1', name: 'Ada' })
+    expect(await mirror.get('p1')).not.toBeNull() // materialize (lazy resolve-on-read)
+
+    // Elevate the OUTPUT row directly.
+    await mirror.elevate('p1', 1)
+
+    // Cold session (fresh cekCache) — the ownership decode genuinely fails now.
+    const { vault: coldVault } = await open()
+    const result = await coldVault.forget('subj-1')
+
+    // Ownership unconfirmed (undecodable) → NOT deleted, NOT counted as erased...
+    expect(result.derivedRecordsErased).toBe(0)
+    // ...but surfaced, not silently skipped (the #724 posture).
+    expect(result.derivedResidueUndecodable).toEqual(['people-mirror-tiered:p1'])
   })
 })

--- a/packages/hub/__tests__/via/lookup-forget-ref.test.ts
+++ b/packages/hub/__tests__/via/lookup-forget-ref.test.ts
@@ -222,7 +222,7 @@ describe('forget() × lookup ref semantics (#650 Task 5, fixes #648)', () => {
     // strictly additive to the existing set.
     expect(Object.keys(result).sort()).toEqual([
       'blobResidueCollections', 'blobsRetainedShared', 'blobsShredded', 'collections',
-      'derivedAggregatesRecomputed', 'derivedRecordsErased', 'derivedResidueFrozen',
+      'derivedAggregatesRecomputed', 'derivedRecordsErased', 'derivedResidueFrozen', 'derivedResidueUndecodable',
       'historyVersionsShredded', 'indexPostingsPurged', 'indexResidue', 'ledgerDeltaResidue',
       'ledgerDeltasPurged', 'ledgerEntry',
       'lookupReferencesCascaded', 'lookupReferencesNullified', 'lookupReferencesResidue',

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -2928,17 +2928,16 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    * row count TOMBSTONED across EVERY MV sourced here (#638 T6 — `forgetDerivedFanout`'s
    * `derivedRecordsErased`) — eager AND lazy/manual `invalidateMVAtRest` purges both contribute now
    * (#761 item 1, previously eager-only); lazy persists a stale mark for cold-session recompute;
-   * manual serves empty until `refreshView()`.
+   * manual serves empty until `refreshView()`. `residue` (#776) carries `outputCollection:id` entries whose ownership stamp `invalidateMVAtRest` could not decode — surfaced, not erased.
    * @internal
    */
-  async dispatchMaterializedViewsOnDelete(id: string): Promise<number> {
-    if (this.materializedViewSource === undefined) return 0
+  async dispatchMaterializedViewsOnDelete(id: string): Promise<{ deleted: number; residue: string[] }> {
+    if (this.materializedViewSource === undefined) return { deleted: 0, residue: [] }
     const registry = this.materializedViewSource.registry()
     const mvs = registry.mvsForSource(this.name)
-    if (mvs.length === 0) return 0
-    let executor: typeof MVExecutorType | null = null
-    let staleHelpers: typeof MVStaleModule | null = null
-    let deleted = 0
+    if (mvs.length === 0) return { deleted: 0, residue: [] }
+    let executor: typeof MVExecutorType | null = null; let staleHelpers: typeof MVStaleModule | null = null
+    let deleted = 0; const residue: string[] = []
     for (const reg of mvs) {
       const mode = reg.spec.refresh
       if (mode === 'eager') {
@@ -2955,10 +2954,11 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         if (staleHelpers === null) {
           staleHelpers = await import('../with-formula/materialized-views/stale.js')
         }
-        deleted += await staleHelpers.invalidateMVAtRest(this.materializedViewSource, reg, mode)
+        const inv = await staleHelpers.invalidateMVAtRest(this.materializedViewSource, reg, mode)
+        deleted += inv.deleted; residue.push(...inv.residue.map((rid) => `${reg.outputCollection}:${rid}`))
       }
     }
-    return deleted
+    return { deleted, residue }
   }
 
   /**

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -2299,7 +2299,7 @@ export class Vault {
     const sealedCekResidue: string[] = []; const sealedResidue: string[] = []; const indexResidue: string[] = []; const ledgerDeltaResidue: string[] = []
     const blobsEnabled = this.blobStrategy !== undefined
     const actor = this.keyring.userId
-    const fanoutStats: ForgetFanoutStats = { recordsErased: 0, aggregatesRecomputed: 0, residueFrozen: [], lookupReferencesCascaded: 0, lookupReferencesNullified: 0, lookupReferencesResidue: [] }
+    const fanoutStats: ForgetFanoutStats = { recordsErased: 0, aggregatesRecomputed: 0, residueFrozen: [], lookupReferencesCascaded: 0, lookupReferencesNullified: 0, lookupReferencesResidue: [], derivedResidueUndecodable: [] }
     // #633 — scoped-purge per-collection skip accumulators (empty under the unconditional default); lazy (S4 gate: kernel spine → with-* service via dynamic import()).
     const { partitionSealedCekKeys, shouldSkipBlobScan, bumpResidueCount, residueNoticesFromMap } = await import('../with-audit/forget/purge-scope.js')
     const scopedPurge = this.forgetStrategy.scopedPurge === true
@@ -2495,6 +2495,7 @@ export class Vault {
       derivedAggregatesRecomputed: fanoutStats.aggregatesRecomputed,
       derivedResidueFrozen: fanoutStats.residueFrozen,
       lookupReferencesCascaded: fanoutStats.lookupReferencesCascaded, lookupReferencesNullified: fanoutStats.lookupReferencesNullified, lookupReferencesResidue: fanoutStats.lookupReferencesResidue, scopedPurgeResidue, ledgerDeltasPurged, ledgerDeltaResidue, // #650 Task 5 (+ review Important fix: residue) + #633 + #734
+      derivedResidueUndecodable: fanoutStats.derivedResidueUndecodable, // #776
     }
   }
 

--- a/packages/hub/src/kernel/via/dispatch.ts
+++ b/packages/hub/src/kernel/via/dispatch.ts
@@ -284,6 +284,11 @@ export interface ForgetFanoutStats {
    *  skipped for these, reported here so the skip is never silent. `backing:key:collection.field`
    *  entries, one per un-propagated edge. */
   readonly lookupReferencesResidue: string[]
+  /** #776 — `outputCollection:id` MV-output rows whose `_materializedFrom` ownership stamp
+   *  `invalidateMVAtRest` could not decode (undecodable under the default DEK — e.g. elevated
+   *  above tier 0 on a tiered output collection). Never erased (ownership unconfirmed), but
+   *  surfaced here rather than silently skipped. */
+  readonly derivedResidueUndecodable: string[]
 }
 
 /**
@@ -322,7 +327,9 @@ export async function forgetDerivedFanout(
   // stamp-scoped (#762) — before that fix this would have opened a NEW forget-time
   // data-loss path into the unscoped tombstone diff.
   if (coll) {
-    stats.recordsErased += await coll.dispatchMaterializedViewsOnDelete(ref.id)
+    const mv = await coll.dispatchMaterializedViewsOnDelete(ref.id)
+    stats.recordsErased += mv.deleted
+    stats.derivedResidueUndecodable.push(...mv.residue)
   }
 
   const edges = vault.graph.derivedArtifactsOf(ref.collection)

--- a/packages/hub/src/with-audit/forget/strategy.ts
+++ b/packages/hub/src/with-audit/forget/strategy.ts
@@ -177,6 +177,13 @@ export interface ForgetResult {
    *  Always empty under the unconditional default. Non-empty means a `_sealed_cek` entry or a
    *  blob scan was skipped for an undeclared collection — reported, never a silent skip. */
   readonly scopedPurgeResidue: readonly ScopedPurgeResidueNotice[]
+  /** #776 — `collection:id` MV-output rows whose `_materializedFrom` ownership stamp could NOT
+   *  be decoded during erasure invalidation (undecodable under the collection's default DEK —
+   *  e.g. elevated above tier 0 on a tiered output collection). Never erased (ownership
+   *  unconfirmed — could be a plain user record on a same-collection partition MV), but
+   *  surfaced here rather than silently skipped (the #724 posture). Non-empty means the row may
+   *  still hold the forgotten/pre-elevation contribution, decryptable by tier-holders. */
+  readonly derivedResidueUndecodable: readonly string[]
 }
 
 /** #633 — the two `scopedPurgeResidue` skip reasons. Single source of truth: `purge-scope.ts`

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -318,7 +318,7 @@ function isElevatorOrOwner<T>(ctx: TiersContext<T>): boolean {
  * structurally — no cast needed at the `tiersContext()` call site).
  */
 export interface DerivedOutputsHost<T> {
-  dispatchMaterializedViewsOnDelete(id: string): Promise<number>
+  dispatchMaterializedViewsOnDelete(id: string): Promise<{ deleted: number; residue: string[] }>
   dispatchArrayDerivationsOnDelete(id: string, eraseRecordShapeToo?: boolean): Promise<number>
   dispatchRollupsOnDelete(id: string, deleted: T): Promise<unknown>
   /** Task 2 (#722) add-direction: the same local-write dispatchers an ordinary `put()` fires. */

--- a/packages/hub/src/with-formula/materialized-views/executor.ts
+++ b/packages/hub/src/with-formula/materialized-views/executor.ts
@@ -355,8 +355,10 @@ export const MaterializedViewExecutor = {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const outAny = outputColl as any
           if (typeof outAny._internalDelete === 'function') {
-            await outAny._internalDelete(priorId, txCtx)
-            deleted++
+            // #776 part b — gate on the boolean, matching invalidateMVAtRest's discipline
+            // (stale.ts): `_internalDelete` returns `false` for a #718 elevated-skip (no
+            // erasure happened), and that must not inflate the tombstone count.
+            if (await outAny._internalDelete(priorId, txCtx)) deleted++
           } else {
             // Defensive fallback — should never hit in real flow since
             // every Collection has `_internalDelete`.

--- a/packages/hub/src/with-formula/materialized-views/executor.ts
+++ b/packages/hub/src/with-formula/materialized-views/executor.ts
@@ -259,6 +259,18 @@ export const MaterializedViewExecutor = {
       rows = await materializeQueryResult(q, spec.name, spec.i18nLocale, spec.i18nFields)
     }
 
+    // #777 — exclude this MV's OWN previously-stamped output rows from the
+    // input scan. A same-collection Query-form MV copies the whole source row
+    // verbatim into its output, so a stale output row can itself satisfy the
+    // MV's own input filter (when the filter is on a field disjoint from the
+    // partition field) and get re-selected as if it were live source — the
+    // row self-perpetuates after its true source is gone. Prior output is
+    // never this MV's own source.
+    rows = rows.filter((row) => {
+      const stamp = row._materializedFrom as { mvName?: string } | undefined
+      return stamp?.mvName !== spec.name
+    })
+
     // 2. Cost ceiling check BEFORE any writes — keeps the rollback
     //    clean if the source-write is wrapped in a transaction.
     if (rows.length > maxRows) {

--- a/packages/hub/src/with-formula/materialized-views/stale.ts
+++ b/packages/hub/src/with-formula/materialized-views/stale.ts
@@ -132,7 +132,13 @@ async function hydratePersistedStaleMarkers(accessor: MVStaleAccessor, registry:
  *
  * Returns the count of rows actually `_internalDelete`d (#761 item 1) — folded by the
  * caller into `dispatchMaterializedViewsOnDelete`'s `deleted` so `ForgetResult.derivedRecordsErased`
- * counts lazy/manual purges too, not just the eager executor's tombstone leg.
+ * counts lazy/manual purges too, not just the eager executor's tombstone leg — plus `residue`,
+ * the bare ids whose ownership stamp could NOT be decoded (#776): a candidate row that fails to
+ * decode under the collection's default DEK (e.g. elevated above tier 0 on a tiered output
+ * collection) has UNKNOWN ownership — it might be this MV's own output, or (same-collection
+ * shape) a plain user record — so it is never erased, but it must be SURFACED rather than
+ * silently skipped (the #724 posture), since it may still hold the forgotten/pre-elevation
+ * contribution, decryptable by tier-holders.
  *
  * @internal
  */
@@ -140,11 +146,12 @@ export async function invalidateMVAtRest(
   accessor: MVStaleAccessor,
   reg: RegisteredMV,
   mode: 'lazy' | 'manual',
-): Promise<number> {
+): Promise<{ deleted: number; residue: string[] }> {
   const outputColl = accessor.getCollection(reg.outputCollection)
   const txCtx = accessor.getActiveTxContext()
   const { adapter, vault } = storeOf(accessor, reg.outputCollection)
   let deleted = 0
+  const residue: string[] = []
   for (const id of await adapter.list(vault, reg.outputCollection)) {
     // A same-collection partition MV (`output: { collection: <source>, partition }`,
     // the DERIV-PP30-001 shape) writes INTO its own source collection — `adapter.list`
@@ -157,10 +164,8 @@ export async function invalidateMVAtRest(
     if (envelope === null) continue
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const decoded = await (outputColl as any)._decodeEnvelope(envelope, id)
-    const stampedBy =
-      decoded !== null && typeof decoded === 'object'
-        ? (decoded as Record<string, unknown>)._materializedFrom as { mvName?: string } | undefined
-        : undefined
+    if (decoded === null) { residue.push(id); continue } // #776 — ownership unknown, surfaced not skipped
+    const stampedBy = (decoded as Record<string, unknown>)._materializedFrom as { mvName?: string } | undefined
     if (stampedBy?.mvName !== reg.spec.name) continue
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (await (outputColl as any)._internalDelete(id, txCtx)) deleted++
@@ -175,7 +180,7 @@ export async function invalidateMVAtRest(
     markMVStale(registry, reg.spec.name)
     await writeMVStaleMarker(adapter, vault, reg.spec.name)
   }
-  return deleted
+  return { deleted, residue }
 }
 
 /**


### PR DESCRIPTION
Closes #776. Closes #777. Milestone-34 MV/derivation candor follow-ups.

- **#777 (self-perpetuation):** a same-collection Query-form MV whose input filter matched a field its output copies re-selected its own stale output as source on the next eager refresh → the row self-perpetuated after its true source was deleted/forgotten. The executor's input scan now excludes rows stamped with the MV's own `_materializedFrom.mvName` before they feed materialization or the tombstone diff (only the MV's own output — chained MVs and user rows unaffected). (RED reproduced.)
- **#776a (residue notice):** an MV output row elevated above tier 0 that decodes null under the default DEK is now surfaced as `ForgetResult.derivedResidueUndecodable` instead of silently skipped — funded shrink-first, no ceiling bump.
- **#776b (honest count):** the eager executor tombstone leg gates its erased-count on `_internalDelete`'s boolean, so a `#718`-skipped elevated row no longer over-reports as erased.

## Verification

All REDs reproduced; full hub suite green (4333); typecheck / lint / `check:architecture` clean; `collection.ts` 4548/4549, `vault.ts` 3958/3959. Reviewed **Approved**. Follow-up filed for two adjacent candor gaps.