### PR TITLE
fix(hub): eager MV residue channel + elevated-handle searchResidue observability (#782, #779)

### DIFF
--- a/packages/hub/__tests__/materialized-views/correctness.test.ts
+++ b/packages/hub/__tests__/materialized-views/correctness.test.ts
@@ -270,6 +270,9 @@ describe('MV correctness (#152)', () => {
       const second = await vault.refreshView('red-items')
 
       expect(second.deleted).toBe(0) // #776 part b — the over-count RED this test pins
+      // #782 part b — decoded (warm cek) + stamp-owned but #718-declined: a real silent
+      // survival, must be surfaced as residue, not just correctly excluded from `deleted`.
+      expect(second.residue).toEqual(['red-items-out:a'])
     })
   })
 

--- a/packages/hub/__tests__/materialized-views/lazy-and-manual.test.ts
+++ b/packages/hub/__tests__/materialized-views/lazy-and-manual.test.ts
@@ -176,7 +176,7 @@ describe('MV lazy lifecycle + vault.refreshView (#151)', () => {
     })
     const vault = await db.openVault('demo')
     // No MVs registered — returns zero counts.
-    expect(await vault.refreshView('nonexistent')).toEqual({ written: 0, deleted: 0, failed: 0 })
+    expect(await vault.refreshView('nonexistent')).toEqual({ written: 0, deleted: 0, failed: 0, residue: [] })
 
     // With at least one MV registered, an unknown name throws.
     const mv = withMaterializedView<Item>({

--- a/packages/hub/__tests__/search-compensation-residue.test.ts
+++ b/packages/hub/__tests__/search-compensation-residue.test.ts
@@ -186,6 +186,34 @@ describe('#764 (b) elevate()/demote() surface a stuck compensation as residue, n
   })
 })
 
