### PR TITLE
fix(hub): split forget/MV residue into undecodable vs declined — audit-precise erasure reporting (#785)

### DIFF
--- a/packages/hub/__tests__/materialized-views/correctness.test.ts
+++ b/packages/hub/__tests__/materialized-views/correctness.test.ts
@@ -270,9 +270,11 @@ describe('MV correctness (#152)', () => {
       const second = await vault.refreshView('red-items')
 
       expect(second.deleted).toBe(0) // #776 part b — the over-count RED this test pins
-      // #782 part b — decoded (warm cek) + stamp-owned but #718-declined: a real silent
-      // survival, must be surfaced as residue, not just correctly excluded from `deleted`.
-      expect(second.residue).toEqual(['red-items-out:a'])
+      // #782 part b / #785 — decoded (warm cek) + stamp-owned but #718-declined: a real
+      // silent survival, must be surfaced in the declined channel, not just correctly
+      // excluded from `deleted`.
+      expect(second.residueDeclined).toEqual(['red-items-out:a'])
+      expect(second.residueUndecodable).toEqual([])
     })
   })
 

--- a/packages/hub/__tests__/materialized-views/lazy-and-manual.test.ts
+++ b/packages/hub/__tests__/materialized-views/lazy-and-manual.test.ts
@@ -176,7 +176,7 @@ describe('MV lazy lifecycle + vault.refreshView (#151)', () => {
     })
     const vault = await db.openVault('demo')
     // No MVs registered — returns zero counts.
