### PR TITLE
fix(cli,create-noy-db): packaging polish — canonical `npm create noy-db`, devtools READMEs, redaction artifacts, scaffold streams (#704, #705)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,7 +19,7 @@ Command-line tool for noy-db — inspect .noydb bundles without decrypting, veri
 
 ## Status
 
-**Pre-release** (`0.1.0-pre.1`). API may change before `1.0`.
+**Pre-release.** API may change before `1.0`. Run `noydb --version` for the installed version.
 
 ## Documentation
 

--- a/packages/cli/src/bin/noydb.ts
+++ b/packages/cli/src/bin/noydb.ts
@@ -23,7 +23,9 @@ import { runConfigValidate, runConfigScaffold } from '../commands/config.js'
 import { runMonitor } from '../commands/monitor.js'
 import { runDescribe } from '../commands/describe.js'
 
-const VERSION = '0.1.0'
+// Replaced at build time by tsup's `define` with the package.json version.
+declare const __CLI_VERSION__: string
+const VERSION = __CLI_VERSION__
 
 function usage(): string {
   return [

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -12,9 +12,10 @@
  *   - `blob` routes (if present) sit on a bundle-capable store.
  *
  * **scaffold** — emit a working skeleton for one of the topology
- * profiles from `docs/guides/topology-matrix.md`. Output goes to stdout
- * (pipe to a file yourself) and is a ready-to-edit `.ts` + `.env`
- * pair, concatenated so the consumer can split them.
+ * profiles from `docs/guides/topology-matrix.md`. The `.ts`/`.mjs`
+ * config is written to **stdout** (pipe it straight to a file, e.g.
+ * `> noydb.config.mjs`); the companion `.env` template is written to
+ * **stderr** so it stays out of the piped config.
  *
  * @module
  */
@@ -359,12 +360,15 @@ export async function runConfigScaffold(argv: readonly string[]): Promise<number
     return 2
   }
   const out = scaffold(profile)
+  // The config goes to stdout so `noydb config scaffold > noydb.config.mjs`
+  // captures a loadable module with no .env contamination; the companion
+  // .env template goes to stderr as guidance (see #705).
   process.stdout.write(`// ── noydb config (profile ${out.profile}) ───────────────────\n`)
   process.stdout.write(`// ${out.notes}\n\n`)
-  process.stdout.write(out.code + '\n\n')
+  process.stdout.write(out.code + '\n')
   if (out.env) {
-    process.stdout.write(`// ── .env template ───────────────────────────────────────\n`)
-    process.stdout.write(out.env)
+    process.stderr.write(`\n# ── .env template (profile ${out.profile}) ─────────────────\n`)
+    process.stderr.write(out.env)
   }
   return 0
 }

--- a/packages/cli/src/commands/monitor.ts
+++ b/packages/cli/src/commands/monitor.ts
@@ -6,9 +6,9 @@
  * refreshing snapshot to stdout at a configurable interval. Ctrl-C
  * to stop.
  *
- * This is the scope of issue  — CLI-first. A web dashboard
- * is deferred: the meter handle already exposes everything a dashboard
- * needs via `snapshot()` + `subscribe()`.
+ * This is intentionally CLI-first. A web dashboard is deferred: the
+ * meter handle already exposes everything a dashboard needs via
+ * `snapshot()` + `subscribe()`.
  *
  * @module
  */

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,4 +1,11 @@
+import { readFileSync } from 'node:fs'
 import { defineConfig } from 'tsup'
+
+// Derive the CLI version from package.json at build time so `noydb --version`
+// never drifts from the published version (see #705).
+const { version } = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf8'),
+) as { version: string }
 
 export default defineConfig({
   entry: {
@@ -11,5 +18,6 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   target: 'es2022',
+  define: { __CLI_VERSION__: JSON.stringify(version) },
 })
 

--- a/packages/create-noy-db/README.md
+++ b/packages/create-noy-db/README.md
@@ -1,15 +1,15 @@
-# @noy-db/create
+# create-noy-db
 
 Wizard + CLI tool for [noy-db](https://github.com/vLannaAi/noy-db) — scaffold a fresh Nuxt 4 + Pinia encrypted store, augment an existing Nuxt project, or run operational commands (add user, rotate keys, backup) from the command line.
 
 Two bins ship in this package:
 
-- **`create`** — invoked by `npm create @noy-db`. Fresh-project wizard OR in-place augmenter for an existing Nuxt 4 project, depending on where you run it.
+- **`create-noy-db`** — invoked by `npm create noy-db`. Fresh-project wizard OR in-place augmenter for an existing Nuxt 4 project, depending on where you run it.
 - **`noy-db`** — ongoing CLI tool. Invoked via `pnpm exec noy-db <cmd>` or `npx noy-db <cmd>` from inside a project. Five subcommands: `add`, `add user`, `verify`, `rotate`, `backup`.
 
 ---
 
-## `create @noy-db` — the wizard
+## `create noy-db` — the wizard
 
 The wizard auto-detects whether your current directory is an existing Nuxt 4 project:
 
@@ -20,10 +20,10 @@ The wizard auto-detects whether your current directory is an existing Nuxt 4 pro
 
 ```bash
 # In an empty directory
-npm  create @noy-db my-app
-pnpm create @noy-db my-app
-yarn create @noy-db my-app
-bun  create @noy-db my-app
+npm  create noy-db my-app
+pnpm create noy-db my-app
+yarn create noy-db my-app
+bun  create noy-db my-app
 ```
 
 The wizard asks at most 3 questions (project name, adapter, include sample data) and writes a complete Nuxt 4 + Pinia + `@noy-db/in-nuxt` starter into `./my-app/`. Nothing is installed automatically — pick your package manager and run it yourself.
@@ -31,8 +31,8 @@ The wizard asks at most 3 questions (project name, adapter, include sample data)
 Skip the prompts with `--yes`:
 
 ```bash
-npm create @noy-db my-app --yes
-npm create @noy-db my-app --yes --adapter file --no-sample-data
+npm create noy-db my-app --yes
+npm create noy-db my-app --yes --adapter file --no-sample-data
 ```
 
 ### Augment mode — existing Nuxt 4 project
@@ -40,7 +40,7 @@ npm create @noy-db my-app --yes --adapter file --no-sample-data
 ```bash
 # From inside an existing Nuxt 4 project root
 cd ~/my-existing-app
-npm create @noy-db
+npm create noy-db
 ```
 
 The wizard will:
@@ -66,7 +66,7 @@ The wizard will:
 Preview the diff without writing anything:
 
 ```bash
-npm create @noy-db --dry-run
+npm create noy-db --dry-run
 ```
 
 Prints the unified diff and exits. Useful in CI, code review, and "what would this do to my config?" exploration.
@@ -77,7 +77,7 @@ If you're inside a Nuxt workspace but want to create a **new** sub-project rathe
 
 ```bash
 cd ~/my-monorepo-with-nuxt
-npm create @noy-db my-sub-app --force-fresh
+npm create noy-db my-sub-app --force-fresh
 ```
 
 ### All flags
@@ -98,13 +98,13 @@ npm create @noy-db my-sub-app --force-fresh
 The wizard's prompts and notes are available in **English** (default) and **Thai** (`th`). Pick a language explicitly with `--lang`:
 
 ```bash
-npm create @noy-db my-app --lang th
+npm create noy-db my-app --lang th
 ```
 
 When `--lang` is omitted, the wizard reads the standard POSIX locale env vars (`LC_ALL`, `LC_MESSAGES`, `LANG`, `LANGUAGE`) and auto-selects Thai when they point to a Thai locale, e.g.:
 
 ```bash
-LANG=th_TH.UTF-8 npm create @noy-db my-app
+LANG=th_TH.UTF-8 npm create noy-db my-app
 ```
 
 Validation errors and stack traces stay in English regardless of language so bug reports look the same in any locale.
@@ -113,10 +113,10 @@ Validation errors and stack traces stay in English regardless of language so bug
 
 ## `noy-db` — the CLI tool
 
-The `noy-db` bin ships inside the same `@noy-db/create` package. Install it as a dev dependency and it's available via `pnpm exec` / `npx`:
+The `noy-db` bin ships inside the same `create-noy-db` package. Install it as a dev dependency and it's available via `pnpm exec` / `npx`:
 
 ```bash
-pnpm add -D @noy-db/create
+pnpm add -D create-noy-db
 pnpm exec noy-db <command>
 ```
 

--- a/packages/create-noy-db/package.json
+++ b/packages/create-noy-db/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-noy-db",
   "version": "0.3.0-pre.13",
-  "description": "Wizard + CLI tool for noy-db: scaffold a fresh Nuxt 4 + Pinia encrypted store, or add collections to an existing project. Invoke via `npm create @noy-db`.",
+  "description": "Wizard + CLI tool for noy-db: scaffold a fresh Nuxt 4 + Pinia encrypted store, or add collections to an existing project. Invoke via `npm create noy-db`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",
   "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/create-noy-db#readme",

--- a/packages/create-noy-db/src/bin/create.ts
+++ b/packages/create-noy-db/src/bin/create.ts
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 /**
- * The `create` bin of `@noy-db/create`. Invoked by the scoped-initializer
- * idioms `npm create @noy-db`, `pnpm create @noy-db`, `yarn create @noy-db`,
- * and `bun create @noy-db`.
+ * The `create-noy-db` bin of the `create-noy-db` package. Invoked by the
+ * initializer idioms `npm create noy-db`, `pnpm create noy-db`,
+ * `yarn create noy-db`, and `bun create noy-db`.
  *
- * Why the bin is called `create` (no suffix): npm's `npm init @scope` is
- * sugar for `npm exec @scope/create`, and `npm exec` picks the bin whose
- * name matches the package's "stripped" name. For `@noy-db/create` that's
- * literally `create`. If we named the bin anything else, the shortcut
- * `npm create @noy-db` would break.
+ * Why the bin is named `create-noy-db` (matching the package): npm's
+ * `npm init <name>` / `npm create <name>` is sugar for
+ * `npm exec create-<name>`, and `npm exec` picks the bin whose name
+ * matches the package name. `npm create noy-db` therefore resolves to the
+ * package `create-noy-db` and runs its `create-noy-db` bin. If we named
+ * the bin anything else, that shortcut would break.
  *
  * Argument convention follows the de-facto standard for `create-*` tools:
  * the first positional argument (if any) becomes the project name. Flags:
@@ -29,7 +30,7 @@ import { runWizard } from '../wizard/run.js'
 import { parseArgs, type ParsedArgs } from './parse-args.js'
 import { detectLocale, loadMessages } from '../wizard/i18n/index.js'
 
-const HELP = `Usage: npm create @noy-db [project-name] [options]
+const HELP = `Usage: npm create noy-db [project-name] [options]
 
 The wizard auto-detects whether cwd is an existing Nuxt 4 project:
 
@@ -45,7 +46,7 @@ Options:
   -y, --yes               Skip prompts; use defaults for missing values
       --adapter <name>    Adapter: browser (default) | file | memory
       --template <name>   Template: nuxt-default (default) | vite-vue | vanilla | electron
-      --sync <name>       Sync target (multi-backend, ):
+      --sync <name>       Sync target (multi-backend):
                           none (default) | memory | file | browser
       --no-sample-data    (fresh mode) Skip the seed invoice records
       --dry-run           (augment mode) Show the diff without writing
@@ -57,16 +58,16 @@ Options:
 
 Examples:
   # Fresh project in a new directory
-  npm create @noy-db my-app
-  npm create @noy-db my-app --yes --adapter file
-  npm create @noy-db my-app --yes --template vite-vue
-  npm create @noy-db my-app --yes --template vanilla
+  npm create noy-db my-app
+  npm create noy-db my-app --yes --adapter file
+  npm create noy-db my-app --yes --template vite-vue
+  npm create noy-db my-app --yes --template vanilla
 
   # Augment an existing Nuxt 4 project (run from its root)
   cd ~/my-existing-nuxt-app
-  npm create @noy-db                          # preview the diff and confirm
-  npm create @noy-db --dry-run                # print the diff, no write
-  npm create @noy-db --yes                    # non-interactive, write immediately
+  npm create noy-db                          # preview the diff and confirm
+  npm create noy-db --dry-run                # print the diff, no write
+  npm create noy-db --yes                    # non-interactive, write immediately
 `
 
 async function main(): Promise<void> {
@@ -91,7 +92,7 @@ async function main(): Promise<void> {
     // banner matches the rest of the flow. Explicit --lang wins;
     // otherwise we fall back to env-var detection.
     const msg = loadMessages(parsed.options.locale ?? detectLocale())
-    p.intro(pc.bgCyan(pc.black(' @noy-db/create ')))
+    p.intro(pc.bgCyan(pc.black(' create-noy-db ')))
     p.note(msg.wizardIntro)
   }
 

--- a/packages/create-noy-db/src/bin/noy-db.ts
+++ b/packages/create-noy-db/src/bin/noy-db.ts
@@ -79,7 +79,7 @@ Examples:
 
 Run from the root of a project that already has a noy-db file
 adapter directory in place. For new projects, use
-\`npm create @noy-db\` instead.
+\`npm create noy-db\` instead.
 `
 
 async function main(): Promise<void> {

--- a/packages/create-noy-db/src/commands/backup.ts
+++ b/packages/create-noy-db/src/commands/backup.ts
@@ -13,7 +13,7 @@
  *
  * ships **`file://` only** (or a plain filesystem path).
  * The issue spec originally called for `s3://` as well, but
- * wiring @aws-sdk into @noy-db/create would defeat the
+ * wiring @aws-sdk into create-noy-db would defeat the
  * zero-runtime-deps story for the CLI package. S3 backup is
  * deferred to a follow-up that can live in @noy-db/s3-cli or a
  * similar optional companion package.

--- a/packages/create-noy-db/src/wizard/i18n/index.ts
+++ b/packages/create-noy-db/src/wizard/i18n/index.ts
@@ -1,5 +1,5 @@
 /**
- * i18n entrypoint for the `@noy-db/create` wizard.
+ * i18n entrypoint for the `create-noy-db` wizard.
  *
  * Three responsibilities:
  *
@@ -24,7 +24,7 @@
  * for 30+ years — that's what a Thai-speaking dev's terminal will
  * actually have set. Following that convention also means power
  * users can override per-invocation with `LANG=th_TH.UTF-8 npm
- * create @noy-db`, no flag required.
+ * create noy-db`, no flag required.
  */
 
 import { en } from './en.js'

--- a/packages/create-noy-db/src/wizard/i18n/types.ts
+++ b/packages/create-noy-db/src/wizard/i18n/types.ts
@@ -1,5 +1,5 @@
 /**
- * Internationalization types for the `@noy-db/create` wizard.
+ * Internationalization types for the `create-noy-db` wizard.
  *
  * `WizardMessages` is the full set of user-facing strings the
  * wizard emits: prompt labels, note titles, note bodies, outro

--- a/packages/create-noy-db/tsup.config.ts
+++ b/packages/create-noy-db/tsup.config.ts
@@ -4,10 +4,10 @@ export default defineConfig({
   // Three entry points:
   //   - `src/index.ts` → public API surface (exported wizard + commands so
   //     they can be re-used programmatically and tested cleanly)
-  //   - `src/bin/create.ts` → the `create` bin — the wizard for fresh
-  //     projects, invoked by `npm create @noy-db`. Bin name matches npm's
-  //     scoped-initializer convention: `npm create @scope` resolves to
-  //     package `@scope/create` and looks for a bin named `create`.
+  //   - `src/bin/create.ts` → the `create-noy-db` bin — the wizard for
+  //     fresh projects, invoked by `npm create noy-db`. Bin name matches
+  //     npm's initializer convention: `npm create <name>` resolves to
+  //     package `create-<name>` and looks for a bin of the same name.
   //   - `src/bin/noy-db.ts` → the `noy-db` bin (subcommand dispatcher for
   //     ongoing project commands like `add` and `verify`)
   //

--- a/packages/in-devtools-tui/README.md
+++ b/packages/in-devtools-tui/README.md
@@ -1,0 +1,33 @@
+# @noy-db/in-devtools-tui
+
+[![npm](https://img.shields.io/npm/v/%40noy-db/in-devtools-tui.svg)](https://www.npmjs.com/package/@noy-db/in-devtools-tui)
+
+> Interactive terminal inspector for a live [noy-db](https://github.com/vLannaAi/noy-db) — an [ink](https://github.com/vadimdemedes/ink) TUI over [`@noy-db/in-devtools`](https://www.npmjs.com/package/@noy-db/in-devtools).
+
+Part of [**`@noy-db/hub`**](https://www.npmjs.com/package/@noy-db/hub) — the zero-knowledge, offline-first, encrypted document store.
+
+## Install
+
+```bash
+pnpm add -D @noy-db/in-devtools-tui
+```
+
+## Usage
+
+Point the `noydb-inspect` bin at a config file that default-exports your `NoydbOptions`. It unlocks the vault (prompting for the passphrase, or reading `--passphrase=…` / `NOYDB_PASSPHRASE`), then opens a read-only terminal dashboard of collections, records, and live writes.
+
+```bash
+npx noydb-inspect ./noydb.config.mjs --vault=acme
+```
+
+Add `--meter` to wrap the store in [`@noy-db/to-meter`](https://www.npmjs.com/package/@noy-db/to-meter) and show live store metrics. Like the inspector core it wraps, the TUI is read-only and never persists your passphrase.
+
+## Documentation
+
+- Guide — [`content/docs/families/in/devtools-tui.md`](https://github.com/vLannaAi/noy-db-docs/blob/main/content/docs/families/in/devtools-tui.md)
+- Source — [`packages/in-devtools-tui`](https://github.com/vLannaAi/noy-db/tree/main/packages/in-devtools-tui)
+- Issues — [github.com/vLannaAi/noy-db/issues](https://github.com/vLannaAi/noy-db/issues)
+
+## License
+
+MIT

--- a/packages/in-devtools-tui/package.json
+++ b/packages/in-devtools-tui/package.json
@@ -9,7 +9,8 @@
   },
   "main": "./dist/bin.js",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/in-devtools/README.md
+++ b/packages/in-devtools/README.md
@@ -1,0 +1,41 @@
+# @noy-db/in-devtools
+
+[![npm](https://img.shields.io/npm/v/%40noy-db/in-devtools.svg)](https://www.npmjs.com/package/@noy-db/in-devtools)
+
+> Framework-agnostic, read-only inspector for a live [noy-db](https://github.com/vLannaAi/noy-db) — vaults, collections, schema, stats, records, and live writes.
+
+Part of [**`@noy-db/hub`**](https://www.npmjs.com/package/@noy-db/hub) — the zero-knowledge, offline-first, encrypted document store.
+
+## Install
+
+```bash
+pnpm add @noy-db/hub @noy-db/in-devtools
+```
+
+## What it is
+
+`createInspector(db, { meter? })` turns a live `Noydb` instance into serializable, read-only views for a CLI, a browser panel, or the terminal TUI ([`@noy-db/in-devtools-tui`](https://www.npmjs.com/package/@noy-db/in-devtools-tui)). It is a pure consumer of public hub APIs — read-only and zero-knowledge-respecting: it never holds passphrases and shows only what the caller's unlocked session can already read.
+
+```ts
+import { createInspector } from '@noy-db/in-devtools'
+
+const inspector = createInspector(db)
+
+inspector.listVaults()                                // accessible vaults
+inspector.snapshot(vault)                             // collections: fields, indexes, refs, stats
+inspector.records(vault, 'invoices', { limit: 50 })   // page decrypted rows (default 50, ceiling 500)
+inspector.subscribe((e) => console.log(e))            // live write events
+inspector.pendingWrites()                             // write-queue state
+```
+
+Pass a [`@noy-db/to-meter`](https://www.npmjs.com/package/@noy-db/to-meter) handle as `meter` to also expose `meterSnapshot()`.
+
+## Documentation
+
+- Guide — [`content/docs/families/in/devtools.md`](https://github.com/vLannaAi/noy-db-docs/blob/main/content/docs/families/in/devtools.md)
+- Source — [`packages/in-devtools`](https://github.com/vLannaAi/noy-db/tree/main/packages/in-devtools)
+- Issues — [github.com/vLannaAi/noy-db/issues](https://github.com/vLannaAi/noy-db/issues)
+
+## License
+
+MIT

--- a/packages/in-devtools/package.json
+++ b/packages/in-devtools/package.json
@@ -13,7 +13,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
Closes #704, closes #705. Two small, well-specified packaging-polish issues on the developer-tooling surface — landed together because they share `packages/create-noy-db/src/bin/create.ts`.

## #704 — `create-noy-db` documented invocation was broken
The scaffolder is **published unscoped** as `create-noy-db` (`npm view create-noy-db` → `next: 0.3.0-pre.13`), but the README, `package.json` description, `--help`, and code comments all documented `npm create @noy-db` / `@noy-db/create` — which resolves to the **unpublished** `@noy-db/create` (404).

- Every documented invocation now uses **`npm create noy-db`**; repo-wide `grep "create @noy-db" / "@noy-db/create"` → **0 hits**.
- The `create.ts` header and `tsup.config.ts` comments described a *never-shipped scoped model* (`@noy-db/create` with a bin named `create`). Rewritten to the actual unscoped package: bin `create-noy-db`, and the correct npm convention (`npm create <name>` → package `create-<name>` → bin of the same name).
- **Decision (issue's "decide either way"):** no `@noy-db/create` alias published — canonical invocation is `npm create noy-db`. (An alias would need a separate, user-gated publish and adds surface.)

## #705 — CLI / devtools packaging polish
- **Blank npm pages:** `@noy-db/in-devtools` and `@noy-db/in-devtools-tui` now ship a README (added to each `files` array). Content verified against the actual source APIs.
- **Stale `--version`:** `noydb --version` now **derives from `package.json` at build time** via tsup `define` → `__CLI_VERSION__` (was hardcoded `0.1.0`; now prints `0.3.0-pre.13`). Stale version string dropped from the cli README.
- **Redaction artifacts finished:** `--sync (multi-backend, )` → `(multi-backend)` in the scaffolder `--help`; a dangling `monitor.ts` doc sentence reworded. Fragments **removed**, no scrubbed content restored.
- **Scaffold stream split:** `noydb config scaffold` writes the loadable config to **stdout** and the `.env` template to **stderr**, so `noydb config scaffold > noydb.config.mjs` produces a clean, loadable module with no `.env` contamination.

Deferred (belongs to #742's `@latest` retag pass): the devtools `@latest` tags sit at `0.2.0-pre.6` — they move when the stable cut retags `@latest`.

## Verification
- Acceptance criteria for both issues confirmed empirically (`--version`, `--help` clean, scaffold pipes to a loadable file, `create-noy-db --help` renders).
- Tests green: cli 29 / create-noy-db 132 / in-devtools 16 / in-devtools-tui 18. Typecheck, lint, `pnpm check:architecture` all clean.
- Whole-branch review clean after one fix (a bin-name label in the README).

Patch changeset included (lockstep, rides the next release).