+describe('#779 vault.elevate(...).collection().put() surfaces searchResidue', () => {
+  it('a stuck search compensation on the vault.elevate() convenience path is observable, not discarded', async () => {
+    const store = readOnlyFtindexDelete(memoryStore())
+    const db = await createNoydb({
+      store, user: 'owner', secret: SECRET,
+      searchStrategy: withSearch(), tiersStrategy: withTiers(),
+    })
+    const vault = await db.openVault('v1')
+    vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true, textIndexes: ['body'], textIndexPersist: true,
+    })
+
+    // `_elevatedPut` routes through the SAME resilient `putAtTier` code path
+    // (#774) — it's `ElevatedHandle.collection().put()` that was discarding
+    // the returned `TierMoveResult` before this fix.
+    const elev = await vault.elevate(1, { ttlMs: 60_000, reason: 'export' })
+    await expect(
+      elev.collection<Doc>('docs').put('e1', { id: 'e1', body: 'topsecret-alpha' }),
+    ).resolves.toEqual({ searchResidue: true })
+    await elev.release()
+
+    // The record actually landed at the elevated tier despite the stuck
+    // search compensation — proves the write itself wasn't aborted either.
+    const env = await store.get('v1', 'docs', 'e1')
+    expect(env?._tier).toBe(1)
+  })
+})
+
 describe('#774 putAtTier() has the same resilience as elevate()/demote()', () => {
   it('putAtTier(tier>0) completes the write (put lands, cross-tier event fires) and returns searchResidue: true instead of throwing', async () => {
     const store = readOnlyFtindexDelete(memoryStore())

--- a/packages/hub/__tests__/via/forget-fanout.test.ts
+++ b/packages/hub/__tests__/via/forget-fanout.test.ts
@@ -345,4 +345,113 @@ describe('forget() fanout to derived residue (#622)', () => {
     // ...but surfaced, not silently skipped (the #724 posture).
     expect(result.derivedResidueUndecodable).toEqual(['people-mirror-tiered:p1'])
   })
+
+  it('forget × EAGER MV with a TIERED output: an elevated, undecodable output row survives forget() — surfaced now, not silently (#782 part a)', async () => {
+    interface Person extends Record<string, unknown> { id: string; subjectId: string; name: string }
+    const mv = withMaterializedView<Person>({
+      name: 'people-mirror-eager',
+      query: (db) => db.collection<Person>('people').query(),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const store = memory()
+    const open = async () => {
+      const db = await createNoydb({
+        store, user: 'alice', secret: 'forget-fanout-782a-passphrase-2026',
+        materializedViewStrategies: [mv],
+        historyStrategy: withHistory(),
+        forgetStrategy: withForgetCascade({ subjects: { people: 'subjectId' } }),
+        tiersStrategy: withTiers(),
+      })
+      const vault = await db.openVault('firm')
+      // Declare tiers on the OUTPUT collection BEFORE the first eager materialize
+      // constructs it untiered (first-construction-wins, same discipline as #776a).
+      const mirror = vault.collection<Person>('people-mirror-eager', { tiers: [0, 1], perRecordKeys: true })
+      return { vault, people: vault.collection<Person>('people'), mirror }
+    }
+
+    const { people, mirror } = await open()
+    await people.put('p1', { id: 'p1', subjectId: 'subj-1', name: 'Ada' }) // eager materialize fires inline
+
+    // Elevate the OUTPUT row directly.
+    await mirror.elevate('p1', 1)
+
+    // Cold session (fresh cekCache) — the ownership decode genuinely fails now, and
+    // forget() drives this collection's EAGER tombstone leg (executor.refresh), not the
+    // lazy invalidateMVAtRest leg #776 already covered.
+    const { vault: coldVault } = await open()
+    const result = await coldVault.forget('subj-1')
+
+    // Ownership unconfirmed (undecodable) → NOT counted as erased...
+    expect(result.derivedRecordsErased).toBe(0)
+    // ...but surfaced, not silently skipped on the eager path either (#782 part a).
+    expect(result.derivedResidueUndecodable).toEqual(['people-mirror-eager:p1'])
+  })
+
+  it('forget × lazy MV: a decoded, stamp-owned, but #718-declined output row is surfaced as residue too (#782 part b, lazy leg)', async () => {
+    interface Person extends Record<string, unknown> { id: string; subjectId: string; name: string }
+    const mv = withMaterializedView<Person>({
+      name: 'people-mirror-lazy-782b',
+      query: (db) => db.collection<Person>('people').query(),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'forget-fanout-782b-lazy-passphrase-2026',
+      materializedViewStrategies: [mv],
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { people: 'subjectId' } }),
+      tiersStrategy: withTiers(),
+    })
+    const vault = await db.openVault('firm')
+    const mirror = vault.collection<Person>('people-mirror-lazy-782b', { tiers: [0, 1], perRecordKeys: true })
+    const people = vault.collection<Person>('people')
+
+    await people.put('p1', { id: 'p1', subjectId: 'subj-1', name: 'Ada' })
+    expect(await mirror.get('p1')).not.toBeNull() // materialize (lazy resolve-on-read)
+
+    // Elevate the OUTPUT row directly — SAME session, so the ownership decode below still
+    // succeeds (the cekCache is warm from the elevate call itself), but `_internalDelete`
+    // is #718-gated and declines. NOT a cold reopen — that's the #776/part-a scenario.
+    await mirror.elevate('p1', 1)
+
+    const result = await vault.forget('subj-1')
+
+    // Deletion declined (elevated) → NOT counted as erased...
+    expect(result.derivedRecordsErased).toBe(0)
+    // ...but this is a REAL silent survival (ownership confirmed, erasure declined) — must
+    // be surfaced, not dropped (#782 part b).
+    expect(result.derivedResidueUndecodable).toEqual(['people-mirror-lazy-782b:p1'])
+  })
+
+  it('forget × eager MV: a decoded, stamp-owned, but #718-declined output row is surfaced as residue too (#782 part b, eager leg)', async () => {
+    interface Person extends Record<string, unknown> { id: string; subjectId: string; name: string }
+    const mv = withMaterializedView<Person>({
+      name: 'people-mirror-eager-782b',
+      query: (db) => db.collection<Person>('people').query(),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'forget-fanout-782b-eager-passphrase-2026',
+      materializedViewStrategies: [mv],
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { people: 'subjectId' } }),
+      tiersStrategy: withTiers(),
+    })
+    const vault = await db.openVault('firm')
+    const mirror = vault.collection<Person>('people-mirror-eager-782b', { tiers: [0, 1], perRecordKeys: true })
+    const people = vault.collection<Person>('people')
+
+    await people.put('p1', { id: 'p1', subjectId: 'subj-1', name: 'Ada' }) // eager materialize fires inline
+
+    // Elevate the OUTPUT row directly — SAME session, warm cekCache (see the lazy-leg
+    // test above for why decode succeeds here while `_internalDelete` still declines).
+    await mirror.elevate('p1', 1)
+
+    const result = await vault.forget('subj-1')
+
+    expect(result.derivedRecordsErased).toBe(0)
+    expect(result.derivedResidueUndecodable).toEqual(['people-mirror-eager-782b:p1'])
+  })
 })

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -2944,12 +2944,12 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         if (executor === null) {
           ;({ MaterializedViewExecutor: executor } = await import('../with-formula/materialized-views/executor.js'))
         }
