### PR TITLE
fix(hub): namespace _vec sidecars by collection — no cross-collection id collision, clobber, or crash (#726)

### DIFF
--- a/packages/hub/__tests__/embeddings-forget.test.ts
+++ b/packages/hub/__tests__/embeddings-forget.test.ts
@@ -102,18 +102,18 @@ describe('embeddings forget — case 1: _vec purged + excluded from retrieve', (
     await docs.put('doc-b', { id: 'doc-b', text: 'client account setup', ownerId: 'bob' })
 
     // Both _vec sidecars exist before forget.
-    expect(await store.get('vec-v', '_vec', 'doc-a')).not.toBeNull()
-    expect(await store.get('vec-v', '_vec', 'doc-b')).not.toBeNull()
+    expect(await store.get('vec-v', '_vec', 'docs/doc-a')).not.toBeNull()
+    expect(await store.get('vec-v', '_vec', 'docs/doc-b')).not.toBeNull()
 
     // Forget alice's record.
     const result = await vault.forget('alice')
     expect(result.recordsShredded).toBe(1)
 
     // doc-a's _vec sidecar must be gone.
-    expect(await store.get('vec-v', '_vec', 'doc-a')).toBeNull()
+    expect(await store.get('vec-v', '_vec', 'docs/doc-a')).toBeNull()
 
     // doc-b's _vec sidecar must be intact.
-    expect(await store.get('vec-v', '_vec', 'doc-b')).not.toBeNull()
+    expect(await store.get('vec-v', '_vec', 'docs/doc-b')).not.toBeNull()
 
     // Semantic retrieve must exclude the forgotten record.
     // Open a fresh vault so the in-memory vectorSet is cold and rebuilt from store.
@@ -182,11 +182,11 @@ describe('embeddings forget — case 3: idempotent second forget', () => {
 
     // First forget.
     await vault.forget('dave')
-    expect(await store.get('vec-i', '_vec', 'doc-y')).toBeNull()
+    expect(await store.get('vec-i', '_vec', 'docs/doc-y')).toBeNull()
 
     // Second forget — idempotent, no throw.
     const result2 = await vault.forget('dave')
     expect(result2.recordsShredded).toBe(0)
-    expect(await store.get('vec-i', '_vec', 'doc-y')).toBeNull()
+    expect(await store.get('vec-i', '_vec', 'docs/doc-y')).toBeNull()
   })
 })

--- a/packages/hub/__tests__/embeddings-retrieve.test.ts
+++ b/packages/hub/__tests__/embeddings-retrieve.test.ts
@@ -160,7 +160,7 @@ describe('semantic retrieval (#308 L2)', () => {
     expect(puts.filter((p) => p.startsWith('_vec/'))).toHaveLength(0)
 
     // The raw envelope body stored in _vec should not contain the plaintext source text
-    const env = await store.get('v', '_vec', 'doc1')
+    const env = await store.get('v', '_vec', 'docs/doc1')
     expect(JSON.stringify(env)).not.toContain('overdue')
     expect(JSON.stringify(env)).not.toContain('invoice')
   })

--- a/packages/hub/__tests__/embeddings-vec-id.test.ts
+++ b/packages/hub/__tests__/embeddings-vec-id.test.ts
@@ -30,6 +30,12 @@ describe('encodeVecId / decodeVecId', () => {
   })
 })
 
