### PR TITLE
feat(hub): Collection.rebuildEmbeddings() — opt-in bulk _vec re-derive after the #726 namespace change (#788)

### DIFF
--- a/packages/hub/__tests__/kernel-api.golden.json
+++ b/packages/hub/__tests__/kernel-api.golden.json
@@ -220,6 +220,7 @@
     "queryByDet",
     "querySourceForJoin",
     "rebuildEagerIndexesFromCache",
+    "rebuildEmbeddings",
     "rebuildIndexes",
     "rebuildUniqueConstraintsFromCache",
     "recomputeRollup",

--- a/packages/hub/__tests__/rebuild-embeddings.test.ts
+++ b/packages/hub/__tests__/rebuild-embeddings.test.ts
@@ -1,0 +1,255 @@
+/**
+ * #788 — opt-in `Collection.rebuildEmbeddings()` bulk `_vec` re-derive.
+ *
+ * After #726 re-namespaced `_vec` sidecars to `_vec/<collection>/<recordId>`,
+ * legacy bare-id rows are unreachable to `buildVectorLoad` and only self-heal
+ * when a record is next `put()`. This adds an opt-in bulk utility to
+ * force-re-derive every eligible record's sidecar once.
+ *
+ * Fixture pattern mirrors `embeddings-vec-namespace.test.ts` (memoryStore +
+ * deterministic stub encoder) and `satellites-cek-migration.test.ts` (the
+ * put-failure spy store for the resumability test).
+ *
+ * The load-bearing invariant under test: an ELEVATED record must never get a
+ * `_vec` row written for it by this walk — it must be counted in `skipped`
+ * instead, mirrored against the raw store, never merely inferred from the
+ * public API.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withSearch, ConflictError } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { SearchNotEnabledError } from '../src/kernel/errors.js'
+import { memory } from '../../to-memory/src/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+
+interface Doc {
+  id: string
+  body: string
+}
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+// Deterministic stub encoder: 8-dim bag-of-chars hash → Float32Array.
+const enc = (dim: number, model = 'stub') => ({
+  dim, model, source: 'body' as const,
+  encode: async (t: string) => { const v = new Float32Array(dim); for (let i = 0; i < t.length; i++) { const idx = t.charCodeAt(i) % dim; v[idx] = (v[idx] ?? 0) + 1 } return v },
+})
+const ENCODER = enc(8)
+
+const SECRET = 'rebuild-embeddings-passphrase-788'
+
+describe('#788 Collection.rebuildEmbeddings()', () => {
+  it('rebuilds every live tier-0 record\'s missing/stale _vec sidecar; round-trips through similarTo()', async () => {
+    const store = memoryStore()
+
+    // Session 1: no embeddings config at all — simulates records written
+    // before the collection ever opted into embeddings (the #726 legacy
+    // scenario), so no `_vec` row is ever derived for them.
+    const db1 = await createNoydb({ store, user: 'owner', secret: SECRET })
+    const vault1 = await db1.openVault('v1')
+    const docs1 = vault1.collection<Doc>('docs', {})
+    await docs1.put('a', { id: 'a', body: 'alpha content one' })
+    await docs1.put('b', { id: 'b', body: 'bravo content two' })
+    await docs1.put('c', { id: 'c', body: 'charlie content three' })
+
+    // Session 2 (cold reopen): opt into search + embeddings for the first time.
+    const db2 = await createNoydb({ store, user: 'owner', secret: SECRET, searchStrategy: withSearch() })
+    const vault2 = await db2.openVault('v1')
+    const docs2 = vault2.collection<Doc>('docs', { embeddings: ENCODER })
+
+    expect(await store.get('v1', '_vec', 'docs/a')).toBeNull()
+    expect(await store.get('v1', '_vec', 'docs/b')).toBeNull()
+    expect(await store.get('v1', '_vec', 'docs/c')).toBeNull()
+
+    const result = await docs2.rebuildEmbeddings()
+    expect(result).toEqual({ rebuilt: 3, skipped: 0 })
+
+    expect(await store.get('v1', '_vec', 'docs/a')).not.toBeNull()
+    expect(await store.get('v1', '_vec', 'docs/b')).not.toBeNull()
+    expect(await store.get('v1', '_vec', 'docs/c')).not.toBeNull()
+
+    const qVec = await ENCODER.encode('alpha content one')
+    const hits = await docs2.similarTo(qVec, { k: 1 })
+    expect(hits.map((h) => h.id)).toEqual(['a'])
+  })
+
+  it('overwrites a stale/corrupt _vec row with a freshly-derived one', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'owner', secret: SECRET, searchStrategy: withSearch() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { embeddings: ENCODER })
+    await docs.put('a', { id: 'a', body: 'alpha content one' })
+
+    const freshRow = await store.get('v1', '_vec', 'docs/a')
+    expect(freshRow).not.toBeNull()
+
+    // Corrupt the sidecar in place (simulate a stale row from before a
+    // content edit that never went through embedOnWrite, e.g. a raw
+    // migration write).
+    await store.put('v1', '_vec', 'docs/a', { ...freshRow!, _data: freshRow!._data + 'garbage-suffix' })
+
+    const result = await docs.rebuildEmbeddings()
+    expect(result).toEqual({ rebuilt: 1, skipped: 0 })
+
+    const qVec = await ENCODER.encode('alpha content one')
+    const hits = await docs.similarTo(qVec, { k: 1 })
+    expect(hits.map((h) => h.id)).toEqual(['a'])
+  })
+
+  it('SKIPS an elevated record: no _vec row is written for it, and it is counted in `skipped` — the load-bearing invariant', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, user: 'owner', secret: SECRET,
+      searchStrategy: withSearch(),
+      tiersStrategy: withTiers(),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1],
+      perRecordKeys: true,
+      embeddings: ENCODER,
+    })
+    await docs.put('e1', { id: 'e1', body: 'topsecret elevated content' })
+    await docs.put('t0', { id: 't0', body: 'public tier-0 content' })
+
+    // e1's _vec was derived on put(); elevate() purges it (syncTierSearch).
+    expect(await store.get('v1', '_vec', 'docs/e1')).not.toBeNull()
+    await docs.elevate('e1', 1)
+    expect(await store.get('v1', '_vec', 'docs/e1')).toBeNull()
+
+    const result = await docs.rebuildEmbeddings()
+    expect(result).toEqual({ rebuilt: 1, skipped: 1 })
+
+    // Direct raw-store assertion — the crux: rebuildEmbeddings must NOT
+    // resurrect a _vec row for the elevated record.
+    expect(await store.get('v1', '_vec', 'docs/e1')).toBeNull()
+    expect(await store.get('v1', '_vec', 'docs/t0')).not.toBeNull()
+  })
+
+  it('skips a crypto-shred tombstone row without error (forget() leaves the id key in place, body unreadable)', async () => {
+    const store = memoryStore()
+    interface Subject extends Doc { ownerId?: string }
+    const db = await createNoydb({
+      store, user: 'owner', secret: SECRET,
+      searchStrategy: withSearch(),
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { docs: 'ownerId' } }),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Subject>('docs', { embeddings: ENCODER })
+    await docs.put('a', { id: 'a', body: 'alpha content one' })
+    await docs.put('b', { id: 'b', body: 'bravo content two', ownerId: 'bob' })
+
+    const forgetResult = await vault.forget('bob')
+    expect(forgetResult.recordsShredded).toBe(1)
+    // forget() tombstones the envelope in place — the id key survives in
+    // adapter.list(), but its body is unreadable (isTombstone).
+    expect(await store.get('v1', 'docs', 'b')).not.toBeNull()
+
+    // The tombstone must not be re-derived; only the live record ('a')
+    // counts toward `rebuilt`, and the tombstoned id counts toward `skipped`.
+    const result = await docs.rebuildEmbeddings()
+    expect(result).toEqual({ rebuilt: 1, skipped: 1 })
+  })
+
+  it('collection WITHOUT embeddings config returns {rebuilt:0, skipped:0} and does not throw', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'owner', secret: SECRET })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {})
+    await docs.put('a', { id: 'a', body: 'alpha content one' })
+
+    await expect(docs.rebuildEmbeddings()).resolves.toEqual({ rebuilt: 0, skipped: 0 })
+  })
+
+  it('collection with embeddings declared but NO withSearch() throws SearchNotEnabledError', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'owner', secret: SECRET })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { embeddings: ENCODER })
+
+    await expect(docs.rebuildEmbeddings()).rejects.toBeInstanceOf(SearchNotEnabledError)
+  })
+
+  it('resumability: a store put-failure mid-walk leaves earlier records rebuilt; a re-run completes', async () => {
+    const rawStore = memory()
+
+    const db1 = await createNoydb({ store: rawStore, user: 'owner', secret: SECRET })
+    const vault1 = await db1.openVault('v1')
+    const docs1 = vault1.collection<Doc>('docs', {})
+    await docs1.put('a', { id: 'a', body: 'alpha' })
+    await docs1.put('b', { id: 'b', body: 'bravo' })
+    await docs1.put('c', { id: 'c', body: 'charlie' })
+
+    // Fail the SECOND record's _vec write mid-walk.
+    let putCount = 0
+    const spy2: NoydbStore = {
+      ...rawStore,
+      async put(vault, coll, id, env, expectedVersion) {
+        if (coll === '_vec') {
+          putCount++
+          if (putCount === 2) throw new Error('spy: injected failure for put("_vec") #2')
+        }
+        return rawStore.put(vault, coll, id, env, expectedVersion)
+      },
+    }
+    const db2b = await createNoydb({ store: spy2, user: 'owner', secret: SECRET, searchStrategy: withSearch() })
+    const vault2b = await db2b.openVault('v1')
+    const docs2b = vault2b.collection<Doc>('docs', { embeddings: ENCODER })
+
+    await expect(docs2b.rebuildEmbeddings()).rejects.toThrow()
+
+    const vecCountBefore = (await rawStore.list('v1', '_vec')).length
+    expect(vecCountBefore).toBe(1) // exactly one landed before the injected failure
+
+    // Resume with a clean store (no further injected failures).
+    const db3 = await createNoydb({ store: rawStore, user: 'owner', secret: SECRET, searchStrategy: withSearch() })
+    const vault3 = await db3.openVault('v1')
+    const docs3 = vault3.collection<Doc>('docs', { embeddings: ENCODER })
+
+    const result = await docs3.rebuildEmbeddings()
+    expect(result).toEqual({ rebuilt: 3, skipped: 0 })
+
+    expect(await rawStore.get('v1', '_vec', 'docs/a')).not.toBeNull()
+    expect(await rawStore.get('v1', '_vec', 'docs/b')).not.toBeNull()
+    expect(await rawStore.get('v1', '_vec', 'docs/c')).not.toBeNull()
+  })
+})

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -39,15 +39,9 @@ import {
 } from '../with-lookup/search/collection-facade.js'
 import type { SearchStrategy } from '../with-lookup/search/strategy.js'
 import {
-  rebuildEagerIndexesFromCache as rebuildEagerIndexesFromCacheImpl,
-  rebuildUniqueConstraintsFromCache as rebuildUniqueConstraintsFromCacheImpl,
-  rebuildIndexes as rebuildIndexesImpl,
-  reconcileIndex as reconcileIndexImpl,
-  maintainPersistedIndexesOnPut as maintainPersistedIndexesOnPutImpl,
-  maintainPersistedIndexesOnDelete as maintainPersistedIndexesOnDeleteImpl,
-  purgePersistedIndexes as purgePersistedIndexesImpl,
-  syncTierIndexes as syncTierIndexesImpl,
-  type IndexingContext,
+  rebuildEagerIndexesFromCache as rebuildEagerIndexesFromCacheImpl, rebuildUniqueConstraintsFromCache as rebuildUniqueConstraintsFromCacheImpl, rebuildIndexes as rebuildIndexesImpl,
+  reconcileIndex as reconcileIndexImpl, maintainPersistedIndexesOnPut as maintainPersistedIndexesOnPutImpl, maintainPersistedIndexesOnDelete as maintainPersistedIndexesOnDeleteImpl,
+  purgePersistedIndexes as purgePersistedIndexesImpl, syncTierIndexes as syncTierIndexesImpl, type IndexingContext,
 } from '../with-lookup/indexing/collection-facade.js'
 import { ConflictError, ReadOnlyError, ClassifiedConfigError, ClassifiedRevealError, ClassifiedVerifyError } from './errors.js'
 import type { GhostRecord, TierMode, CrossTierAccessEvent } from './types.js'
@@ -3027,6 +3021,12 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   /** Raw-vector kNN — gated behind `searchStrategy: withSearch()`. */
   similarTo(vector: Float32Array, opts: { k?: number; minScore?: number; includeRecord?: boolean } = {}): Promise<RetrieveHit<T>[]> {
     return this.searchStrategy.similarTo(this.searchContext(), vector, opts)
+  }
+
+  /** Opt-in bulk `_vec` re-derive (#788) — a plain collection has nothing to rebuild; gated behind `searchStrategy: withSearch()` otherwise. */
+  rebuildEmbeddings(): Promise<{ rebuilt: number; skipped: number }> {
+    if (!this.embeddings) return Promise.resolve({ rebuilt: 0, skipped: 0 })
+    return this.searchStrategy.rebuildEmbeddings(this.searchContext())
   }
 
   /**

--- a/packages/hub/src/with-lookup/search/active.ts
+++ b/packages/hub/src/with-lookup/search/active.ts
@@ -34,5 +34,9 @@ export function withSearch(): SearchStrategy {
       const { embedOnWrite } = await import('./collection-facade.js')
       return embedOnWrite(ctx, id, record, version)
     },
+    async rebuildEmbeddings(ctx) {
+      const { rebuildEmbeddings } = await import('./collection-facade.js')
+      return rebuildEmbeddings(ctx)
+    },
   }
 }

--- a/packages/hub/src/with-lookup/search/collection-facade.ts
+++ b/packages/hub/src/with-lookup/search/collection-facade.ts
@@ -414,6 +414,43 @@ export async function embedOnWrite<T>(ctx: SearchContext<T>, id: string, record:
 }
 
 /**
+ * Force-re-derive every eligible tier-0 record's `_vec` sidecar once (#788).
+ * Opt-in bulk repair for the #726 re-namespace: legacy bare-id rows are
+ * unreachable to `buildVectorLoad` (it only recognises `<collection>/<id>`
+ * keys) and otherwise self-heal only when a record is next `put()` — this
+ * lets an adopter recover recall immediately instead of waiting on writes.
+ *
+ * **Skips elevated records** (`liveRecordIsElevated`) rather than refusing
+ * the whole walk — the OPPOSITE of `_applyCutoverTransform`'s
+ * `assertCutoverTierSafe` refuse-whole-batch precedent. An elevated record is
+ * SUPPOSED to have no `_vec` (`syncTierSearch` purges it on elevate);
+ * re-embedding one here would write searchable plaintext-derived data above
+ * tier 0. Load-bearing: never write a `_vec` row for an elevated record.
+ *
+ * Tombstones, delete markers, and a raw `get` racing a delete between `list`
+ * and `get` all decrypt to `null` (`decryptRecord` already folds
+ * tombstone/delete-marker into that null) and are skipped the same way.
+ * Unconditional re-derive, no already-migrated check — safe to re-run after
+ * a partial failure (each id is independently idempotent).
+ */
+export async function rebuildEmbeddings<T>(ctx: SearchContext<T>): Promise<{ rebuilt: number; skipped: number }> {
+  if (!ctx.embeddings) return { rebuilt: 0, skipped: 0 }
+  const ids = await ctx.adapter.list(ctx.vault, ctx.name)
+  let rebuilt = 0
+  let skipped = 0
+  for (const id of ids) {
+    if (await liveRecordIsElevated(ctx.adapter, ctx.vault, ctx.name, id)) { skipped++; continue }
+    const env = await ctx.adapter.get(ctx.vault, ctx.name, id)
+    if (!env) { skipped++; continue }
+    const decoded = await ctx.codec.decryptRecord(env, { id })
+    if (decoded === null) { skipped++; continue }
+    await embedOnWrite(ctx, id, decoded, env._v ?? 1)
+    rebuilt++
+  }
+  return { rebuilt, skipped }
+}
+
+/**
  * Sync the collection's SEARCH artifacts after a tier move (#721). Both the
  * lexical `_ftindex` blob and the `_vec/<id>` embedding are encrypted under
  * the tier-0 DEK and hold the record's derived plaintext (full field text /

--- a/packages/hub/src/with-lookup/search/strategy.ts
+++ b/packages/hub/src/with-lookup/search/strategy.ts
@@ -26,6 +26,7 @@ export interface SearchStrategy {
   warmIndex<T>(ctx: SearchContext<T>): Promise<void>
   flushIndex<T>(ctx: SearchContext<T>): Promise<void>
   embedOnWrite<T>(ctx: SearchContext<T>, id: string, record: T, version: number): Promise<void>
+  rebuildEmbeddings<T>(ctx: SearchContext<T>): Promise<{ rebuilt: number; skipped: number }>
 }
 
 /**
@@ -40,4 +41,5 @@ export const NO_SEARCH: SearchStrategy = {
   async warmIndex() { throw new SearchNotEnabledError() },
   async flushIndex() { throw new SearchNotEnabledError() },
   async embedOnWrite() { throw new SearchNotEnabledError() },
+  async rebuildEmbeddings() { throw new SearchNotEnabledError() },
 }

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -764,6 +764,12 @@ const KERNEL_SURFACE_BUDGET = {
   // were paid for by reflowing the adjacent 4-line `ledger` field JSDoc's first paragraph
   // (byte-preserving — same wording, joined onto one line) to a single line, a −3 net.
   // Net zero versus pre-#766: the file lands back at the exact same line count.
+  // #788 (2026-07-20, Collection.rebuildEmbeddings() thin delegator): funded IN PLACE,
+  // no bump. The +6 lines (doc comment + method signature + embeddings guard + delegate
+  // call + closing brace, beside similarTo/flushIndex) were paid for by reflowing the
+  // `indexing/collection-facade.js` named-import block from one name per line to three
+  // per line (byte-preserving — same 9 imported names, only the line breaks moved), a
+  // −6 net. Net zero versus pre-#788: the file lands back at the exact same line count.
   'packages/hub/src/kernel/collection.ts': 4549,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The


### PR DESCRIPTION
Closes #788 (milestone 34). Follow-up to #726.

## Why
#726 re-namespaced `_vec` sidecars to `_vec/<collection>/<recordId>`. Existing legacy bare-id rows became unreachable and self-heal only when each record is next `put()`. This adds an **opt-in** utility so an adopter can force-recover recall immediately instead of waiting for organic rewrites.

## API
`Collection.rebuildEmbeddings(): Promise<{ rebuilt: number; skipped: number }>` — walks the collection and re-derives each eligible record's `_vec` sidecar under the current namespaced grammar. Mirrors the `migrateSatellitePerRecordKeys`/`_applyCutoverTransform` precedent (thin `Collection` delegator → new `SearchStrategy.rebuildEmbeddings`; heavy walk in the search facade).

## Load-bearing invariant: elevated records are SKIPPED
An elevated record is *supposed* to have no `_vec` (tier elevation purges it — a searchable, plaintext-derived vector above tier 0 would defeat elevation's confidentiality). So — unlike the CEK-migration precedent, which refuses the whole batch on any elevated record — this walk **skips elevated records per-record** and never writes a `_vec` row for one. Doubly enforced: an explicit `liveRecordIsElevated` check before any embed, and a fail-closed tier-0-only decrypt (an elevated envelope can't decrypt under the tier-0 DEK). `skipped` counts elevated + tombstone/delete-marker/undecodable rows.

## Gates
- Collection has no `embeddings` config → returns `{rebuilt:0, skipped:0}` (no throw).
- Collection declared `embeddings` but never opted into `withSearch()` → throws `SearchNotEnabledError` (matches `put()`).

## Verification
- New `rebuild-embeddings.test.ts` (7): legacy/stale/missing `_vec` rebuilt + round-trips through `similarTo()`; **elevated record skipped** (no `_vec` written, asserted against the raw store — with a confirmed adversarial RED); tombstone/delete-marker skipped; no-embeddings → `{0,0}`; no-`withSearch` → throws; resumability (mid-walk store failure leaves earlier rows rebuilt, re-run completes).
- Full hub suite green (4375 tests); typecheck, lint, `check:architecture` all pass; `collection.ts` funded shrink-first, exactly at 4549. New public method reflected in the kernel-api golden surface.
- Adversarial whole-branch review (strongest model): Ready to merge.

Hub **minor** (new public API). Not published; changeset local per repo convention.