-        deleted += (await executor.refresh(reg, {
+        const rr = await executor.refresh(reg, {
           getCollection: (name) => this.materializedViewSource!.getCollection(name),
           getActiveTxContext: () => this.materializedViewSource!.getActiveTxContext(),
           getQueryContext: () => this.materializedViewSource!.getQueryContext(),
           dispatchCtx: this.#dispatchCtx({ collection: this.name, id }),
-        })).deleted
+        }); deleted += rr.deleted; residue.push(...rr.residue) // #782 — eager leg now reports too
       } else {
         if (staleHelpers === null) {
           staleHelpers = await import('../with-formula/materialized-views/stale.js')

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -2758,13 +2758,13 @@ export class Vault {
   /**
    * Manual re-materialize for a single registered MV (`refresh: 'manual'` consumers,
    * stale-bit recovery on vault reopen, bulk-recompute escape hatch after a strategy
-   * change). Returns `{ written, deleted, failed }` (`deleted` always 0 without
-   * tombstoning). Throws if `name` is not a registered MV.
+   * change). Returns `{ written, deleted, failed, residue }` (`deleted` always 0 without
+   * tombstoning; `residue` = #782 undecodable/declined leftovers). Throws if not registered.
    */
-  async refreshView(name: string): Promise<{ written: number; deleted: number; failed: number }> {
+  async refreshView(name: string): Promise<{ written: number; deleted: number; failed: number; residue: string[] }> {
     const registry = this.materializedViewRegistry
     if (registry === null) {
-      return { written: 0, deleted: 0, failed: 0 }
+      return { written: 0, deleted: 0, failed: 0, residue: [] }
     }
     const reg = registry.byName(name)
     if (!reg) {

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -57,7 +57,7 @@ import type { IndexStrategy } from '../with-lookup/indexing/strategy.js'
 import type { LazyStrategy } from '../port/with/lazy-strategy.js'
 import type { AggregateStrategy } from '../with-lookup/aggregate/strategy.js'
 import type { CrdtStrategy } from './types.js' // direct, not via crdt/strategy.js — avoids a dts cycle (#667)
-import type { TiersStrategy } from '../with-audit/tiers/strategy.js'
+import type { TiersStrategy, TierMoveResult } from '../with-audit/tiers/strategy.js'
 import type { SearchStrategy } from '../with-lookup/search/strategy.js'
 import { NO_CARGO, type CargoStrategy } from '../with-cargo/strategy.js'
 import { NO_BROKER, buildCredentialBrokerHandle, type BrokerStrategy, type CredentialBrokerHandle } from '../port/with/broker-strategy.js'
@@ -3211,7 +3211,7 @@ export class Vault {
    * Internal — invoked by an `ElevatedHandle.collection().put()` call.
    * Routes through the existing `Collection.putAtTier` code path with
    * the elevation context attached so the cross-tier event reflects
-   * the right authorization class.
+   * the right authorization class. Returns `putAtTier`'s `TierMoveResult` (#779).
    */
   async _elevatedPut<T>(
     collectionName: string,
@@ -3219,9 +3219,9 @@ export class Vault {
     record: T,
     tier: number,
     reason: string,
-  ): Promise<void> {
+  ): Promise<TierMoveResult> {
     const coll = this.collection<T>(collectionName)
-    await coll.putAtTier(id, record, tier, {
+    return coll.putAtTier(id, record, tier, {
       elevation: { reason, fromTier: 0 },
     })
   }

--- a/packages/hub/src/kernel/via/dispatch.ts
+++ b/packages/hub/src/kernel/via/dispatch.ts
@@ -284,10 +284,13 @@ export interface ForgetFanoutStats {
    *  skipped for these, reported here so the skip is never silent. `backing:key:collection.field`
    *  entries, one per un-propagated edge. */
   readonly lookupReferencesResidue: string[]
-  /** #776 — `outputCollection:id` MV-output rows whose `_materializedFrom` ownership stamp
-   *  `invalidateMVAtRest` could not decode (undecodable under the default DEK — e.g. elevated
-   *  above tier 0 on a tiered output collection). Never erased (ownership unconfirmed), but
-   *  surfaced here rather than silently skipped. */
+  /** #776/#782 — `outputCollection:id` MV-output rows that survived erasure invalidation
+   *  (eager tombstone leg AND lazy/manual `invalidateMVAtRest`) despite belonging to the
+   *  forgotten subject: either the ownership stamp could not be decoded (undecodable under
+   *  the default DEK — e.g. elevated above tier 0 on a tiered output collection, ownership
+   *  unconfirmed), or it decoded and stamp-matched but `_internalDelete` declined (the #718
+   *  tier-elevation gate — ownership confirmed, erasure declined). Never erased either way,
+   *  but surfaced here rather than silently skipped. */
   readonly derivedResidueUndecodable: string[]
 }
 

--- a/packages/hub/src/with-audit/forget/strategy.ts
+++ b/packages/hub/src/with-audit/forget/strategy.ts
@@ -177,10 +177,13 @@ export interface ForgetResult {
    *  Always empty under the unconditional default. Non-empty means a `_sealed_cek` entry or a
    *  blob scan was skipped for an undeclared collection — reported, never a silent skip. */
   readonly scopedPurgeResidue: readonly ScopedPurgeResidueNotice[]
-  /** #776 — `collection:id` MV-output rows whose `_materializedFrom` ownership stamp could NOT
-   *  be decoded during erasure invalidation (undecodable under the collection's default DEK —
-   *  e.g. elevated above tier 0 on a tiered output collection). Never erased (ownership
-   *  unconfirmed — could be a plain user record on a same-collection partition MV), but
+  /** #776/#782 — `collection:id` MV-output rows that survived erasure invalidation (eager
+   *  tombstone leg AND lazy/manual `invalidateMVAtRest`) despite belonging to the forgotten
+   *  subject: either the `_materializedFrom` ownership stamp could NOT be decoded (undecodable
+   *  under the collection's default DEK — e.g. elevated above tier 0 on a tiered output
+   *  collection; ownership unconfirmed — could be a plain user record on a same-collection
+   *  partition MV), or it decoded and stamp-matched but `_internalDelete` declined (the #718
+   *  tier-elevation gate; ownership confirmed, erasure declined). Never erased either way, but
    *  surfaced here rather than silently skipped (the #724 posture). Non-empty means the row may
    *  still hold the forgotten/pre-elevation contribution, decryptable by tier-holders. */
   readonly derivedResidueUndecodable: readonly string[]

--- a/packages/hub/src/with-audit/tiers/strategy.ts
+++ b/packages/hub/src/with-audit/tiers/strategy.ts
@@ -11,6 +11,11 @@ import type { GhostRecord } from '../../kernel/types.js'
 import type { TiersContext, TierMoveResult } from './index.js'
 import { TiersNotEnabledError } from '../../kernel/errors.js'
 
+// #779 — re-exported so kernel-spine callers (e.g. `Vault._elevatedPut`) can reference the
+// result shape via this grandfathered strategy.js seam instead of statically importing
+// tiers/index.js directly (the port-layering check only grandfathers this file).
+export type { TierMoveResult }
+
 export interface TiersStrategy {
   putAtTier<T>(
     ctx: TiersContext<T>,

--- a/packages/hub/src/with-commit/tx/elevated-handle.ts
+++ b/packages/hub/src/with-commit/tx/elevated-handle.ts
@@ -9,6 +9,7 @@
  */
 import { ElevationExpiredError } from '../../kernel/errors.js'
 import type { Vault } from '../../kernel/vault.js'
+import type { TierMoveResult } from '../../with-audit/tiers/index.js'
 
 /**
  * Reserved collection that holds the audit ledger of elevation
@@ -63,15 +64,18 @@ export class ElevatedHandle {
    * `collection(...)`, which keeps "writes elevated, reads
    * unprivileged" trivially true.
    */
-  collection<T>(name: string): { put(id: string, record: T): Promise<void> } {
+  collection<T>(name: string): { put(id: string, record: T): Promise<TierMoveResult> } {
     // Don't gate the wrapper itself — just the operation. Adopters
     // commonly cache `const docs = elev.collection('docs')` and the
     // lazy-check still works correctly because assertActive runs at
     // every `put` call, against a fresh `Date.now()`.
     return {
-      put: async (id: string, record: T): Promise<void> => {
+      // #779 — surface `_elevatedPut`'s `TierMoveResult` (searchResidue) instead of
+      // discarding it, so a stuck search compensation on this convenience path is
+      // observable by the caller, mirroring `putAtTier`'s direct-call parity (#774).
+      put: async (id: string, record: T): Promise<TierMoveResult> => {
         this.assertActive()
-        await this.vault._elevatedPut<T>(name, id, record, this.tier, this.reason)
+        return await this.vault._elevatedPut<T>(name, id, record, this.tier, this.reason)
       },
     }
   }

--- a/packages/hub/src/with-formula/materialized-views/executor.ts
+++ b/packages/hub/src/with-formula/materialized-views/executor.ts
@@ -45,6 +45,13 @@ export interface RefreshResult {
   deleted: number
   /** Failed row writes (non-strict mode). */
   failed: number
+  /** #782 — `outputCollection:id` entries from the tombstone pass that were NOT tombstoned
+   *  despite belonging here: either the ownership stamp couldn't be decoded (undecodable
+   *  under the collection's default DEK, mirroring `invalidateMVAtRest`'s #776 posture), or
+   *  it decoded, stamp-matched this MV, but `_internalDelete` declined (the #718
+   *  tier-elevation gate) — a real silent survival either way, surfaced rather than dropped.
+   *  Only populated when `onEmpty: 'delete'`. */
+  residue: string[]
 }
 
 /** Default cost ceiling — overridable per-MV via `spec.maxRows`. */
@@ -332,6 +339,7 @@ export const MaterializedViewExecutor = {
     //    `_internalDelete` so a user-registered `onDelete` on the
     //    output collection does NOT fire on housekeeping (composition fix).
     let deleted = 0
+    const residue: string[] = []
     if (onEmpty === 'delete') {
       const priorIds = await listOutputIds(outputColl)
       for (const priorId of priorIds) {
@@ -346,8 +354,16 @@ export const MaterializedViewExecutor = {
         if (priorEnvelope === null) continue
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const priorDecoded = await (outputColl as any)._decodeEnvelope(priorEnvelope, priorId)
+        if (priorDecoded === null) {
+          // #782 part a — ownership unknown (undecodable, e.g. elevated above tier 0 on a
+          // tiered output collection): can't rule out this being THIS MV's own stamped row.
+          // Surface it rather than silently skip (mirrors invalidateMVAtRest's #776 posture —
+          // previously this leg had NO residue channel at all).
+          residue.push(`${reg.outputCollection}:${priorId}`)
+          continue
+        }
         const priorStampedBy =
-          priorDecoded !== null && typeof priorDecoded === 'object'
+          typeof priorDecoded === 'object'
             ? (priorDecoded as Record<string, unknown>)._materializedFrom as { mvName?: string } | undefined
             : undefined
         if (priorStampedBy?.mvName !== spec.name) continue
@@ -358,7 +374,14 @@ export const MaterializedViewExecutor = {
             // #776 part b — gate on the boolean, matching invalidateMVAtRest's discipline
             // (stale.ts): `_internalDelete` returns `false` for a #718 elevated-skip (no
             // erasure happened), and that must not inflate the tombstone count.
-            if (await outAny._internalDelete(priorId, txCtx)) deleted++
+            if (await outAny._internalDelete(priorId, txCtx)) {
+              deleted++
+            } else {
+              // #782 part b — decoded AND stamp-owned, but erasure was declined (#718
+              // tier-elevation gate). Ownership IS confirmed here — a real silent survival,
+              // not a legit stamp-mismatch skip. Surface it too.
+              residue.push(`${reg.outputCollection}:${priorId}`)
+            }
           } else {
             // Defensive fallback — should never hit in real flow since
             // every Collection has `_internalDelete`.
@@ -368,13 +391,13 @@ export const MaterializedViewExecutor = {
         } catch (err) {
           failed++
           if (strict) throw err
-           
+
           console.warn(`[mv] "${spec.name}" tombstone failed for id="${priorId}":`, err)
         }
       }
     }
 
-    return { written, deleted, failed }
+    return { written, deleted, failed, residue }
   },
 }
 

--- a/packages/hub/src/with-formula/materialized-views/stale.ts
+++ b/packages/hub/src/with-formula/materialized-views/stale.ts
@@ -168,7 +168,14 @@ export async function invalidateMVAtRest(
     const stampedBy = (decoded as Record<string, unknown>)._materializedFrom as { mvName?: string } | undefined
     if (stampedBy?.mvName !== reg.spec.name) continue
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (await (outputColl as any)._internalDelete(id, txCtx)) deleted++
+    if (await (outputColl as any)._internalDelete(id, txCtx)) {
+      deleted++
+    } else {
+      // #782 part b — decoded AND stamp-owned, but erasure declined (#718 tier-elevation
+      // gate). Ownership IS confirmed — a real silent survival, not a legit stamp-mismatch
+      // skip. Surface it too, same channel as the decode-null case above.
+      residue.push(id)
+    }
   }
 
   // `mode: 'manual'` gets the purge only (erasure wins, no auto-recompute promise);


### PR DESCRIPTION
Closes #782. Closes #779. Milestone-34 final erasure-candor follow-ups.

- **#782** — the eager MV executor's tombstone leg silently skipped rows it couldn't decode (no residue channel at all), so an elevated undecodable stamped output row survived `forget()` invisibly on the eager path. `RefreshResult` now carries `residue`, threaded through the eager `dispatchMaterializedViewsOnDelete` branch into the existing `ForgetResult.derivedResidueUndecodable`. Both legs (eager + lazy) also now surface a decoded-and-owned-but-undeletable row (the `#718` tier gate declined) as residue. A legitimate other-owner row (stamp mismatch) is still skipped, never reported — verified the discrimination on both legs.
- **#779** — the `vault.elevate(...).collection().put()` convenience path discarded `putAtTier`'s `TierMoveResult { searchResidue }`; it's now threaded through `_elevatedPut` → `ElevatedHandle.put()`, purely additive.

## Verification

Both REDs reproduced (eager silent-survival; dropped searchResidue signal); full hub suite green (518 files / 4347); typecheck / lint / `check:architecture` clean; `collection.ts` 4548/4549 and `vault.ts` 3958/3959 funded in place (zero net growth), `TierMoveResult` reaches vault.ts via the grandfathered strategy re-export. Reviewed **Approved**. Follow-up filed to reason-tag/split `derivedResidueUndecodable` (two audit-relevant modes now folded) before the external audit finalizes.