### PR TITLE
fix(hub): tier moves snapshot the pre-move version into history under the destination-tier DEK (#728)

### DIFF
--- a/packages/hub/__tests__/enclave-surface.golden.json
+++ b/packages/hub/__tests__/enclave-surface.golden.json
@@ -4,6 +4,7 @@
   "values": [
     "RecordCodec",
     "SEALED_CEK_NS",
+    "applyRewrappedBody",
     "base64ToBuffer",
     "bufferToBase64",
     "buildDeleteMarker",
@@ -69,6 +70,7 @@
     "EnclaveKey",
     "IssuedChallenge",
     "PassphraseKeyUsage",
+    "RewrappedBody",
     "SealedShredSlot",
     "SealingContext",
     "VerifyBrokerProofArgs"

--- a/packages/hub/__tests__/tier-move-history.test.ts
+++ b/packages/hub/__tests__/tier-move-history.test.ts
@@ -23,6 +23,7 @@ import { withTiers } from '../src/with-audit/tiers/index.js'
 import { withHistory } from '../src/with-commit/history/index.js'
 import { NOYDB_FORMAT_VERSION, type EncryptedEnvelope, type NoydbStore, type VaultSnapshot } from '../src/kernel/types.js'
 import { unwrapCek, decrypt, type EnclaveKey } from '../src/kernel/enclave/index.js'
+import { LEDGER_COLLECTION } from '../src/with-commit/history/ledger/constants.js'
 
 interface HistDoc { id: string; body: string }
 
@@ -188,5 +189,67 @@ describe('#728 tier moves snapshot the pre-move version into _history', () => {
     await expect(docs.putAtTier('d1', { id: 'd1', body: 'v2' }, 1)).resolves.toBeDefined()
 
     expect(await store.list('v1', '_history')).toEqual([])
+  })
+
+  // Review fix 1: `saveHistorySnapshot` only called `saveHistory`, dropping
+  // put()'s `maxVersions` auto-prune — a tiered collection with `maxVersions`
+  // configured grew `_history` unbounded across repeated tier moves.
+  it('review-fix-1: maxVersions caps _history growth across repeated tier moves, same as put()', async () => {
+    const store = memoryStoreForTiers()
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'pw-728-max-versions',
+      tiersStrategy: withTiers(), historyStrategy: withHistory(),
+      history: { enabled: true, maxVersions: 2 },
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<HistDoc>('docs', { tiers: [0, 1], perRecordKeys: true })
+
+    await docs.put('d1', { id: 'd1', body: 'v1' })
+    // 5 elevate/demote round-trips = 10 tier-move snapshots, well over maxVersions.
+    for (let i = 0; i < 5; i++) {
+      await docs.elevate('d1', 1)
+      await docs.demote('d1', 0)
+    }
+
+    // Landed back at tier 0 so the public history() read-gate doesn't hide everything.
+    const history = await docs.history('d1')
+    expect(history.length).toBeLessThanOrEqual(2)
+  })
+
+  // Review fix 2: putAtTier built+saved its snapshot AFTER the live write and
+  // AFTER the fallible syncIndexes/syncLedger/syncDerived/syncSearchResilient
+  // calls — a downstream throw stranded the live (already-moved) record with
+  // no pre-move snapshot ever saved. Fault-inject a syncLedger read failure
+  // (a real downstream step putAtTier always runs when tier > 0 and a real
+  // history strategy is wired) and prove the snapshot survives it.
+  it('review-fix-2: putAtTier snapshots the pre-move version BEFORE the live write — a downstream syncLedger throw does not strand it', async () => {
+    const store = memoryStoreForTiers()
+    let failLedgerList = false
+    const wrapped: NoydbStore = {
+      ...store,
+      async list(v, c) {
+        if (c === LEDGER_COLLECTION && failLedgerList) throw new Error('injected: ledger read failure')
+        return store.list(v, c)
+      },
+    }
+    const db = await createNoydb({
+      store: wrapped, user: 'owner', secret: 'pw-728-fix2-order',
+      tiersStrategy: withTiers(), historyStrategy: withHistory(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<HistDoc>('docs', { tiers: [0, 1], perRecordKeys: true })
+
+    await docs.putAtTier('d1', { id: 'd1', body: 'v1' }, 0)
+
+    failLedgerList = true
+    await expect(docs.putAtTier('d1', { id: 'd1', body: 'v2' }, 1)).rejects.toThrow('injected')
+
+    // The live write landed (tier moved) despite the downstream throw...
+    const live = await store.get('v1', 'docs', 'd1')
+    expect(live!._tier).toBe(1)
+
+    // ...and the pre-move version (v1) was snapshotted before that throw could strand it.
+    const snapshot = await store.get('v1', '_history', historyId('docs', 'd1', 1))
+    expect(snapshot).not.toBeNull()
   })
 })

--- a/packages/hub/__tests__/tier-move-history.test.ts
+++ b/packages/hub/__tests__/tier-move-history.test.ts
@@ -1,0 +1,192 @@
+/**
+ * #728 — tier moves (`elevate`/`demote`/`putAtTier`) snapshot the pre-move
+ * version into `_history`. Before this fix, a tier move bumped `_v` and
+ * overwrote the live envelope without ever saving the version that existed
+ * just before the move — `history()` silently lost it.
+ *
+ * HARD correctness constraint (the crux): when the pre-move body is a
+ * tier-0 body (elevate 0→N), its `_history` snapshot must be encrypted
+ * under the DESTINATION tier's DEK, never the tier-0 DEK — otherwise a
+ * tier-0 caller could read the elevated record's body via a raw `_history`
+ * fetch, a new at-rest tier-invisibility leak. `ctx.codec.encryptRecord`
+ * always resolves the tier-0 DEK, so the fix reuses the SAME
+ * `rewrapBodyToDek(envelope, fromDek, toDek)` result each tier-move
+ * function already computes for its live write.
+ *
+ * Plan: docs/superpowers/plans/2026-07-20-728-tier-move-history.md
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/index.js'
+import { ConflictError } from '../src/kernel/errors.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { NOYDB_FORMAT_VERSION, type EncryptedEnvelope, type NoydbStore, type VaultSnapshot } from '../src/kernel/types.js'
+import { unwrapCek, decrypt, type EnclaveKey } from '../src/kernel/enclave/index.js'
+
+interface HistDoc { id: string; body: string }
+
+/** Full-fidelity NoydbStore (optimistic-concurrency `put`) — mirrors
+ * `history-at-rest.test.ts`'s `memoryStoreForTiers`. */
+function memoryStoreForTiers(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+const historyId = (collection: string, recordId: string, version: number) =>
+  `${collection}:${recordId}:${String(version).padStart(10, '0')}`
+
+/** perRecordKeys + withHistory + withTiers ([0,1,2]). */
+async function openHistoryTiers() {
+  const store = memoryStoreForTiers()
+  const db = await createNoydb({
+    store, user: 'owner', secret: 'pw-728-tier-move-history',
+    tiersStrategy: withTiers(), historyStrategy: withHistory(),
+  })
+  const vault = await db.openVault('v1')
+  const docs = vault.collection<HistDoc>('docs', { tiers: [0, 1, 2], perRecordKeys: true })
+  const getDEK = (vault as unknown as { getDEK(name: string): Promise<EnclaveKey> }).getDEK
+  const tier0Dek = await getDEK('docs')
+  const tier1Dek = await getDEK('docs#1')
+  const tier2Dek = await getDEK('docs#2')
+  return { db, vault, docs, store, getDEK, tier0Dek, tier1Dek, tier2Dek }
+}
+
+/** No history strategy wired — tier moves should no-op the snapshot, never throw. */
+async function openTiersNoHistory() {
+  const store = memoryStoreForTiers()
+  const db = await createNoydb({
+    store, user: 'owner', secret: 'pw-728-no-history',
+    tiersStrategy: withTiers(),
+  })
+  const vault = await db.openVault('v1')
+  const docs = vault.collection<HistDoc>('docs', { tiers: [0, 1, 2] })
+  return { store, docs }
+}
+
+describe('#728 tier moves snapshot the pre-move version into _history', () => {
+  it('elevate(0→N) then demote(N→0): history() shows the pre-elevation entry with the original tier-0 body', async () => {
+    const { docs } = await openHistoryTiers()
+    await docs.put('d1', { id: 'd1', body: 'v1-secret' })
+    await docs.elevate('d1', 1)
+    await docs.demote('d1', 0)
+
+    const history = await docs.history('d1')
+    const preElevationEntry = history.find((h) => h.version === 1)
+    expect(preElevationEntry).toBeDefined()
+    expect(preElevationEntry!.record).toMatchObject({ body: 'v1-secret' })
+  })
+
+  it('INVISIBILITY: while elevated, the pre-elevation _history snapshot does not decrypt under tier-0 but does under tier-N', async () => {
+    const { store, docs, tier0Dek, tier1Dek } = await openHistoryTiers()
+    await docs.put('d1', { id: 'd1', body: 'v1-secret' })
+    await docs.elevate('d1', 1)
+
+    const env = await store.get('v1', '_history', historyId('docs', 'd1', 1))
+    expect(env).not.toBeNull()
+    expect(env!._tier).toBeUndefined() // untagged — matches an ordinary put() snapshot shape
+    await expect(unwrapCek(env!._cek!, tier0Dek)).rejects.toThrow()
+    const cek = await unwrapCek(env!._cek!, tier1Dek)
+    expect(await decrypt(env!._iv, env!._data, cek)).toContain('v1-secret')
+
+    // Public read-gate: history() stays hidden while elevated (existing #712 behavior).
+    expect(await docs.history('d1')).toEqual([])
+  })
+
+  it('chained elevate(1→2): the snapshot is wrapped under tier 2, not tier 0 or tier 1', async () => {
+    const { store, docs, tier0Dek, tier1Dek, tier2Dek } = await openHistoryTiers()
+    await docs.put('d1', { id: 'd1', body: 'v1' })
+    await docs.elevate('d1', 1) // v1 → _history:...0001 (tier-1 wrapped)
+    await docs.elevate('d1', 2) // v2 (the tier-1 live body) → _history:...0002 (tier-2 wrapped)
+
+    const secondSnapshot = await store.get('v1', '_history', historyId('docs', 'd1', 2))
+    expect(secondSnapshot).not.toBeNull()
+    await expect(unwrapCek(secondSnapshot!._cek!, tier0Dek)).rejects.toThrow()
+    await expect(unwrapCek(secondSnapshot!._cek!, tier1Dek)).rejects.toThrow()
+    const cek = await unwrapCek(secondSnapshot!._cek!, tier2Dek)
+    expect(await decrypt(secondSnapshot!._iv, secondSnapshot!._data, cek)).toContain('v1')
+
+    // The first elevate's snapshot follows the chain: the trailing syncHistory
+    // rewrap of the second elevate() moves it tier-1 → tier-2 as well.
+    const firstSnapshot = await store.get('v1', '_history', historyId('docs', 'd1', 1))
+    await expect(unwrapCek(firstSnapshot!._cek!, tier1Dek)).rejects.toThrow()
+    await expect(unwrapCek(firstSnapshot!._cek!, tier2Dek)).resolves.toBeDefined()
+  })
+
+  it('demote leaves the snapshot readable at rest under the tier-0 DEK once landed back at tier 0', async () => {
+    const { store, docs, tier0Dek } = await openHistoryTiers()
+    await docs.put('d1', { id: 'd1', body: 'v1-secret' })
+    await docs.elevate('d1', 1)
+    await docs.demote('d1', 0)
+
+    const env = await store.get('v1', '_history', historyId('docs', 'd1', 1))
+    expect(env).not.toBeNull()
+    expect(env!._tier).toBeUndefined()
+    const cek = await unwrapCek(env!._cek!, tier0Dek)
+    expect(await decrypt(env!._iv, env!._data, cek)).toContain('v1-secret')
+  })
+
+  it('putAtTier over an existing record snapshots the prior version', async () => {
+    const { store, docs, tier0Dek } = await openHistoryTiers()
+    await docs.putAtTier('d1', { id: 'd1', body: 'v1' }, 0)
+    await docs.putAtTier('d1', { id: 'd1', body: 'v2' }, 1)
+
+    const env = await store.get('v1', '_history', historyId('docs', 'd1', 1))
+    expect(env).not.toBeNull()
+    expect(env!._tier).toBeUndefined()
+    const history = await docs.history('d1')
+    // Elevated now — read-gate hides it through the API; assert at rest instead.
+    expect(history).toEqual([])
+    await expect(unwrapCek(env!._cek!, tier0Dek)).rejects.toThrow()
+  })
+
+  it('first putAtTier (no existing record) snapshots nothing', async () => {
+    const { store, docs } = await openHistoryTiers()
+    await docs.putAtTier('d1', { id: 'd1', body: 'v1' }, 1)
+
+    expect(await store.list('v1', '_history')).toEqual([])
+  })
+
+  it('history disabled (no withHistory): tier moves add no _history rows and do not throw', async () => {
+    const { store, docs } = await openTiersNoHistory()
+    await docs.put('d1', { id: 'd1', body: 'v1' })
+    await expect(docs.elevate('d1', 1)).resolves.toBeDefined()
+    await expect(docs.demote('d1', 0)).resolves.toBeDefined()
+    await expect(docs.putAtTier('d1', { id: 'd1', body: 'v2' }, 1)).resolves.toBeDefined()
+
+    expect(await store.list('v1', '_history')).toEqual([])
+  })
+})

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -64,7 +64,7 @@ import { validateSchemaInput } from './schema.js'
 import { derivePersistedSchema } from '../with-shape/persisted-schemas/derive.js'
 import type { LedgerStore } from '../with-commit/history/ledger/index.js'
 import type { DiffEntry } from '../with-commit/history/diff.js'
-import type { HistoryStrategy } from '../with-commit/history/strategy.js'
+import { NO_HISTORY, type HistoryStrategy } from '../with-commit/history/strategy.js'
 import { Query, ScanBuilder } from './query/index.js'
 import type { QuerySource, JoinContext, JoinableSource } from './query/index.js'
 import type { CollectionIndexes } from '../with-lookup/indexing/eager-indexes.js'
@@ -4461,9 +4461,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   }
 
   /**
-   * Emit a cross-tier access event. The subscriber sink stays collection-
-   * resident (it captures `onCrossTierAccess`); the tiers module reaches it
-   * via the {@link TiersContext.emitCrossTierEvent} callback.
+   * Emit a cross-tier access event. The subscriber sink stays collection-resident (it captures `onCrossTierAccess`); the tiers module reaches it via the {@link TiersContext.emitCrossTierEvent} callback.
    */
   private emitCrossTierEvent(event: CrossTierAccessEvent): void {
     try {
@@ -4494,8 +4492,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     if (patch.presentForJoin) this.presentForJoin = patch.presentForJoin
   }
   /**
-   * Bind the {@link TiersContext} the tier ops need — `cekCache` by reference
-   * (same `Lru` the read/write path owns) for a synchronous re-wrap; `syncDerived` closes over `this` for {@link syncDerivedOutputs} (#722).
+   * Bind the {@link TiersContext} the tier ops need — `cekCache` by reference (same `Lru` the read/write path owns) for a synchronous re-wrap; `syncDerived` closes over `this` for {@link syncDerivedOutputs} (#722).
    */
   private tiersContext(): TiersContext<T> {
     return {
@@ -4509,6 +4506,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       syncIndexes: (id: string, rec: T | null, version: number, priorEnvelope?: EncryptedEnvelope) => syncTierIndexesImpl(this.indexingContext(), id, rec, version, priorEnvelope),
       syncSearch: (id: string, rec: T | null, version?: number) => syncTierSearchImpl(this.searchContext(), id, rec, version),
       syncHistory: async (id: string, fromDek: EnclaveKey, toDek: EnclaveKey) => this.historyStrategy.rewrapHistory(this.adapter, this.vault, this.name, id, fromDek, toDek, await this.getDEK(this.name)),
+      saveHistorySnapshot: (id: string, envelope: EncryptedEnvelope) => this.historyConfig.enabled !== false ? this.historyStrategy.saveHistory(this.adapter, this.vault, this.name, id, envelope) : Promise.resolve(), // #728: gate folded in here so tiers/index.ts stays simple
+      historyEnabled: this.historyConfig.enabled !== false && this.historyStrategy !== NO_HISTORY, // #728/#737: lets putAtTier skip decrypting `existing` when no real history strategy is wired
       syncBlobs: (id: string, fromTier: number, toTier: number) => this.blobStrategy !== NO_BLOBS ? this.blob(id).syncTierMove(fromTier, toTier, this.blobTierPolicy) : Promise.resolve(), // #724 I1: gate on blob storage enabled (not on declared blobFields) so undeclared-field blobs still rehome; #746: syncTierMove mints/resumes the rehome journal marker; self-no-ops on an empty slot map
       syncLedger: async (id: string) => { await this.ledger?.purgeRecordDeltas(this.name, id) },
       syncDerived: (id: string, record: T | null, elevated: boolean, version?: number) => syncDerivedOutputs(this, id, record, elevated, version),

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -1989,11 +1989,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       })
 
       // Auto-prune if maxVersions configured
-      if (this.historyConfig.maxVersions) {
-        await this.historyStrategy.pruneHistory(this.adapter, this.vault, this.name, id, {
-          keepVersions: this.historyConfig.maxVersions,
-        })
-      }
+      if (this.historyConfig.maxVersions) await this.historyStrategy.pruneHistory(this.adapter, this.vault, this.name, id, { keepVersions: this.historyConfig.maxVersions })
     }
 
     const envelope = await this.codec.encryptRecord(record, version, cek, options?.source, options?.sourceTs, vdigCtx, id)
@@ -4506,7 +4502,12 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       syncIndexes: (id: string, rec: T | null, version: number, priorEnvelope?: EncryptedEnvelope) => syncTierIndexesImpl(this.indexingContext(), id, rec, version, priorEnvelope),
       syncSearch: (id: string, rec: T | null, version?: number) => syncTierSearchImpl(this.searchContext(), id, rec, version),
       syncHistory: async (id: string, fromDek: EnclaveKey, toDek: EnclaveKey) => this.historyStrategy.rewrapHistory(this.adapter, this.vault, this.name, id, fromDek, toDek, await this.getDEK(this.name)),
-      saveHistorySnapshot: (id: string, envelope: EncryptedEnvelope) => this.historyConfig.enabled !== false ? this.historyStrategy.saveHistory(this.adapter, this.vault, this.name, id, envelope) : Promise.resolve(), // #728: gate folded in here so tiers/index.ts stays simple
+      saveHistorySnapshot: async (id: string, envelope: EncryptedEnvelope) => { // #728: gate folded in here so tiers/index.ts stays simple; review fix — mirror put()'s save→emit→prune parity (maxVersions was unbounded on tier moves)
+        if (this.historyConfig.enabled === false) return
+        await this.historyStrategy.saveHistory(this.adapter, this.vault, this.name, id, envelope)
+        this.emitter.emit('history:save', { vault: this.vault, collection: this.name, id, version: envelope._v })
+        if (this.historyConfig.maxVersions) await this.historyStrategy.pruneHistory(this.adapter, this.vault, this.name, id, { keepVersions: this.historyConfig.maxVersions })
+      },
       historyEnabled: this.historyConfig.enabled !== false && this.historyStrategy !== NO_HISTORY, // #728/#737: lets putAtTier skip decrypting `existing` when no real history strategy is wired
       syncBlobs: (id: string, fromTier: number, toTier: number) => this.blobStrategy !== NO_BLOBS ? this.blob(id).syncTierMove(fromTier, toTier, this.blobTierPolicy) : Promise.resolve(), // #724 I1: gate on blob storage enabled (not on declared blobFields) so undeclared-field blobs still rehome; #746: syncTierMove mints/resumes the rehome journal marker; self-no-ops on an empty slot map
       syncLedger: async (id: string) => { await this.ledger?.purgeRecordDeltas(this.name, id) },

--- a/packages/hub/src/kernel/enclave/index.ts
+++ b/packages/hub/src/kernel/enclave/index.ts
@@ -92,7 +92,8 @@ export {
   importCek,
 } from './crypto.js'
 export type { PassphraseKeyUsage } from './crypto.js'
-export { resolveStableCek, rewrapBodyToDek, rewrapEnvelope, isRewrappedUnder } from './record-keys/lifecycle.js'
+export { resolveStableCek, rewrapBodyToDek, rewrapEnvelope, applyRewrappedBody, isRewrappedUnder } from './record-keys/lifecycle.js'
+export type { RewrappedBody } from './record-keys/lifecycle.js'
 
 // ─── record codec ──────────────────────────────────────────────────
 export { RecordCodec } from './record-keys/record-codec.js'

--- a/packages/hub/src/kernel/enclave/record-keys/lifecycle.ts
+++ b/packages/hub/src/kernel/enclave/record-keys/lifecycle.ts
@@ -89,23 +89,18 @@ export async function rewrapBodyToDek(
 }
 
 /**
- * Move a FULL stored envelope from `fromDek` to `toDek`, preserving every
- * field other than the re-keyed body (`_iv`/`_data`/`_cek`) unchanged.
+ * Merge an ALREADY-rewrapped {@link RewrappedBody} into `envelope`, keeping
+ * every field but the re-keyed body (`_iv`/`_data`/`_cek`) unchanged.
  *
  * Body-field access (`_iv`/`_data`/`_cek`) is sanctioned inside the enclave;
- * this lets callers outside it (e.g. `with-commit/history`'s history
- * re-keying) get back a ready-to-store envelope without reading those fields
- * themselves. Mirrors the spread-merge idiom `with-audit/tiers/index.ts`'s
- * `elevate()`/`demote()` use to apply `rewrapBodyToDek`'s result to the live
- * envelope, generalized to any envelope shape (history callers don't bump
- * `_v`/`_ts`/`_tier` the way a tier move does).
+ * this lets callers outside it get back a ready-to-store envelope without
+ * reading those fields themselves. Takes a body the caller has ALREADY
+ * computed (vs. {@link rewrapEnvelope}, which also runs `rewrapBodyToDek`)
+ * so a caller building a SECOND envelope from the same rewrap — a tier
+ * move's live write AND its pre-move `_history` snapshot, #728 — pays the
+ * unwrap/decrypt/encrypt/wrap crypto once, not twice.
  */
-export async function rewrapEnvelope(
-  envelope: EncryptedEnvelope,
-  fromDek: EnclaveKey,
-  toDek: EnclaveKey,
-): Promise<EncryptedEnvelope> {
-  const body = await rewrapBodyToDek(envelope, fromDek, toDek)
+export function applyRewrappedBody(envelope: EncryptedEnvelope, body: RewrappedBody): EncryptedEnvelope {
   const next: EncryptedEnvelope = {
     ...envelope,
     _iv: body._iv,
@@ -116,6 +111,22 @@ export async function rewrapEnvelope(
     delete (next as { _cek?: string })._cek
   }
   return next
+}
+
+/**
+ * Move a FULL stored envelope from `fromDek` to `toDek`, preserving every
+ * field other than the re-keyed body (`_iv`/`_data`/`_cek`) unchanged.
+ * Mirrors the spread-merge idiom `with-audit/tiers/index.ts`'s
+ * `elevate()`/`demote()` use to apply `rewrapBodyToDek`'s result to the live
+ * envelope, generalized to any envelope shape (history callers don't bump
+ * `_v`/`_ts`/`_tier` the way a tier move does).
+ */
+export async function rewrapEnvelope(
+  envelope: EncryptedEnvelope,
+  fromDek: EnclaveKey,
+  toDek: EnclaveKey,
+): Promise<EncryptedEnvelope> {
+  return applyRewrappedBody(envelope, await rewrapBodyToDek(envelope, fromDek, toDek))
 }
 
 /**

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -422,6 +422,31 @@ export async function putAtTier<T>(
   // admin/custodian still bypass (they may mint, same as elevate/demote).
   assertTierAccess(ctx.keyring, ctx.name, existing?._tier ?? 0)
   const version = existing ? existing._v + 1 : 1
+
+  // #728 review-fix-2: resolve the from-tier DEK and snapshot the PRE-move
+  // version BEFORE the live write below, mirroring elevate()/demote() —
+  // originally this ran much later (after syncIndexes/syncLedger/syncDerived/
+  // syncSearchResilient), so a throw in any of those left the live record
+  // already moved with `existing` — its sole pre-move copy — gone, silently
+  // losing the version #728 exists to preserve. `fromKey`/`fromDek` are
+  // resolved ONCE here and reused below for the trailing syncHistory rewrap.
+  const fromKey = dekKey(ctx.name, existing?._tier ?? 0)
+  const fromDek = await ctx.getDEK(fromKey)
+  if (existing && ctx.historyEnabled) {
+    // Snapshot the version this write is about to overwrite — same law as
+    // Collection.put()'s history save, extended to putAtTier (#728). Rewrap
+    // under the DESTINATION `dek` via `applyRewrappedBody` (never
+    // `ctx.codec.encryptRecord`, which always resolves the tier-0 DEK and
+    // would leak this body at rest whenever the prior tier was > 0).
+    // Untagged (`_tier`/`_elevatedBy` stripped), same as elevate()/
+    // demote()'s snapshots. `_v` stays the PRE-move version (unbumped), as
+    // `preCarried` already carries it.
+    const body = await rewrapBodyToDek(existing, fromDek, dek)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- excluded from ...preCarried
+    const { _tier: _preTier, _elevatedBy: _preElevatedBy, ...preCarried } = existing
+    await ctx.saveHistorySnapshot(id, applyRewrappedBody(preCarried, body))
+  }
+
   const json = JSON.stringify(record)
   const { iv, data } = await encrypt(json, dek)
   const envelope: EncryptedEnvelope = {
@@ -512,26 +537,9 @@ export async function putAtTier<T>(
   // reopen #709/#721/#723 on the error path). A direct putAtTier also moves
   // the record's tier — its history snapshots (if any exist from an earlier
   // tier-0 put()) must follow, same as elevate/demote. Skip when the record
-  // was already at this tier (no move, nothing to rewrap).
-  const fromKey = dekKey(ctx.name, existing?._tier ?? 0)
-  // #728: resolve the from-tier DEK once — reused below for BOTH the
-  // pre-move history snapshot and (when the tier actually changed) the
-  // trailing syncHistory rewrap, instead of resolving it twice.
-  const fromDek = await ctx.getDEK(fromKey)
-  if (existing && ctx.historyEnabled) {
-    // Snapshot the version this write is about to overwrite — same law as
-    // Collection.put()'s history save, extended to putAtTier (#728). Rewrap
-    // under the DESTINATION `dek` via `applyRewrappedBody` (never
-    // `ctx.codec.encryptRecord`, which always resolves the tier-0 DEK and
-    // would leak this body at rest whenever the prior tier was > 0).
-    // Untagged (`_tier`/`_elevatedBy` stripped), same as elevate()/
-    // demote()'s snapshots. `_v` stays the PRE-move version (unbumped), as
-    // `preCarried` already carries it.
-    const body = await rewrapBodyToDek(existing, fromDek, dek)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- excluded from ...preCarried
-    const { _tier: _preTier, _elevatedBy: _preElevatedBy, ...preCarried } = existing
-    await ctx.saveHistorySnapshot(id, applyRewrappedBody(preCarried, body))
-  }
+  // was already at this tier (no move, nothing to rewrap). `fromKey`/
+  // `fromDek` were already resolved above (review-fix-2), before the live
+  // write, for the pre-move snapshot — reused here rather than recomputed.
   if (fromKey !== key) {
     await ctx.syncHistory(id, fromDek, dek)
     // #724: this putAtTier moved the record's tier — rehome its blobs too.

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -23,7 +23,7 @@
 export { withTiers } from './active.js'
 export { NO_TIERS, type TiersStrategy } from './strategy.js'
 export { TiersNotEnabledError } from '../../kernel/errors.js'
-import { encrypt, decrypt, unwrapCek, rewrapBodyToDek, isDeleteMarker, isTombstoneShape, type RecordCodec, type EnclaveKey, type SealedShredSlot } from '../../kernel/enclave/index.js'
+import { encrypt, decrypt, unwrapCek, rewrapBodyToDek, applyRewrappedBody, isDeleteMarker, isTombstoneShape, type RecordCodec, type EnclaveKey, type SealedShredSlot } from '../../kernel/enclave/index.js'
 import { TierDemoteDeniedError, UnsupportedTierCompositionError, PersistedIndexCompensationError } from '../../kernel/errors.js'
 import { dekKey, assertTierAccess } from '../../with-party/team/tiers.js'
 import type { UnlockedKeyring } from '../../with-party/team/keyring.js'
@@ -118,6 +118,32 @@ export interface TiersContext<T> {
    * recompute. No-op when the strategy is `NO_HISTORY`.
    */
   syncHistory(id: string, fromDek: EnclaveKey, toDek: EnclaveKey): Promise<void>
+  /**
+   * Save a raw pre-move envelope as a `_history` snapshot (#728). Tier moves
+   * (`putAtTier`/`elevate`/`demote`) bump `_v` and overwrite the live
+   * envelope without ever snapshotting the version that existed just before
+   * the move — so `history()` silently lost it. The caller (`tiers/index.ts`)
+   * builds `envelope` by reusing the SAME `rewrapBodyToDek(envelope, fromDek,
+   * toDek)` result it already computed for the live write, so the snapshot
+   * lands wrapped under the DESTINATION tier's DEK — never `ctx.codec.
+   * encryptRecord`, which always resolves the tier-0 DEK and would leak the
+   * pre-move body whenever `fromTier > 0`. No-op when history is disabled
+   * (folds the `historyConfig.enabled` gate so `tiers/index.ts` stays simple).
+   */
+  saveHistorySnapshot(id: string, envelope: EncryptedEnvelope): Promise<void>
+  /**
+   * `true` iff a real history strategy is wired (not `NO_HISTORY`) AND not
+   * explicitly disabled via `historyConfig.enabled`. `putAtTier` checks this
+   * BEFORE decrypting `existing` to build a snapshot (#728, #737 regression
+   * fix) — unlike elevate/demote, which reuse a `body` rewrap their live
+   * write needs unconditionally, putAtTier's live write never decrypts the
+   * prior envelope, so building a snapshot is the ONLY reason it would
+   * touch (and potentially throw decrypting) `existing`'s ciphertext. A
+   * derivation-free, history-disabled collection must not pay that decode —
+   * or risk it, on a corrupted/inaccessible prior body — same law
+   * `hasDerivedOutputs` already enforces for the derived-outputs decode.
+   */
+  readonly historyEnabled: boolean
   /**
    * Rehome a record's blob attachments after a tier move (#724 Arc 10 Task
    * 2, at-rest hardening). A blob's home tier is its owning record's tier —
@@ -488,8 +514,26 @@ export async function putAtTier<T>(
   // tier-0 put()) must follow, same as elevate/demote. Skip when the record
   // was already at this tier (no move, nothing to rewrap).
   const fromKey = dekKey(ctx.name, existing?._tier ?? 0)
+  // #728: resolve the from-tier DEK once — reused below for BOTH the
+  // pre-move history snapshot and (when the tier actually changed) the
+  // trailing syncHistory rewrap, instead of resolving it twice.
+  const fromDek = await ctx.getDEK(fromKey)
+  if (existing && ctx.historyEnabled) {
+    // Snapshot the version this write is about to overwrite — same law as
+    // Collection.put()'s history save, extended to putAtTier (#728). Rewrap
+    // under the DESTINATION `dek` via `applyRewrappedBody` (never
+    // `ctx.codec.encryptRecord`, which always resolves the tier-0 DEK and
+    // would leak this body at rest whenever the prior tier was > 0).
+    // Untagged (`_tier`/`_elevatedBy` stripped), same as elevate()/
+    // demote()'s snapshots. `_v` stays the PRE-move version (unbumped), as
+    // `preCarried` already carries it.
+    const body = await rewrapBodyToDek(existing, fromDek, dek)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- excluded from ...preCarried
+    const { _tier: _preTier, _elevatedBy: _preElevatedBy, ...preCarried } = existing
+    await ctx.saveHistorySnapshot(id, applyRewrappedBody(preCarried, body))
+  }
   if (fromKey !== key) {
-    await ctx.syncHistory(id, await ctx.getDEK(fromKey), dek)
+    await ctx.syncHistory(id, fromDek, dek)
     // #724: this putAtTier moved the record's tier — rehome its blobs too.
     await ctx.syncBlobs(id, existing?._tier ?? 0, tier)
   }
@@ -654,6 +698,18 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   const now = new Date().toISOString()
   const body = await rewrapBodyToDek(envelope, fromDek, toDek)
   if (body.cek) ctx.cekCache?.set(id, body.cek, 1)
+  // #728: snapshot the PRE-move version into `_history` before it's
+  // overwritten below — reuses `body` (already fromDek→toDek) via
+  // `applyRewrappedBody` (never `ctx.codec.encryptRecord`, which always
+  // resolves the tier-0 DEK and would leak this body at rest whenever
+  // `fromTier > 0`). Untagged (`_tier`/`_elevatedBy` stripped) so the
+  // history read-gate doesn't hide it PERMANENTLY once the record demotes
+  // back — at-rest protection comes from the ciphertext being under
+  // `toDek`, not from the tag. `_v` stays the PRE-move version (unbumped),
+  // exactly as `envelope` already carries it.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- excluded from ...snapshot
+  const { _tier: _preTier, _elevatedBy: _preElevatedBy, ...snapshot } = applyRewrappedBody(envelope, body)
+  await ctx.saveHistorySnapshot(id, snapshot)
   // #662: spread every slot the source carries (_sealed/_det/_vdig/_bidx/
   // _source/_sourceTs/_debug) through UNCHANGED, then override only
   // the fields a tier move manages. rewrapBodyToDek preserves the CEK, so no
@@ -762,6 +818,14 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
   // both are destructured out of the spread rather than carried.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- excluded from ...carried
   const { _elevatedBy, _tier: _priorTier, ...carried } = envelope
+  // #728: snapshot the PRE-move version into `_history` — reuses `body`
+  // (already fromDek→toDek) and `carried` (envelope minus `_tier`/
+  // `_elevatedBy`, computed above for the live write) via
+  // `applyRewrappedBody`, so a tier-0-landing demote's snapshot is untagged
+  // just like an ordinary put() entry, same law as elevate()'s snapshot
+  // above. `_v` stays the PRE-move version (unbumped), as `carried` already
+  // carries it.
+  await ctx.saveHistorySnapshot(id, applyRewrappedBody(carried, body))
   const next: EncryptedEnvelope = {
     ...carried,
     _noydb: NOYDB_FORMAT_VERSION,


### PR DESCRIPTION
Closes #728 (milestone 34 — tier-invisibility hardening).

## Problem
`elevate`/`demote`/`putAtTier` bumped `_v+1` and `adapter.put` the rewrapped live envelope but **never** snapshotted the pre-move version into `_history` — so `history()` silently lost the version that existed just before a tier move (a normal `put()` snapshots the prior version). This is a version-chain completeness gap, not data loss.

## Fix
All three tier-move ops now snapshot the pre-move version into `_history`.

The snapshot is built from the `body = rewrapBodyToDek(envelope, fromDek, toDek)` each function already computes for its live write (via the extracted enclave-internal `applyRewrappedBody` helper) — **never** through `codec.encryptRecord`, which is hard-wired to the tier-0 DEK and would leak an elevated record's body into a tier-0-readable history row whenever `fromTier > 0`. Concretely the snapshot:
- is encrypted under the **destination**-tier DEK (tier-invisible at rest — a tier-0 caller cannot decrypt an elevated record's history entry);
- keeps the **pre-move** `_v` and **strips** `_tier`/`_elevatedBy`, so a later demote-to-0 makes it visible again rather than permanently hidden;
- is saved **before** the trailing `syncHistory` rewrap and is idempotent against it.

A new `TiersContext.saveHistorySnapshot` (implemented in the `tiersContext()` binder) carries `put()`'s full history semantics — including `history:save` emission and `maxVersions` pruning, so tiered collections don't grow `_history` unbounded. `putAtTier` saves its snapshot before the live write so a downstream throw can't lose the pre-move body. History-disabled collections write nothing and do no wasted decrypt.

## Verification
- New `tier-move-history.test.ts` (9 tests, incl. an at-rest **invisibility** assertion that the snapshot ciphertext rejects the tier-0 DEK and decrypts only under tier N, a chained elevate(1→2) case, `maxVersions`×tiers pruning bound, and a `putAtTier` save-before-write fault-injection test).
- Full hub suite green (4356 tests); typecheck, lint, `check:architecture` all pass. `collection.ts` funded shrink-first, exactly at its 4549 ceiling; `vault.ts` untouched.
- Two review passes (task + adversarial whole-branch on the strongest model): final verdict Ready to merge.

Not published; changeset is local per repo convention.