+describe('encodeVecId rejects ambiguous collection names', () => {
+  it('throws when the collection name contains "/" (would make isVecIdFor\'s prefix match ambiguous)', () => {
+    expect(() => encodeVecId('a/b', 'x')).toThrow()
+  })
+})
+
 describe('isVecIdFor', () => {
   it('is true for ids belonging to the collection', () => {
     expect(isVecIdFor('docs', 'docs/x')).toBe(true)

--- a/packages/hub/__tests__/embeddings-vec-id.test.ts
+++ b/packages/hub/__tests__/embeddings-vec-id.test.ts
@@ -1,0 +1,44 @@
+/**
+ * `_vec` side-car id encode/decode (#726) — collection-namespaced keys.
+ */
+import { describe, it, expect } from 'vitest'
+import { encodeVecId, decodeVecId, isVecIdFor } from '../src/with-lookup/embeddings/vec-id.js'
+
+describe('encodeVecId / decodeVecId', () => {
+  it('round-trips collection + recordId', () => {
+    const id = encodeVecId('docs', 'doc-1')
+    expect(id).toBe('docs/doc-1')
+    expect(decodeVecId('docs', id)).toBe('doc-1')
+  })
+
+  it('decodes record ids that contain slashes (strips known prefix, does not split)', () => {
+    const id = encodeVecId('docs', 'nested/id/with/slashes')
+    expect(id).toBe('docs/nested/id/with/slashes')
+    expect(decodeVecId('docs', id)).toBe('nested/id/with/slashes')
+  })
+
+  it('returns null when the id does not belong to the given collection', () => {
+    const id = encodeVecId('docs', 'x')
+    expect(decodeVecId('other', id)).toBeNull()
+  })
+
+  it('does not falsely match a collection whose name is a prefix of another', () => {
+    // collection 'a' vs 'ab': 'a/foo' must not decode under 'ab', and
+    // 'ab/foo' must not decode under 'a'.
+    expect(decodeVecId('ab', encodeVecId('a', 'foo'))).toBeNull()
+    expect(decodeVecId('a', encodeVecId('ab', 'foo'))).toBeNull()
+  })
+})
+
+describe('isVecIdFor', () => {
+  it('is true for ids belonging to the collection', () => {
+    expect(isVecIdFor('docs', 'docs/x')).toBe(true)
+    expect(isVecIdFor('docs', 'docs/nested/id/with/slashes')).toBe(true)
+  })
+
+  it('is false for ids belonging to a different collection', () => {
+    expect(isVecIdFor('docs', 'other/x')).toBe(false)
+    expect(isVecIdFor('ab', 'a/foo')).toBe(false)
+    expect(isVecIdFor('a', 'ab/foo')).toBe(false)
+  })
+})

--- a/packages/hub/__tests__/embeddings-vec-namespace.test.ts
+++ b/packages/hub/__tests__/embeddings-vec-namespace.test.ts
@@ -1,0 +1,157 @@
+/**
+ * #726 — `_vec` embedding sidecars are collection-namespaced. Before this
+ * fix, `_vec` rows were keyed by the bare record id, vault-wide: two
+ * collections sharing a record id shared ONE `_vec` row, so (a) collection
+ * A's `similarTo()` could surface collection B's — possibly ELEVATED —
+ * embedding, and (b) writing/forgetting a record in A could clobber or
+ * delete B's same-id sidecar. Fixture pattern mirrors `tiers-search.test.ts`
+ * (memoryStore + stub encoder) and `embeddings-forget.test.ts` (forget
+ * harness).
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withSearch, ConflictError } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+
+interface Doc {
+  id: string
+  body: string
+  ownerId?: string
+}
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+// Deterministic stub encoder: 8-dim bag-of-chars hash → Float32Array.
+const enc = (dim: number, model = 'stub') => ({
+  dim, model, source: 'body' as const,
+  encode: async (t: string) => { const v = new Float32Array(dim); for (let i = 0; i < t.length; i++) { const idx = t.charCodeAt(i) % dim; v[idx] = (v[idx] ?? 0) + 1 } return v },
+})
+const ENCODER = enc(8)
+
+const SECRET = 'vec-namespace-passphrase-726'
+
+describe('#726 leak closed: A\'s similarTo() never surfaces B\'s elevated embedding', () => {
+  it('a legacy bare-id survivor row (vault-wide, un-namespaced) is invisible to a sibling collection', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, user: 'owner', secret: SECRET,
+      searchStrategy: withSearch(), tiersStrategy: withTiers(),
+    })
+    const vault = await db.openVault('v1')
+    const a = vault.collection<Doc>('a', { tiers: [0, 1], perRecordKeys: true, embeddings: ENCODER })
+    const b = vault.collection<Doc>('b', { tiers: [0, 1], perRecordKeys: true, embeddings: ENCODER })
+
+    // Collection A never writes a record 'x' of its own.
+    await b.put('x', { id: 'x', body: 'topsecret-restricted-alpha' })
+    const bVecRow = await store.get('v1', '_vec', 'b/x')
+    expect(bVecRow).not.toBeNull()
+
+    // B elevates its own 'x' — the tier-0 DEK sidecar must not survive.
+    await b.elevate('x', 1)
+    expect(await store.get('v1', '_vec', 'b/x')).toBeNull()
+
+    // Simulate a legacy pre-#726 survivor: the physical row shape a
+    // vault-wide, un-namespaced `_vec` bucket would have left behind for
+    // record id 'x' (same bare id B just wrote, now elevated). This is
+    // exactly the row collection A's OLD (bare-id) buildVectorLoad would
+    // have picked up: A has no live record 'x' of its own, so the elevation
+    // gate (checked against A's OWN collection) would have passed, and A's
+    // similarTo() would have decrypted and returned B's elevated content.
+    await store.put('v1', '_vec', 'x', bVecRow!)
+
+    const qVec = await ENCODER.encode('topsecret-restricted-alpha')
+    const hits = await a.similarTo(qVec)
+    expect(hits.map((h) => h.id)).not.toContain('x')
+    expect(hits).toEqual([]) // A has no vector rows of its own at all
+  })
+})
+
+describe('#726 isolation: same record id in two collections keeps separate _vec rows', () => {
+  it('writing A\'s x does not clobber B\'s x', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'owner', secret: SECRET, searchStrategy: withSearch() })
+    const vault = await db.openVault('v2')
+    const a = vault.collection<Doc>('a', { embeddings: ENCODER })
+    const b = vault.collection<Doc>('b', { embeddings: ENCODER })
+
+    await a.put('x', { id: 'x', body: 'alpha content from collection A' })
+    await b.put('x', { id: 'x', body: 'zzzzzzzzzzzz totally different from B' })
+
+    const aRow = await store.get('v2', '_vec', 'a/x')
+    const bRow = await store.get('v2', '_vec', 'b/x')
+    expect(aRow).not.toBeNull()
+    expect(bRow).not.toBeNull()
+    expect(JSON.stringify(aRow)).not.toEqual(JSON.stringify(bRow))
+
+    // Each collection's similarTo() still finds its own 'x'.
+    const aQVec = await ENCODER.encode('alpha content from collection A')
+    expect((await a.similarTo(aQVec)).map((h) => h.id)).toContain('x')
+    const bQVec = await ENCODER.encode('zzzzzzzzzzzz totally different from B')
+    expect((await b.similarTo(bQVec)).map((h) => h.id)).toContain('x')
+  })
+
+  it('forgetting A\'s x does not delete B\'s x sidecar', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, user: 'owner', secret: SECRET,
+      searchStrategy: withSearch(),
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { a: 'ownerId', b: 'ownerId' } }),
+    })
+    const vault = await db.openVault('v3')
+    const a = vault.collection<Doc>('a', { embeddings: ENCODER })
+    const b = vault.collection<Doc>('b', { embeddings: ENCODER })
+
+    await a.put('x', { id: 'x', body: 'alpha content from collection A', ownerId: 'alice' })
+    await b.put('x', { id: 'x', body: 'zzzzzzzzzzzz totally different from B', ownerId: 'bob' })
+    expect(await store.get('v3', '_vec', 'a/x')).not.toBeNull()
+    expect(await store.get('v3', '_vec', 'b/x')).not.toBeNull()
+
+    const result = await vault.forget('alice')
+    expect(result.recordsShredded).toBe(1)
+
+    expect(await store.get('v3', '_vec', 'a/x')).toBeNull()
+    expect(await store.get('v3', '_vec', 'b/x')).not.toBeNull() // untouched
+
+    const bQVec = await ENCODER.encode('zzzzzzzzzzzz totally different from B')
+    expect((await b.similarTo(bQVec)).map((h) => h.id)).toContain('x')
+  })
+})

--- a/packages/hub/__tests__/embeddings-vec-namespace.test.ts
+++ b/packages/hub/__tests__/embeddings-vec-namespace.test.ts
@@ -1,16 +1,22 @@
 /**
  * #726 — `_vec` embedding sidecars are collection-namespaced. Before this
  * fix, `_vec` rows were keyed by the bare record id, vault-wide: two
- * collections sharing a record id shared ONE `_vec` row, so (a) collection
- * A's `similarTo()` could surface collection B's — possibly ELEVATED —
- * embedding, and (b) writing/forgetting a record in A could clobber or
- * delete B's same-id sidecar. Fixture pattern mirrors `tiers-search.test.ts`
- * (memoryStore + stub encoder) and `embeddings-forget.test.ts` (forget
- * harness).
+ * collections sharing a record id shared ONE `_vec` row.
+ *
+ * This is NOT a confidentiality-disclosure bug: every collection has its own
+ * DEK, and AES-GCM auth-tag verification means decrypting a foreign
+ * collection's row under the wrong DEK throws `TamperedError` rather than
+ * returning wrong plaintext — verified empirically, no two ordinary
+ * collections share a DEK, so a cross-collection read cannot occur. The real
+ * bug was id collision: (a) writing/forgetting a record in A could clobber
+ * or delete B's same-id sidecar, and (b) a collection whose `similarTo()` /
+ * cold semantic `retrieve()` encountered a foreign same-id row crashed with
+ * an uncaught `TamperedError` (a denial-of-service). Fixture pattern mirrors
+ * `tiers-search.test.ts` (memoryStore + stub encoder) and
+ * `embeddings-forget.test.ts` (forget harness).
  */
 import { describe, it, expect } from 'vitest'
 import { createNoydb, withSearch, ConflictError } from '../src/index.js'
-import { withTiers } from '../src/with-audit/tiers/index.js'
 import { withHistory } from '../src/with-commit/history/index.js'
 import { withForgetCascade } from '../src/with-audit/forget/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
@@ -68,39 +74,32 @@ const ENCODER = enc(8)
 
 const SECRET = 'vec-namespace-passphrase-726'
 
-describe('#726 leak closed: A\'s similarTo() never surfaces B\'s elevated embedding', () => {
-  it('a legacy bare-id survivor row (vault-wide, un-namespaced) is invisible to a sibling collection', async () => {
+describe('#726 crash/clobber closed: same record id in two collections neither collides nor crashes similarTo() (NOT a disclosure bug)', () => {
+  it('A.similarTo() returns only A\'s own "x" row — no TamperedError crash, no blending of B\'s content', async () => {
     const store = memoryStore()
-    const db = await createNoydb({
-      store, user: 'owner', secret: SECRET,
-      searchStrategy: withSearch(), tiersStrategy: withTiers(),
-    })
+    const db = await createNoydb({ store, user: 'owner', secret: SECRET, searchStrategy: withSearch() })
     const vault = await db.openVault('v1')
-    const a = vault.collection<Doc>('a', { tiers: [0, 1], perRecordKeys: true, embeddings: ENCODER })
-    const b = vault.collection<Doc>('b', { tiers: [0, 1], perRecordKeys: true, embeddings: ENCODER })
+    const a = vault.collection<Doc>('a', { embeddings: ENCODER })
+    const b = vault.collection<Doc>('b', { embeddings: ENCODER })
 
-    // Collection A never writes a record 'x' of its own.
-    await b.put('x', { id: 'x', body: 'topsecret-restricted-alpha' })
-    const bVecRow = await store.get('v1', '_vec', 'b/x')
-    expect(bVecRow).not.toBeNull()
+    // Both collections hold record id 'x' with different content. Under
+    // pre-#726 bare-id keying this pair collided on a single '_vec/x' row:
+    // B's put() below would silently CLOBBER A's row with B's ciphertext
+    // (encrypted under B's DEK, since A and B never share a DEK).
+    await a.put('x', { id: 'x', body: 'alpha content from collection A' })
+    await b.put('x', { id: 'x', body: 'zzzzzzzzzzzz totally different from B' })
 
-    // B elevates its own 'x' — the tier-0 DEK sidecar must not survive.
-    await b.elevate('x', 1)
-    expect(await store.get('v1', '_vec', 'b/x')).toBeNull()
-
-    // Simulate a legacy pre-#726 survivor: the physical row shape a
-    // vault-wide, un-namespaced `_vec` bucket would have left behind for
-    // record id 'x' (same bare id B just wrote, now elevated). This is
-    // exactly the row collection A's OLD (bare-id) buildVectorLoad would
-    // have picked up: A has no live record 'x' of its own, so the elevation
-    // gate (checked against A's OWN collection) would have passed, and A's
-    // similarTo() would have decrypted and returned B's elevated content.
-    await store.put('v1', '_vec', 'x', bVecRow!)
-
-    const qVec = await ENCODER.encode('topsecret-restricted-alpha')
-    const hits = await a.similarTo(qVec)
-    expect(hits.map((h) => h.id)).not.toContain('x')
-    expect(hits).toEqual([]) // A has no vector rows of its own at all
+    const aQVec = await ENCODER.encode('alpha content from collection A')
+    // Pre-fix: buildVectorLoad for A would find the (now B-owned) '_vec/x'
+    // row, pass A's OWN elevation gate (checked against A's live record, not
+    // B's), then try to decrypt B's ciphertext under A's DEK. AES-GCM
+    // auth-tag verification fails on a wrong-key decrypt, so this THROWS an
+    // uncaught TamperedError (a crash / DoS) — it never returns B's
+    // plaintext to A. The fix (collection-namespaced ids) means A only ever
+    // sees its own 'a/x' row: no throw, no clobber, no blending.
+    const hits = await a.similarTo(aQVec)
+    expect(hits.map((h) => h.id)).toContain('x')
+    expect(hits).toHaveLength(1)
   })
 })
 

--- a/packages/hub/__tests__/embeddings-vec-namespace.test.ts
+++ b/packages/hub/__tests__/embeddings-vec-namespace.test.ts
@@ -154,3 +154,30 @@ describe('#726 isolation: same record id in two collections keeps separate _vec 
     expect((await b.similarTo(bQVec)).map((h) => h.id)).toContain('x')
   })
 })
+
+describe('#726 residual gap: a surviving "<collection>/" row that cannot be decrypted is skipped, not fatal', () => {
+  it('similarTo() returns own legitimate results and does not throw on a poison row', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'owner', secret: SECRET, searchStrategy: withSearch() })
+    const vault = await db.openVault('v4')
+    const a = vault.collection<Doc>('a', { embeddings: ENCODER })
+    const b = vault.collection<Doc>('b', { embeddings: ENCODER })
+
+    await a.put('x', { id: 'x', body: 'alpha content from collection A' })
+    await b.put('y', { id: 'y', body: 'zzzzzzzzzzzz totally different from B' })
+
+    // Simulate a surviving legacy/foreign row: an id that still begins with
+    // 'a/' (so it passes A's isVecIdFor prefix filter and decodes to a
+    // record id, 'poison', that never exists in A — the elevation gate
+    // peeks A's own live envelope for that id and finds none, so it does not
+    // skip this row either) but whose ciphertext was written under B's DEK.
+    // Decrypting it under A's DEK fails AES-GCM auth-tag verification.
+    const bRow = await store.get('v4', '_vec', 'b/y')
+    expect(bRow).not.toBeNull()
+    await store.put('v4', '_vec', 'a/poison', bRow!)
+
+    const aQVec = await ENCODER.encode('alpha content from collection A')
+    const hits = await a.similarTo(aQVec)
+    expect(hits.map((h) => h.id)).toEqual(['x'])
+  })
+})

--- a/packages/hub/__tests__/embeddings-write.test.ts
+++ b/packages/hub/__tests__/embeddings-write.test.ts
@@ -62,8 +62,8 @@ describe('embeddings write derivation (#308 L2)', () => {
     const v = await db.openVault('v')
     const c = v.collection<Doc>('d', { embeddings: enc(8) })
     await c.put('x', { id: 'x', text: 'overdue invoice' })
-    expect(puts.some((p) => p.startsWith('_vec/x'))).toBe(true)
-    const env = await wrapped.get('v', '_vec', 'x')
+    expect(puts.some((p) => p.startsWith('_vec/d/x'))).toBe(true)
+    const env = await wrapped.get('v', '_vec', 'd/x')
     expect(JSON.stringify(env)).not.toContain('overdue')          // source text not leaked
     expect((await c.list()).map((r) => r.id)).toEqual(['x'])   // _vec not a phantom record
   })

--- a/packages/hub/__tests__/tiers-search.test.ts
+++ b/packages/hub/__tests__/tiers-search.test.ts
@@ -168,7 +168,7 @@ describe('#721 vector (_vec)', () => {
     const { docs } = await h.open()
     await docs.put('e1', { id: 'e1', body: 'alpha' })
     await docs.put('t0', { id: 't0', body: 'zzzzzzzzzzzzzzzzzzzzz' })
-    expect(await h.store.get('v1', '_vec', 'e1')).not.toBeNull()
+    expect(await h.store.get('v1', '_vec', 'docs/e1')).not.toBeNull()
 
     const qVec = await ENCODER.encode('alpha')
     // Load the VectorSet into memory BEFORE elevate — otherwise the "warm"
@@ -179,7 +179,7 @@ describe('#721 vector (_vec)', () => {
     expect((await docs.similarTo(qVec)).map(x => x.id)).toContain('e1') // warm, pre-elevate
 
     await docs.elevate('e1', 1)
-    expect(await h.store.get('v1', '_vec', 'e1')).toBeNull() // sidecar purged
+    expect(await h.store.get('v1', '_vec', 'docs/e1')).toBeNull() // sidecar purged
 
     // Warm (same-session) eviction: elevate dirtied the VectorSet, so the
     // in-session similarTo rebuilds without e1 — not only the cold reopen below.
@@ -199,9 +199,9 @@ describe('#721 vector (_vec)', () => {
     // Force the precondition demote must handle regardless of elevate's own
     // purge (isolates demote's re-embed responsibility from the elevate test
     // above): the _vec sidecar is gone before demote runs.
-    await h.store.delete('v1', '_vec', 'e1')
+    await h.store.delete('v1', '_vec', 'docs/e1')
     await docs.demote('e1', 0)
-    expect(await h.store.get('v1', '_vec', 'e1')).not.toBeNull()
+    expect(await h.store.get('v1', '_vec', 'docs/e1')).not.toBeNull()
 
     const cold = await h.open()
     const qVec = await ENCODER.encode('alpha')
@@ -219,11 +219,11 @@ describe('#721 defense-in-depth: buildVectorLoad gate', () => {
     const h = searchHarness({ embeddings: true })
     const { docs } = await h.open()
     await docs.put('leaky', { id: 'leaky', body: 'alpha' })
-    const vecRow = await h.store.get('v1', '_vec', 'leaky') // capture a real _vec envelope
+    const vecRow = await h.store.get('v1', '_vec', 'docs/leaky') // capture a real _vec envelope
     expect(vecRow).not.toBeNull()
 
     await docs.elevate('leaky', 1) // Task 1 purges it…
-    await h.store.put('v1', '_vec', 'leaky', vecRow!) // …simulate a legacy/failed-purge survivor
+    await h.store.put('v1', '_vec', 'docs/leaky', vecRow!) // …simulate a legacy/failed-purge survivor
 
     const cold = await h.open()
     const qVec = await ENCODER.encode('alpha')

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -78,7 +78,7 @@ import { MemoryIndexStore, type IndexStore } from '../with-lookup/search/index-s
 import { PersistedIndexStore } from '../with-lookup/search/persisted-index-store.js'
 import type { RetrieveOptions, RetrieveHit } from '../with-lookup/search/retrieve-types.js'
 import { DerivationCapExceededError } from './errors.js'
-import type { VectorSet, EmbeddingDescriptor } from '../with-lookup/embeddings/index.js'
+import { encodeVecId, type VectorSet, type EmbeddingDescriptor } from '../with-lookup/embeddings/index.js'
 import { buildUniqueConstraintSet, type UniqueConstraintSet } from '../with-lookup/indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
 import { buildDescription, deriveZodFields, type CollectionDescription, type DescribeOptions } from '../with-shape/introspection/describe.js'
@@ -4185,7 +4185,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   /** Drop a record's encrypted _vec sidecar on erasure (a vector is text-invertible).
    *  Called by vault.ts forget() inside a resilient try/catch; residue is reported in ForgetResult. */
   async _purgeVector(id: string): Promise<void> {
-    await this.adapter.delete(this.vault, '_vec', id)
+    await this.adapter.delete(this.vault, '_vec', encodeVecId(this.name, id))
     this.vectorSet?.markDirty()
   }
 

--- a/packages/hub/src/with-lookup/embeddings/index.ts
+++ b/packages/hub/src/with-lookup/embeddings/index.ts
@@ -1,4 +1,4 @@
 export { cosine } from './cosine.js'
 export { embeddingSourceText, type EmbeddingDescriptor } from './descriptor.js'
 export { VectorSet, type StoredVector, type VectorHit } from './vector-set.js'
-export { encodeVecId, decodeVecId, isVecIdFor } from './vec-id.js'
+export { encodeVecId } from './vec-id.js'

--- a/packages/hub/src/with-lookup/embeddings/index.ts
+++ b/packages/hub/src/with-lookup/embeddings/index.ts
@@ -1,3 +1,4 @@
 export { cosine } from './cosine.js'
 export { embeddingSourceText, type EmbeddingDescriptor } from './descriptor.js'
 export { VectorSet, type StoredVector, type VectorHit } from './vector-set.js'
+export { encodeVecId, decodeVecId, isVecIdFor } from './vec-id.js'

--- a/packages/hub/src/with-lookup/embeddings/vec-id.ts
+++ b/packages/hub/src/with-lookup/embeddings/vec-id.ts
@@ -1,0 +1,39 @@
+/**
+ * Collection-namespaced `_vec` side-car ids (#726).
+ *
+ * `_vec` embedding side-cars used to be keyed by the bare record id,
+ * vault-wide — two collections sharing a record id shared one `_vec` row,
+ * which let collection A's `similarTo()` surface collection B's (possibly
+ * ELEVATED) embedding. The store-collection bucket stays the literal
+ * `'_vec'`; the id becomes composite: `${collection}/${recordId}`. Mirrors
+ * `encodeIdxId` (`../indexing/persisted-indexes.js`).
+ *
+ * Decode is deliberately NOT split-on-`/`: the collection is always known
+ * at the decode site (`ctx.name`), so `decodeVecId` strips that known
+ * prefix — correct even when `recordId` itself contains `/`.
+ */
+
+/**
+ * Encode the `_vec` side-car id for a (collection, recordId) pair.
+ * Format: `<collection>/<recordId>` — no escaping; `recordId` may contain `/`.
+ */
+export function encodeVecId(collection: string, recordId: string): string {
+  return `${collection}/${recordId}`
+}
+
+/**
+ * Decode a `_vec` id back to the bare record id, given the KNOWN owning
+ * collection — strips the `<collection>/` prefix rather than splitting on
+ * `/`, so a `recordId` containing `/` round-trips correctly. Returns `null`
+ * if `vecId` does not belong to `collection`.
+ */
+export function decodeVecId(collection: string, vecId: string): string | null {
+  const prefix = `${collection}/`
+  if (!vecId.startsWith(prefix)) return null
+  return vecId.slice(prefix.length)
+}
+
+/** Predicate form of {@link decodeVecId} — used to filter `list()` results. */
+export function isVecIdFor(collection: string, vecId: string): boolean {
+  return vecId.startsWith(`${collection}/`)
+}

--- a/packages/hub/src/with-lookup/embeddings/vec-id.ts
+++ b/packages/hub/src/with-lookup/embeddings/vec-id.ts
@@ -2,22 +2,47 @@
  * Collection-namespaced `_vec` side-car ids (#726).
  *
  * `_vec` embedding side-cars used to be keyed by the bare record id,
- * vault-wide — two collections sharing a record id shared one `_vec` row,
- * which let collection A's `similarTo()` surface collection B's (possibly
- * ELEVATED) embedding. The store-collection bucket stays the literal
- * `'_vec'`; the id becomes composite: `${collection}/${recordId}`. Mirrors
- * `encodeIdxId` (`../indexing/persisted-indexes.js`).
+ * vault-wide — two collections sharing a record id shared one `_vec` row.
+ * This was verified to be a clobber/crash bug, NOT a confidentiality leak:
+ * every collection has its own DEK, and AES-GCM auth-tag verification means
+ * decrypting a foreign collection's `_vec` row under the wrong DEK throws
+ * `TamperedError` rather than returning wrong plaintext — no disclosure
+ * mechanism exists. The real bug was id collision: a same-id write/forget in
+ * one collection could clobber or delete the other collection's row, and a
+ * collection whose `similarTo()` / cold semantic `retrieve()` encountered a
+ * foreign same-id row crashed with an uncaught `TamperedError` (a DoS). The
+ * store-collection bucket stays the literal `'_vec'`; the id becomes
+ * composite: `${collection}/${recordId}`. Mirrors `encodeIdxId`
+ * (`../indexing/persisted-indexes.js`).
  *
  * Decode is deliberately NOT split-on-`/`: the collection is always known
  * at the decode site (`ctx.name`), so `decodeVecId` strips that known
  * prefix — correct even when `recordId` itself contains `/`.
+ *
+ * Precondition: `collection` itself must not contain `/` — otherwise
+ * `${collection}/${recordId}` is ambiguous (e.g. collection `'a'` would
+ * misattribute collection `'a/b'`'s rows via prefix match in `isVecIdFor`).
+ * Collection names are NOT currently restricted to a `/`-free charset by
+ * `vault.collection()`, so `encodeVecId` enforces the precondition itself,
+ * failing loud at the write boundary rather than silently misencoding.
  */
 
 /**
  * Encode the `_vec` side-car id for a (collection, recordId) pair.
  * Format: `<collection>/<recordId>` — no escaping; `recordId` may contain `/`.
+ *
+ * Throws if `collection` contains `/`: that would make the composite id
+ * ambiguous against `isVecIdFor`'s prefix match (collection `'a'` would
+ * appear to own collection `'a/b'`'s rows), reintroducing the clobber/crash
+ * risk the namespacing fix exists to close.
  */
 export function encodeVecId(collection: string, recordId: string): string {
+  if (collection.includes('/')) {
+    throw new Error(
+      `encodeVecId: collection name "${collection}" must not contain "/" — ` +
+        `it would make the "${collection}/${recordId}" _vec id ambiguous against another collection's rows.`,
+    )
+  }
   return `${collection}/${recordId}`
 }
 

--- a/packages/hub/src/with-lookup/search/collection-facade.ts
+++ b/packages/hub/src/with-lookup/search/collection-facade.ts
@@ -204,7 +204,19 @@ function buildVectorLoad<T>(ctx: SearchContext<T>): () => Promise<StoredVector[]
       if (await liveRecordIsElevated(ctx.adapter, ctx.vault, ctx.name, id)) continue
       const env = await ctx.adapter.get(ctx.vault, '_vec', vecId)
       if (!env) continue
-      const body = await ctx.codec.decryptJsonString(env)
+      // #726 fails-safe: a row can pass isVecIdFor's prefix filter yet still
+      // be undecryptable under THIS collection's DEK — a surviving legacy
+      // bare-id row whose record id happens to start with `<thisCollection>/`,
+      // or plain corruption. _vec sidecars are derived, re-derivable
+      // artifacts (embedOnWrite regenerates them on the record's next put()),
+      // so best-effort skip is correct: never let one poison row crash
+      // similarTo()/retrieve() for the whole collection.
+      let body: string | null
+      try {
+        body = await ctx.codec.decryptJsonString(env)
+      } catch {
+        continue
+      }
       if (body === null) continue
       const parsed = JSON.parse(body) as { vec: number[]; model: string }
       out.push({ id, vec: new Float32Array(parsed.vec), model: parsed.model })

--- a/packages/hub/src/with-lookup/search/collection-facade.ts
+++ b/packages/hub/src/with-lookup/search/collection-facade.ts
@@ -29,6 +29,7 @@ import type { BlobSet } from '../../with-shape/blobs/blob-set.js'
 import type { BlobFieldsConfig } from '../../with-shape/blobs/blob-compaction.js'
 import type { Query } from '../../kernel/query/index.js'
 import { embeddingSourceText, type VectorSet, type EmbeddingDescriptor, type StoredVector } from '../embeddings/index.js'
+import { encodeVecId, decodeVecId, isVecIdFor } from '../embeddings/vec-id.js'
 import { EmbeddingDimMismatchError } from '../../kernel/errors.js'
 import { liveRecordIsElevated } from '../../kernel/tier-visibility.js'
 import { searchScan, fuseRetrieval, type SearchOptions, type SearchResult } from './index.js'
@@ -192,12 +193,16 @@ function buildVectorLoad<T>(ctx: SearchContext<T>): () => Promise<StoredVector[]
   return async () => {
     const ids = await ctx.adapter.list(ctx.vault, '_vec')
     const out: StoredVector[] = []
-    for (const id of ids) {
+    for (const vecId of ids) {
+      // #726: _vec is a vault-wide bucket namespaced by collection prefix —
+      // skip rows belonging to other collections before touching this one's.
+      if (!isVecIdFor(ctx.name, vecId)) continue
+      const id = decodeVecId(ctx.name, vecId)!
       // #721 defense-in-depth: a _vec row carries no _tier of its own; the purge
       // on elevate is best-effort and cannot reach a legacy sidecar, so gate on
       // the owning record's live tier. Envelope peek, no decryption.
       if (await liveRecordIsElevated(ctx.adapter, ctx.vault, ctx.name, id)) continue
-      const env = await ctx.adapter.get(ctx.vault, '_vec', id)
+      const env = await ctx.adapter.get(ctx.vault, '_vec', vecId)
       if (!env) continue
       const body = await ctx.codec.decryptJsonString(env)
       if (body === null) continue
@@ -392,7 +397,7 @@ export async function embedOnWrite<T>(ctx: SearchContext<T>, id: string, record:
   if (vec.length !== ctx.embeddings.dim) throw new EmbeddingDimMismatchError('embeddings', ctx.embeddings.dim, vec.length)
   const body = JSON.stringify({ vec: Array.from(vec), model: ctx.embeddings.model, dim: ctx.embeddings.dim })
   const vecEnv = await ctx.codec.encryptJsonString(body, version)
-  await ctx.adapter.put(ctx.vault, '_vec', id, vecEnv)
+  await ctx.adapter.put(ctx.vault, '_vec', encodeVecId(ctx.name, id), vecEnv)
   ctx.vectorSet?.markDirty()
 }
 
@@ -419,7 +424,7 @@ export async function syncTierSearch<T>(
 ): Promise<void> {
   if (!ctx.searchIndexStore && !ctx.vectorSet) return
   if (record === null) {
-    await ctx.adapter.delete(ctx.vault, '_vec', id)
+    await ctx.adapter.delete(ctx.vault, '_vec', encodeVecId(ctx.name, id))
     ctx.vectorSet?.markDirty()
   } else {
     await embedOnWrite(ctx, id, record, version ?? 1)


### PR DESCRIPTION
Closes #726 (milestone 34 — tier-invisibility hardening). Follow-up #788 (opt-in rebuild utility) filed.

## Problem
`_vec` embedding sidecars were keyed by the **bare record id, vault-wide** (not namespaced by collection). Two collections sharing a record id collided on one `_vec/<id>` slot, causing:
- **sidecar clobbering** — a same-id `put()`/`forget()` in another collection overwrote/deleted the row; and
- **an uncaught `TamperedError` crash (DoS)** on `similarTo()` / cold semantic `retrieve()` when a collection hit a foreign same-id row.

**Not a confidentiality leak** (correcting the issue's original framing): every collection has its own DEK and AES-GCM auth-tag verification *throws* on a wrong-key decrypt, so a foreign row can never surface as wrong plaintext — it crashes rather than discloses. Verified empirically (RED reproduction at the pre-fix commit yielded `TamperedError`, never wrong content).

## Fix
`_vec` keys are now namespaced by collection: bucket stays the literal `'_vec'`, the **id** becomes composite `<collection>/<recordId>` via a new `encodeVecId`/`decodeVecId`/`isVecIdFor` helper (mirrors `_idx`). All 5 store sites converted (buildVectorLoad scan→filter + read→decode, embedOnWrite write, syncTierSearch delete, `_purgeVector`). Decoded **bare** id flows back into `StoredVector.id`/`cache.get`/`liveRecordIsElevated`. A collection can now only ever list and decrypt its own rows, structurally eliminating the clobber and the crash (and precluding any theoretical cross-collection read).

Robustness:
- Decode strips the **known** `<collection>/` prefix (not split-on-`/`), so a `recordId` containing `/` round-trips.
- `encodeVecId` **fails loud** if a collection name contains `/` (collection names are unvalidated on charset, so the composite grammar would otherwise be ambiguous; no collection in the repo uses `/`).
- `buildVectorLoad` now **skips** any undecryptable `_vec` row (scoped `try/catch`) instead of crashing — closing the residual legacy-residue DoS completely, so the fails-safe claim holds.

## Migration (BREAKING for @next embeddings adopters)
Re-namespaced **outright — no dual-read fallback** (a legacy-bare-id fallback is unsound: which collection a colliding legacy row belongs to is irreducibly ambiguous). Legacy bare-id rows become unreachable ciphertext that **fails safe** (toward not-found, never wrong-record) and **self-heals** — `embedOnWrite` re-derives the sidecar on each record's next `put()`. Adopters wanting zero recall-gap can use the opt-in bulk re-embed utility tracked in #788. Documented in the changeset.

## Verification
- New `embeddings-vec-id.test.ts` (helper incl. `/`-in-recordId + slash-guard) and `embeddings-vec-namespace.test.ts` (behavioral: A and B both hold id `x` → A's `similarTo()` returns only A's row, no throw/blend — RED at pre-fix for the real crash reason; plus write/forget clobber isolation and poison-row skip). 4 existing grammar tests updated (asserted keys only, no weakening).
- Full hub suite green (4367 tests); typecheck, lint, `check:architecture` all pass; `collection.ts` at 4549 (net 0 lines via barrel re-export), `vault.ts` untouched.
- Task review + adversarial whole-branch review (strongest model): Ready to merge.

Not published; changeset is local per repo convention.