### PR TITLE
fix(hub): refuse tiers + CRDT-source derivations at construction (#739)

### DIFF
--- a/packages/hub/__tests__/tiers-crdt-derivation-guard.test.ts
+++ b/packages/hub/__tests__/tiers-crdt-derivation-guard.test.ts
@@ -1,0 +1,175 @@
+/**
+ * #739 — follow-up from #722 (PR #738). `RecordCodec.decryptRecordAtDek()`
+ * (the tier-aware pre-move decode `syncDerived` uses on elevate()/demote())
+ * has no CRDT resolution step, so a registered rollup/derivation reading a
+ * CRDT-mode tiered SOURCE collection sees raw `CrdtState` instead of the
+ * resolved record — its key/value fields read as `undefined` and the
+ * recompute silently no-ops, letting the #722 leak back in for this
+ * combination. Refused at construction (mirrors the #724/#748/#740
+ * `UnsupportedTierCompositionError` guards in `collection-config.ts`)
+ * instead of fixed via CRDT-aware pre-move decode.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withRollup, withDerivation, UnsupportedTierCompositionError, ConflictError } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withCrdt } from '../src/with-commit/crdt/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number }
+interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+
+describe('#739 — tiers + crdt + derivation/rollup source is refused at construction', () => {
+  it('refuses a tiered CRDT collection that is a rollup `from` (child) source', async () => {
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-crdt-rollup-from-passphrase-2026',
+      tiersStrategy: withTiers(),
+      crdtStrategy: withCrdt(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const vault = await db.openVault('firm')
+
+    expect(() =>
+      vault.collection<Sale>('sales', { tiers: [0, 1], perRecordKeys: true, crdt: 'lww-map' }),
+    ).toThrow(UnsupportedTierCompositionError)
+  })
+
+  it('refuses a tiered CRDT collection that is a rollup `into` (parent) source', async () => {
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-crdt-rollup-into-passphrase-2026',
+      tiersStrategy: withTiers(),
+      crdtStrategy: withCrdt(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const vault = await db.openVault('firm')
+
+    expect(() =>
+      vault.collection<Buyer>('buyers', { tiers: [0, 1], perRecordKeys: true, crdt: 'lww-map' }),
+    ).toThrow(UnsupportedTierCompositionError)
+  })
+
+  it('refuses a tiered CRDT collection that is a plain (non-rollup) derivation source', async () => {
+    interface Worker extends Record<string, unknown> { id: string; period: string; baseSalary: number }
+    interface ActivePeriod extends Record<string, unknown> { id: string; workerId: string; period: string }
+    const strategy = withDerivation<Worker, { activeInPeriod: ActivePeriod[] }>({
+      source: 'workers',
+      deterministic: true,
+      outputs: { activeInPeriod: { shape: 'array', collection: 'workerActiveInPeriod', key: (o) => `${o.workerId as string}|${o.period as string}` } },
+      derive: (worker) => ({ activeInPeriod: [{ id: `${worker.id}|${worker.period}`, workerId: worker.id, period: worker.period }] }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-crdt-derivation-passphrase-2026',
+      tiersStrategy: withTiers(),
+      crdtStrategy: withCrdt(),
+      derivationStrategies: [strategy],
+    })
+    const vault = await db.openVault('acme')
+
+    expect(() =>
+      vault.collection<Worker>('workers', { tiers: [0, 1], perRecordKeys: true, crdt: 'lww-map' }),
+    ).toThrow(UnsupportedTierCompositionError)
+  })
+
+  it('allows tiers + crdt WITHOUT a derivation/rollup', async () => {
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-crdt-only-passphrase-2026',
+      tiersStrategy: withTiers(),
+      crdtStrategy: withCrdt(),
+    })
+    const vault = await db.openVault('firm')
+
+    expect(() =>
+      vault.collection<Sale>('sales', { tiers: [0, 1], perRecordKeys: true, crdt: 'lww-map' }),
+    ).not.toThrow()
+  })
+
+  it('allows crdt + a rollup source WITHOUT tiers', async () => {
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'crdt-rollup-no-tiers-passphrase-2026',
+      crdtStrategy: withCrdt(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const vault = await db.openVault('firm')
+
+    expect(() => vault.collection<Sale>('sales', { crdt: 'lww-map' })).not.toThrow()
+  })
+
+  it('allows tiers + a rollup source WITHOUT crdt', async () => {
+    const totalSpentRollup = withRollup<Sale, Buyer>({
+      from: 'sales', key: 'buyerId', into: 'buyers', field: 'totalSpent',
+      compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+    })
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'owner',
+      secret: 'tiers-rollup-no-crdt-passphrase-2026',
+      tiersStrategy: withTiers(),
+      derivationStrategies: [totalSpentRollup],
+    })
+    const vault = await db.openVault('firm')
+
+    expect(() =>
+      vault.collection<Sale>('sales', { tiers: [0, 1], perRecordKeys: true }),
+    ).not.toThrow()
+  })
+})

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -980,6 +980,45 @@ export function resolveCollectionConfig<T>(opts: CollectionOpts<T>) {
     )
   }
 
+  // #739 — a CRDT-mode collection's decrypted body is the raw `CrdtState`
+  // (edit log + bidx pointer), not the resolved record: `RecordCodec
+  // .decryptRecordAtDek()` — the tier-aware pre-move decode `syncDerived`
+  // uses on `elevate()`/`demote()`/`putAtTier()` (#722) — has no CRDT
+  // resolution step (same gap as `getAtTier`'s tier>0 leg), so a registered
+  // rollup/derivation reading this collection sees `undefined` for every
+  // field (e.g. `_rollupDeleteIntents`'s `deleted[spec.rollup.key]`) and its
+  // recompute silently no-ops — the #722 derived-output-follows-tier fix
+  // never fires for this combination. Refuse at construction instead of
+  // leaking silently.
+  //
+  // Caught here: rollup/derivation sources, reliably — `DerivationRegistry`
+  // is fully populated (every `withDerivation()`/`withRollup()` handle
+  // registered) by `Noydb.openVault()` before any `vault.collection()` call
+  // reaches user code, so source/derived registration order never matters.
+  //
+  // NOT caught: a materialized-view SOURCE first constructed inside the
+  // MV's own single-query `query(db)` callback (the common `query: (db) =>
+  // db.collection(name)...` shape) — `MaterializedViewRegistry.register()`
+  // invokes that callback (which constructs THIS collection) before it
+  // records the dependency, so `materializedViewSource.registry()
+  // .mvsForSource(name)` is still empty at this exact call. A
+  // `unionSources`/aggregate-with-explicit-`sources` MV, or a source
+  // constructed by an earlier `vault.collection()` call, is still caught.
+  if (
+    opts.tiers && opts.tiers.length > 0 && opts.crdt !== undefined &&
+    ((opts.derivationSource?.registry().strategiesForSource(opts.name).length ?? 0) > 0 ||
+      (opts.materializedViewSource?.registry().mvsForSource(opts.name).length ?? 0) > 0)
+  ) {
+    throw new UnsupportedTierCompositionError(
+      'crdt-derivation',
+      `Collection "${opts.name}": tiers + crdt cannot be combined with this collection acting as a ` +
+        `derivation/rollup source (#739) — the tier-aware pre-move decode \`syncDerived\` uses on ` +
+        `elevate()/demote() does not resolve CRDT state, so a registered derivation/rollup reads raw ` +
+        `CrdtState instead of the record and silently no-ops. Use a non-CRDT collection for a tiered ` +
+        `derivation/rollup source, or move the derivation off this collection.`,
+    )
+  }
+
   // via() / sugar-key merge (#623 Task 9) — throws on a field declared in both.
   const effectiveViaFields = mergeViaFields(opts)
 


### PR DESCRIPTION
Closes #739 (was `status: blocked`). Milestone-34 — closed via the campaign's refuse-at-construction pattern.

## Problem

For a CRDT-mode tiered rollup/derivation source, `RecordCodec.decryptRecordAtDek()` (the tier-aware pre-move decode feeding `syncDerived`) skips CRDT resolution, so the raw `CrdtState` reaches the recompute, the key field is `undefined`, the recompute no-ops, and #722's derived-output-follows-tier leak persists for the tiers×CRDT×derivations combination. The issue was blocked on "resolve CrdtState in the decode (complex) vs refuse."

## Fix

Refuse the three-way combination at `vault.collection()` — the same registration-guard pattern the campaign already uses for tiers×blobFields (#724), tiers×external-public:true (#748), and tiers×encrypted:false (#740). The guard fires in `resolveCollectionConfig()` when a collection declares `tiers` **and** `crdt` **and** is a derivation/rollup source (via the same `strategiesForSource`/`mvsForSource` registry lookup the runtime dispatch uses — catching both sides of a rollup and plain derivations). Each pairwise combination remains allowed.

## Verification

RED reproduced (all three refusal cases constructed silently pre-guard); 6 tests (3 refusals: rollup `from`, rollup `into`, plain derivation source; 3 positive locks: tiers+crdt, crdt+rollup, tiers+rollup each still allowed); 328 crdt-touching tests + full suite green; typecheck / lint / `check:architecture` clean; no ceiling-gated file touched (guard uses existing `CollectionOpts.derivationSource`/`.registry()` handles). Changeset local-only.

## Review trail

Reviewed **Approved** — guard condition verified correct against the actual registry/dispatch code; the one documented blind spot (an MV source first constructed inside its own `query(db)` callback) is the same accepted class as the existing guards, and this guard is in fact strictly more complete than the prior pattern.