-    expect(await vault.refreshView('nonexistent')).toEqual({ written: 0, deleted: 0, failed: 0, residue: [] })
+    expect(await vault.refreshView('nonexistent')).toEqual({ written: 0, deleted: 0, failed: 0, residueUndecodable: [], residueDeclined: [] })
 
     // With at least one MV registered, an unknown name throws.
     const mv = withMaterializedView<Item>({

--- a/packages/hub/__tests__/via/forget-fanout.test.ts
+++ b/packages/hub/__tests__/via/forget-fanout.test.ts
@@ -288,15 +288,18 @@ describe('forget() fanout to derived residue (#622)', () => {
     expect(result.lookupReferencesResidue).toEqual([])
     // Additive #776 field defaults to empty when nothing was undecodable.
     expect(result.derivedResidueUndecodable).toEqual([])
+    // Additive #785 field defaults to empty when nothing was declined.
+    expect(result.derivedResidueDeclined).toEqual([])
     // Snapshot the full key set — a byte-shape regression on an EXISTING field
     // would silently pass value assertions above but fail this key list.
     // #650 Task 5 — lookupReferencesCascaded/lookupReferencesNullified are new,
     // additive fields (see lookup-forget-ref.test.ts); lookupReferencesResidue is
     // additive too (#650 Task 5 review, Important fix); derivedResidueUndecodable
-    // is additive too (#776); every pre-existing key below is unchanged.
+    // is additive too (#776); derivedResidueDeclined is additive too (#785); every
+    // pre-existing key below is unchanged.
     expect(Object.keys(result).sort()).toEqual([
       'blobResidueCollections', 'blobsRetainedShared', 'blobsShredded', 'collections',
-      'derivedAggregatesRecomputed', 'derivedRecordsErased', 'derivedResidueFrozen', 'derivedResidueUndecodable',
+      'derivedAggregatesRecomputed', 'derivedRecordsErased', 'derivedResidueDeclined', 'derivedResidueFrozen', 'derivedResidueUndecodable',
       'historyVersionsShredded', 'indexPostingsPurged', 'indexResidue', 'ledgerDeltaResidue',
       'ledgerDeltasPurged', 'ledgerEntry',
       'lookupReferencesCascaded', 'lookupReferencesNullified', 'lookupReferencesResidue',
@@ -420,8 +423,9 @@ describe('forget() fanout to derived residue (#622)', () => {
     // Deletion declined (elevated) → NOT counted as erased...
     expect(result.derivedRecordsErased).toBe(0)
     // ...but this is a REAL silent survival (ownership confirmed, erasure declined) — must
-    // be surfaced, not dropped (#782 part b).
-    expect(result.derivedResidueUndecodable).toEqual(['people-mirror-lazy-782b:p1'])
+    // be surfaced, not dropped, in the declined channel (#785, was folded into
+    // derivedResidueUndecodable pre-#785 as #782 part b).
+    expect(result.derivedResidueDeclined).toEqual(['people-mirror-lazy-782b:p1'])
   })
 
   it('forget × eager MV: a decoded, stamp-owned, but #718-declined output row is surfaced as residue too (#782 part b, eager leg)', async () => {
@@ -452,6 +456,58 @@ describe('forget() fanout to derived residue (#622)', () => {
     const result = await vault.forget('subj-1')
 
     expect(result.derivedRecordsErased).toBe(0)
-    expect(result.derivedResidueUndecodable).toEqual(['people-mirror-eager-782b:p1'])
+    expect(result.derivedResidueDeclined).toEqual(['people-mirror-eager-782b:p1'])
+  })
+
+  it('forget × two lazy MVs: one undecodable row and one #718-declined row from a SINGLE forget() call route into their own distinct arrays (#785)', async () => {
+    interface Person extends Record<string, unknown> { id: string; subjectId: string; name: string }
+    const mvA = withMaterializedView<Person>({
+      name: 'people-mirror-785-undecodable',
+      query: (db) => db.collection<Person>('people').query(),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const mvB = withMaterializedView<Person>({
+      name: 'people-mirror-785-declined',
+      query: (db) => db.collection<Person>('people').query(),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const store = memory()
+    const open = async () => {
+      const db = await createNoydb({
+        store, user: 'alice', secret: 'forget-fanout-785-passphrase-2026',
+        materializedViewStrategies: [mvA, mvB],
+        historyStrategy: withHistory(),
+        forgetStrategy: withForgetCascade({ subjects: { people: 'subjectId' } }),
+        tiersStrategy: withTiers(),
+      })
+      const vault = await db.openVault('firm')
+      const mirrorA = vault.collection<Person>('people-mirror-785-undecodable', { tiers: [0, 1], perRecordKeys: true })
+      const mirrorB = vault.collection<Person>('people-mirror-785-declined', { tiers: [0, 1], perRecordKeys: true })
+      return { vault, people: vault.collection<Person>('people'), mirrorA, mirrorB }
+    }
+
+    // Session 1: materialize BOTH mirrors, elevate only mirrorA's row — its tier-1 DEK
+    // cache dies with this session; mirrorB stays at tier 0 for now.
+    const { people, mirrorA, mirrorB: mirrorB1 } = await open()
+    await people.put('p1', { id: 'p1', subjectId: 'subj-1', name: 'Ada' })
+    expect(await mirrorA.get('p1')).not.toBeNull() // materialize A (lazy resolve-on-read)
+    expect(await mirrorB1.get('p1')).not.toBeNull() // materialize B (lazy resolve-on-read)
+    await mirrorA.elevate('p1', 1)
+
+    // Session 2 (cold for A): elevate mirrorB HERE instead — its row already exists at
+    // rest from session 1, so `elevate()` needs no fresh materialize — warming THIS
+    // session's cache for B while A's stays cold. One forget() call now hits both
+    // conditions at once: A's row fails to decode (undecodable), B's row decodes and
+    // stamp-matches but `_internalDelete` declines (owned, retained).
+    const { vault: coldVault, mirrorB } = await open()
+    await mirrorB.elevate('p1', 1)
+
+    const result = await coldVault.forget('subj-1')
+
+    expect(result.derivedRecordsErased).toBe(0)
+    expect(result.derivedResidueUndecodable).toEqual(['people-mirror-785-undecodable:p1'])
+    expect(result.derivedResidueDeclined).toEqual(['people-mirror-785-declined:p1'])
   })
 })

--- a/packages/hub/__tests__/via/lookup-forget-ref.test.ts
+++ b/packages/hub/__tests__/via/lookup-forget-ref.test.ts
@@ -222,7 +222,7 @@ describe('forget() × lookup ref semantics (#650 Task 5, fixes #648)', () => {
     // strictly additive to the existing set.
     expect(Object.keys(result).sort()).toEqual([
       'blobResidueCollections', 'blobsRetainedShared', 'blobsShredded', 'collections',
-      'derivedAggregatesRecomputed', 'derivedRecordsErased', 'derivedResidueFrozen', 'derivedResidueUndecodable',
+      'derivedAggregatesRecomputed', 'derivedRecordsErased', 'derivedResidueDeclined', 'derivedResidueFrozen', 'derivedResidueUndecodable',
       'historyVersionsShredded', 'indexPostingsPurged', 'indexResidue', 'ledgerDeltaResidue',
       'ledgerDeltasPurged', 'ledgerEntry',
       'lookupReferencesCascaded', 'lookupReferencesNullified', 'lookupReferencesResidue',

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -2924,16 +2924,16 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    * row count TOMBSTONED across EVERY MV sourced here (#638 T6 — `forgetDerivedFanout`'s
    * `derivedRecordsErased`) — eager AND lazy/manual `invalidateMVAtRest` purges both contribute now
    * (#761 item 1, previously eager-only); lazy persists a stale mark for cold-session recompute;
-   * manual serves empty until `refreshView()`. `residue` (#776) carries `outputCollection:id` entries whose ownership stamp `invalidateMVAtRest` could not decode — surfaced, not erased.
+   * manual serves empty until `refreshView()`. `residueUndecodable`/`residueDeclined` (#776/#785) carry `outputCollection:id` entries whose ownership stamp `invalidateMVAtRest` could not decode, resp. decoded+stamp-matched but declined erasure — surfaced, not erased.
    * @internal
    */
-  async dispatchMaterializedViewsOnDelete(id: string): Promise<{ deleted: number; residue: string[] }> {
-    if (this.materializedViewSource === undefined) return { deleted: 0, residue: [] }
+  async dispatchMaterializedViewsOnDelete(id: string): Promise<{ deleted: number; residueUndecodable: string[]; residueDeclined: string[] }> {
+    if (this.materializedViewSource === undefined) return { deleted: 0, residueUndecodable: [], residueDeclined: [] }
     const registry = this.materializedViewSource.registry()
     const mvs = registry.mvsForSource(this.name)
-    if (mvs.length === 0) return { deleted: 0, residue: [] }
+    if (mvs.length === 0) return { deleted: 0, residueUndecodable: [], residueDeclined: [] }
     let executor: typeof MVExecutorType | null = null; let staleHelpers: typeof MVStaleModule | null = null
-    let deleted = 0; const residue: string[] = []
+    let deleted = 0; const residueUndecodable: string[] = []; const residueDeclined: string[] = []
     for (const reg of mvs) {
       const mode = reg.spec.refresh
       if (mode === 'eager') {
@@ -2945,16 +2945,16 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
           getActiveTxContext: () => this.materializedViewSource!.getActiveTxContext(),
           getQueryContext: () => this.materializedViewSource!.getQueryContext(),
           dispatchCtx: this.#dispatchCtx({ collection: this.name, id }),
-        }); deleted += rr.deleted; residue.push(...rr.residue) // #782 — eager leg now reports too
+        }); deleted += rr.deleted; residueUndecodable.push(...rr.residueUndecodable); residueDeclined.push(...rr.residueDeclined) // #782/#785 — eager leg now reports both channels
       } else {
         if (staleHelpers === null) {
           staleHelpers = await import('../with-formula/materialized-views/stale.js')
         }
         const inv = await staleHelpers.invalidateMVAtRest(this.materializedViewSource, reg, mode)
-        deleted += inv.deleted; residue.push(...inv.residue.map((rid) => `${reg.outputCollection}:${rid}`))
+        deleted += inv.deleted; residueUndecodable.push(...inv.residueUndecodable.map((rid) => `${reg.outputCollection}:${rid}`)); residueDeclined.push(...inv.residueDeclined.map((rid) => `${reg.outputCollection}:${rid}`))
       }
     }
-    return { deleted, residue }
+    return { deleted, residueUndecodable, residueDeclined }
   }
 
   /**

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -2299,7 +2299,7 @@ export class Vault {
     const sealedCekResidue: string[] = []; const sealedResidue: string[] = []; const indexResidue: string[] = []; const ledgerDeltaResidue: string[] = []
     const blobsEnabled = this.blobStrategy !== undefined
     const actor = this.keyring.userId
-    const fanoutStats: ForgetFanoutStats = { recordsErased: 0, aggregatesRecomputed: 0, residueFrozen: [], lookupReferencesCascaded: 0, lookupReferencesNullified: 0, lookupReferencesResidue: [], derivedResidueUndecodable: [] }
+    const fanoutStats: ForgetFanoutStats = { recordsErased: 0, aggregatesRecomputed: 0, residueFrozen: [], lookupReferencesCascaded: 0, lookupReferencesNullified: 0, lookupReferencesResidue: [], derivedResidueUndecodable: [], derivedResidueDeclined: [] }
     // #633 — scoped-purge per-collection skip accumulators (empty under the unconditional default); lazy (S4 gate: kernel spine → with-* service via dynamic import()).
     const { partitionSealedCekKeys, shouldSkipBlobScan, bumpResidueCount, residueNoticesFromMap } = await import('../with-audit/forget/purge-scope.js')
     const scopedPurge = this.forgetStrategy.scopedPurge === true
@@ -2495,7 +2495,7 @@ export class Vault {
       derivedAggregatesRecomputed: fanoutStats.aggregatesRecomputed,
       derivedResidueFrozen: fanoutStats.residueFrozen,
       lookupReferencesCascaded: fanoutStats.lookupReferencesCascaded, lookupReferencesNullified: fanoutStats.lookupReferencesNullified, lookupReferencesResidue: fanoutStats.lookupReferencesResidue, scopedPurgeResidue, ledgerDeltasPurged, ledgerDeltaResidue, // #650 Task 5 (+ review Important fix: residue) + #633 + #734
-      derivedResidueUndecodable: fanoutStats.derivedResidueUndecodable, // #776
+      derivedResidueUndecodable: fanoutStats.derivedResidueUndecodable, derivedResidueDeclined: fanoutStats.derivedResidueDeclined, // #776/#785
     }
   }
 
@@ -2758,13 +2758,13 @@ export class Vault {
   /**
    * Manual re-materialize for a single registered MV (`refresh: 'manual'` consumers,
    * stale-bit recovery on vault reopen, bulk-recompute escape hatch after a strategy
-   * change). Returns `{ written, deleted, failed, residue }` (`deleted` always 0 without
-   * tombstoning; `residue` = #782 undecodable/declined leftovers). Throws if not registered.
+   * change). Returns `{ written, deleted, failed, residueUndecodable, residueDeclined }` (`deleted`
+   * always 0 without tombstoning; #785 splits the #782 leftovers — undecodable vs #718-declined). Throws if not registered.
    */
-  async refreshView(name: string): Promise<{ written: number; deleted: number; failed: number; residue: string[] }> {
+  async refreshView(name: string): Promise<{ written: number; deleted: number; failed: number; residueUndecodable: string[]; residueDeclined: string[] }> {
     const registry = this.materializedViewRegistry
     if (registry === null) {
-      return { written: 0, deleted: 0, failed: 0, residue: [] }
+      return { written: 0, deleted: 0, failed: 0, residueUndecodable: [], residueDeclined: [] }
     }
     const reg = registry.byName(name)
     if (!reg) {

--- a/packages/hub/src/kernel/via/dispatch.ts
+++ b/packages/hub/src/kernel/via/dispatch.ts
@@ -284,14 +284,16 @@ export interface ForgetFanoutStats {
    *  skipped for these, reported here so the skip is never silent. `backing:key:collection.field`
    *  entries, one per un-propagated edge. */
   readonly lookupReferencesResidue: string[]
-  /** #776/#782 — `outputCollection:id` MV-output rows that survived erasure invalidation
+  /** #776/#782/#785 — `outputCollection:id` MV-output rows that survived erasure invalidation
    *  (eager tombstone leg AND lazy/manual `invalidateMVAtRest`) despite belonging to the
-   *  forgotten subject: either the ownership stamp could not be decoded (undecodable under
-   *  the default DEK — e.g. elevated above tier 0 on a tiered output collection, ownership
-   *  unconfirmed), or it decoded and stamp-matched but `_internalDelete` declined (the #718
-   *  tier-elevation gate — ownership confirmed, erasure declined). Never erased either way,
-   *  but surfaced here rather than silently skipped. */
+   *  forgotten subject, because the ownership stamp could not be decoded (undecodable under
+   *  the default DEK — e.g. elevated above tier 0 on a tiered output collection). Ownership
+   *  UNCONFIRMED. Never erased, but surfaced here rather than silently skipped. */
   readonly derivedResidueUndecodable: string[]
+  /** #782/#785 — `outputCollection:id` MV-output rows that decoded and stamp-matched but whose
+   *  `_internalDelete` declined (the #718 tier-elevation gate). Ownership CONFIRMED, erasure
+   *  declined — a real silent survival, surfaced here rather than silently skipped. */
+  readonly derivedResidueDeclined: string[]
 }
 
 /**
@@ -332,7 +334,8 @@ export async function forgetDerivedFanout(
   if (coll) {
     const mv = await coll.dispatchMaterializedViewsOnDelete(ref.id)
     stats.recordsErased += mv.deleted
-    stats.derivedResidueUndecodable.push(...mv.residue)
+    stats.derivedResidueUndecodable.push(...mv.residueUndecodable)
+    stats.derivedResidueDeclined.push(...mv.residueDeclined)
   }
 
   const edges = vault.graph.derivedArtifactsOf(ref.collection)

--- a/packages/hub/src/with-audit/forget/strategy.ts
+++ b/packages/hub/src/with-audit/forget/strategy.ts
@@ -177,16 +177,21 @@ export interface ForgetResult {
    *  Always empty under the unconditional default. Non-empty means a `_sealed_cek` entry or a
    *  blob scan was skipped for an undeclared collection — reported, never a silent skip. */
   readonly scopedPurgeResidue: readonly ScopedPurgeResidueNotice[]
-  /** #776/#782 — `collection:id` MV-output rows that survived erasure invalidation (eager
+  /** #776/#782/#785 — `collection:id` MV-output rows that survived erasure invalidation (eager
    *  tombstone leg AND lazy/manual `invalidateMVAtRest`) despite belonging to the forgotten
-   *  subject: either the `_materializedFrom` ownership stamp could NOT be decoded (undecodable
+   *  subject, because the `_materializedFrom` ownership stamp could NOT be decoded (undecodable
    *  under the collection's default DEK — e.g. elevated above tier 0 on a tiered output
    *  collection; ownership unconfirmed — could be a plain user record on a same-collection
-   *  partition MV), or it decoded and stamp-matched but `_internalDelete` declined (the #718
-   *  tier-elevation gate; ownership confirmed, erasure declined). Never erased either way, but
-   *  surfaced here rather than silently skipped (the #724 posture). Non-empty means the row may
-   *  still hold the forgotten/pre-elevation contribution, decryptable by tier-holders. */
+   *  partition MV). Never erased, but surfaced here rather than silently skipped (the #724
+   *  posture). Non-empty means the row may still hold the forgotten/pre-elevation contribution,
+   *  decryptable by tier-holders. */
   readonly derivedResidueUndecodable: readonly string[]
+  /** #782/#785 — `collection:id` MV-output rows that DID decode and stamp-match via
+   *  `_materializedFrom`, but whose erasure was declined by the #718 tier-elevation gate
+   *  (`_internalDelete` returned false). Ownership CONFIRMED here — a real silent survival,
+   *  not a stamp-mismatch skip — surfaced rather than dropped. Non-empty means a live,
+   *  tier-holder-decryptable copy of the forgotten contribution was deliberately retained. */
+  readonly derivedResidueDeclined: readonly string[]
 }
 
 /** #633 — the two `scopedPurgeResidue` skip reasons. Single source of truth: `purge-scope.ts`

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -344,7 +344,7 @@ function isElevatorOrOwner<T>(ctx: TiersContext<T>): boolean {
  * structurally — no cast needed at the `tiersContext()` call site).
  */
 export interface DerivedOutputsHost<T> {
-  dispatchMaterializedViewsOnDelete(id: string): Promise<{ deleted: number; residue: string[] }>
+  dispatchMaterializedViewsOnDelete(id: string): Promise<{ deleted: number; residueUndecodable: string[]; residueDeclined: string[] }>
   dispatchArrayDerivationsOnDelete(id: string, eraseRecordShapeToo?: boolean): Promise<number>
   dispatchRollupsOnDelete(id: string, deleted: T): Promise<unknown>
   /** Task 2 (#722) add-direction: the same local-write dispatchers an ordinary `put()` fires. */

--- a/packages/hub/src/with-formula/materialized-views/executor.ts
+++ b/packages/hub/src/with-formula/materialized-views/executor.ts
@@ -45,13 +45,15 @@ export interface RefreshResult {
   deleted: number
   /** Failed row writes (non-strict mode). */
   failed: number
-  /** #782 — `outputCollection:id` entries from the tombstone pass that were NOT tombstoned
-   *  despite belonging here: either the ownership stamp couldn't be decoded (undecodable
-   *  under the collection's default DEK, mirroring `invalidateMVAtRest`'s #776 posture), or
-   *  it decoded, stamp-matched this MV, but `_internalDelete` declined (the #718
-   *  tier-elevation gate) — a real silent survival either way, surfaced rather than dropped.
-   *  Only populated when `onEmpty: 'delete'`. */
-  residue: string[]
+  /** #782/#785 — `outputCollection:id` entries from the tombstone pass whose ownership stamp
+   *  couldn't be decoded under the collection's default DEK (undecodable, mirroring
+   *  `invalidateMVAtRest`'s #776 posture) — ownership UNCONFIRMED. Only populated when
+   *  `onEmpty: 'delete'`. */
+  residueUndecodable: string[]
+  /** #782/#785 — `outputCollection:id` entries that decoded, stamp-matched this MV, but
+   *  `_internalDelete` declined (the #718 tier-elevation gate) — ownership CONFIRMED, a real
+   *  silent survival, surfaced rather than dropped. Only populated when `onEmpty: 'delete'`. */
+  residueDeclined: string[]
 }
 
 /** Default cost ceiling — overridable per-MV via `spec.maxRows`. */
@@ -339,7 +341,8 @@ export const MaterializedViewExecutor = {
     //    `_internalDelete` so a user-registered `onDelete` on the
     //    output collection does NOT fire on housekeeping (composition fix).
     let deleted = 0
-    const residue: string[] = []
+    const residueUndecodable: string[] = []
+    const residueDeclined: string[] = []
     if (onEmpty === 'delete') {
       const priorIds = await listOutputIds(outputColl)
       for (const priorId of priorIds) {
@@ -359,7 +362,7 @@ export const MaterializedViewExecutor = {
           // tiered output collection): can't rule out this being THIS MV's own stamped row.
           // Surface it rather than silently skip (mirrors invalidateMVAtRest's #776 posture —
           // previously this leg had NO residue channel at all).
-          residue.push(`${reg.outputCollection}:${priorId}`)
+          residueUndecodable.push(`${reg.outputCollection}:${priorId}`)
           continue
         }
         const priorStampedBy =
@@ -380,7 +383,7 @@ export const MaterializedViewExecutor = {
               // #782 part b — decoded AND stamp-owned, but erasure was declined (#718
               // tier-elevation gate). Ownership IS confirmed here — a real silent survival,
               // not a legit stamp-mismatch skip. Surface it too.
-              residue.push(`${reg.outputCollection}:${priorId}`)
+              residueDeclined.push(`${reg.outputCollection}:${priorId}`)
             }
           } else {
             // Defensive fallback — should never hit in real flow since
@@ -397,7 +400,7 @@ export const MaterializedViewExecutor = {
       }
     }
 
-    return { written, deleted, failed, residue }
+    return { written, deleted, failed, residueUndecodable, residueDeclined }
   },
 }
 

--- a/packages/hub/src/with-formula/materialized-views/stale.ts
+++ b/packages/hub/src/with-formula/materialized-views/stale.ts
@@ -132,13 +132,15 @@ async function hydratePersistedStaleMarkers(accessor: MVStaleAccessor, registry:
  *
  * Returns the count of rows actually `_internalDelete`d (#761 item 1) — folded by the
  * caller into `dispatchMaterializedViewsOnDelete`'s `deleted` so `ForgetResult.derivedRecordsErased`
- * counts lazy/manual purges too, not just the eager executor's tombstone leg — plus `residue`,
- * the bare ids whose ownership stamp could NOT be decoded (#776): a candidate row that fails to
- * decode under the collection's default DEK (e.g. elevated above tier 0 on a tiered output
- * collection) has UNKNOWN ownership — it might be this MV's own output, or (same-collection
- * shape) a plain user record — so it is never erased, but it must be SURFACED rather than
- * silently skipped (the #724 posture), since it may still hold the forgotten/pre-elevation
- * contribution, decryptable by tier-holders.
+ * counts lazy/manual purges too, not just the eager executor's tombstone leg — plus
+ * `residueUndecodable`, the bare ids whose ownership stamp could NOT be decoded (#776): a
+ * candidate row that fails to decode under the collection's default DEK (e.g. elevated above
+ * tier 0 on a tiered output collection) has UNKNOWN ownership — it might be this MV's own
+ * output, or (same-collection shape) a plain user record — so it is never erased, but it must
+ * be SURFACED rather than silently skipped (the #724 posture), since it may still hold the
+ * forgotten/pre-elevation contribution, decryptable by tier-holders — and `residueDeclined`
+ * (#785), the bare ids that DID decode and stamp-match but whose `_internalDelete` declined
+ * (ownership CONFIRMED, erasure declined).
  *
  * @internal
  */
@@ -146,12 +148,13 @@ export async function invalidateMVAtRest(
   accessor: MVStaleAccessor,
   reg: RegisteredMV,
   mode: 'lazy' | 'manual',
-): Promise<{ deleted: number; residue: string[] }> {
+): Promise<{ deleted: number; residueUndecodable: string[]; residueDeclined: string[] }> {
   const outputColl = accessor.getCollection(reg.outputCollection)
   const txCtx = accessor.getActiveTxContext()
   const { adapter, vault } = storeOf(accessor, reg.outputCollection)
   let deleted = 0
-  const residue: string[] = []
+  const residueUndecodable: string[] = []
+  const residueDeclined: string[] = []
   for (const id of await adapter.list(vault, reg.outputCollection)) {
     // A same-collection partition MV (`output: { collection: <source>, partition }`,
     // the DERIV-PP30-001 shape) writes INTO its own source collection — `adapter.list`
@@ -164,7 +167,7 @@ export async function invalidateMVAtRest(
     if (envelope === null) continue
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const decoded = await (outputColl as any)._decodeEnvelope(envelope, id)
-    if (decoded === null) { residue.push(id); continue } // #776 — ownership unknown, surfaced not skipped
+    if (decoded === null) { residueUndecodable.push(id); continue } // #776 — ownership unknown, surfaced not skipped
     const stampedBy = (decoded as Record<string, unknown>)._materializedFrom as { mvName?: string } | undefined
     if (stampedBy?.mvName !== reg.spec.name) continue
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -173,8 +176,8 @@ export async function invalidateMVAtRest(
     } else {
       // #782 part b — decoded AND stamp-owned, but erasure declined (#718 tier-elevation
       // gate). Ownership IS confirmed — a real silent survival, not a legit stamp-mismatch
-      // skip. Surface it too, same channel as the decode-null case above.
-      residue.push(id)
+      // skip. Surface it too, in its own channel (#785 — distinct from the decode-null case).
+      residueDeclined.push(id)
     }
   }
 
@@ -187,7 +190,7 @@ export async function invalidateMVAtRest(
     markMVStale(registry, reg.spec.name)
     await writeMVStaleMarker(adapter, vault, reg.spec.name)
   }
-  return { deleted, residue }
+  return { deleted, residueUndecodable, residueDeclined }
 }
 
 /**


### PR DESCRIPTION
Closes #785 (milestone 34 — audit precision; feeds the #387 external crypto audit).

## Problem
`ForgetResult.derivedResidueUndecodable` (and the shared `RefreshResult.residue` behind public `vault.refreshView()`) folded two compliance-distinct meanings into one `string[]`:
1. **undecodable** — an MV output row that couldn't be decoded under the default DEK: ownership **unconfirmed** (can't even tell if it's the forgotten subject's data).
2. **declined** — a stamp-**owned** row the #718 tier-elevation gate declined to erase: ownership **confirmed**, a live tier-holder-decryptable copy deliberately retained.

An auditor scanning the field for "what might still exist" reads the name as "we couldn't tell," but ~half the entries mean "we could tell and chose to retain" — a distinction the bare `string[]` can't recover.

## Fix
Split the signal into two audit-precise arrays end-to-end. The two reasons are already cleanly separated by branch at all four push sites (`decoded === null` → undecodable; `_internalDelete()` false after a successful decode + stamp-match → declined), so each push routes to the correct array and the split threads through every layer with no cross-wiring:

- `ForgetResult.derivedResidueUndecodable` narrowed to **undecodable-only** (ownership unconfirmed) + new `ForgetResult.derivedResidueDeclined` (ownership confirmed, retained), with JSDoc rewritten to match.
- `RefreshResult` / `vault.refreshView()` split the same way (single source of truth — the eager leg is shared), so the public refresh surface gains the same precision.
- Threaded through `dispatchMaterializedViewsOnDelete` (both eager + lazy legs), `ForgetFanoutStats`, and `vault.forget()`'s init/return.

## Verification
- New RED-first test: a single `forget()` producing **both** an undecodable (cold, closed-session elevation) and a declined (warm, same-session elevation) row asserts they land in the two **distinct** arrays. Existing declined-case assertions moved to `derivedResidueDeclined` with the same row ids (no weakening); key-snapshot tests updated; `correctness.test.ts` `refreshView()` declined row now asserts `residueDeclined`.
- Full hub suite green (4368 tests); typecheck, lint, `check:architecture` all pass; `collection.ts` funded shrink-first (byte-preserving), `vault.ts` net-zero — both exactly at ceiling, no ratchet.
- Whole-branch review verified no swapped classification, no cross-wired arrays, no vestigial merged field.

## Note
`@next` shape change (`RefreshResult.residue` → `residueUndecodable`/`residueDeclined`; new `ForgetResult` field) — acceptable pre-1.0, campaign unpublished. Not published; changeset local per repo convention.