### PR TITLE
feat(hub): join/projection materialized view — third strategy form (#810)

### DIFF
--- a/docs/superpowers/specs/2026-07-25-join-projection-mv-design.md
+++ b/docs/superpowers/specs/2026-07-25-join-projection-mv-design.md
@@ -94,6 +94,10 @@ All inside `src/with-formula/materialized-views/*` (the lazy-import chunk — mu
 7. queryHash stability across re-open; change of leg set forces refresh
 8. surface goldens updated (`with-surface`, root barrel) for the new exported types
 
+## Implementation note (deviation, accepted)
+
+**Forward-leg auto-dependencies resolve lazily, not at registration.** MV registration runs at vault open — before user code declares collections and their `ref()`s — so a forward leg's target is unknowable then (and constructing the source collection early would silently drop later ref declarations). The registry records pending forward fields with a non-constructive ref-registry probe and retries on each dispatch (`mvsForSource`) until resolved, then folds targets into the dependency set. Net freshness behavior matches the spec. Two documented residuals: (a) a cycle routed *exclusively* through a forward leg is not visible to the open-time cycle pass (source + collect edges are); (b) `queryHash` deliberately excludes late-folded forward targets so hash inputs stay deterministic at registration.
+
 ## Out of scope
 
 - Reverse joins in the general query DSL (`Query.collect()`) — only the MV form

--- a/docs/superpowers/specs/2026-07-25-join-projection-mv-design.md
+++ b/docs/superpowers/specs/2026-07-25-join-projection-mv-design.md
@@ -1,0 +1,101 @@
+# Join/Projection Materialized View (#810)
+
+**Status:** approved-for-implementation · **Milestone:** 40 (Federated read-model: hub support [api])
+**Consumer:** niwat federated read-model (klum-db#44) — per-shard projected rows (bill/payment/dashboard) materialized natively instead of app-side custom refresh.
+
+## Problem
+
+`withMaterializedView` has two forms: `query` (single-source; forward `.join()` legs already auto-tracked by the dependency analyzer) and `unionSources` (multi-source same-shape, per-arm forward `join?` + `map`). Neither can produce the niwat row: **primary record enriched with child SETS resolved by reverse FK** (receipts *pointing at* the bill, credit notes, applications…) plus forward lookups (client name), shaped by a projection function, **kept fresh when any referenced source changes**.
+
+The two gaps, precisely:
+1. **No reverse (one-to-many) join** anywhere in the query DSL or MV forms — `Query.join()` is forward-only (left FK field → right record).
+2. **No row-shaping hook on the query form** — UNION arms have `map`; query-form rows are the raw query result.
+
+Everything else already exists: multi-source dependency dispatch (`registry._bySource`), auto-analyzed forward-join deps, ViaGraph cycle edges from the dependency set, full-rebuild executor with diff/tombstone, eager/lazy/manual refresh, `_materializedFrom` metadata envelope, queryHash.
+
+## Design: a third strategy form — `projection`
+
+`MaterializedViewStrategy<TRow>` gains `projection?`, mutually exclusive with `query`/`unionSources` (exactly-one-of-three, validated in `withMaterializedView()` with `MaterializedViewConfigError`).
+
+```ts
+projection?: {
+  /** Primary collection. One output row per primary record (unless map omits). */
+  readonly source: string
+  /** Join legs attached to each primary row BEFORE map runs. */
+  readonly joins: ReadonlyArray<ProjectionJoinLeg>
+  /** Pure projection: primary row + attachments → MV row. null/undefined omits. */
+  readonly map: (row: Record<string, unknown>) => TRow | null | undefined
+}
+
+type ProjectionJoinLeg =
+  /** Forward FK leg — identical shape + machinery as UnionArmJoin / Query.join(). */
+  | { readonly field: string; readonly as: string
+      readonly maxRows?: number; readonly strategy?: JoinStrategy }
+  /** Reverse one-to-many "collect" leg — NEW. All rows of `from` whose `on`
+      field references the primary record's id, attached as an ARRAY under `as`. */
+  | { readonly collect: string          // sibling collection to collect from
+      readonly on: string               // FK field on `collect` (ref() → source required)
+      readonly as: string
+      readonly maxRows?: number }       // per-primary-row ceiling; default DEFAULT_JOIN_MAX_ROWS
+```
+
+Discriminant: presence of `collect` vs `field`. Both leg kinds may repeat; `as` aliases must be unique across legs and non-empty.
+
+### The niwat acceptance shape
+
+```ts
+withMaterializedView<BillRow>({
+  name: 'billRows',
+  projection: {
+    source: 'bills',
+    joins: [
+      { field: 'clientId', as: 'client' },                       // forward
+      { collect: 'receipts', on: 'billId', as: 'receipts' },     // reverse
+      { collect: 'receiptBillApplications', on: 'billId', as: 'applications' },
+      { collect: 'creditNotes', on: 'billId', as: 'creditNotes' },
+      { collect: 'disbursements', on: 'billId', as: 'disbursements' },
+    ],
+    map: (r) => projectBillRow(r),  // window sums, coverage, status — app-pure
+  },
+  rowKey: (r) => r.billId,
+  refresh: 'eager',
+})
+```
+
+## Semantics
+
+- **Forward legs** reuse the existing join machinery (`applyJoins`/`JoinLeg` path, same as UNION arms): `ref()`-declared FK required, resolved record attached under `as` (record | null), `maxRows`/`strategy` pass through.
+- **Collect legs**: one snapshot pass over `from`, hash-grouped by `on` (O(N+M), mirrors the hash-join fallback), attached as a possibly-empty array. The `on` field **must have a `ref()` declared targeting `source`** — semantic validation at first materialization (parity with join-time ref errors), shape validation at factory time. Exceeding `maxRows` for one primary row throws the join-ceiling error (same family as `JoinTooLargeError`).
+- **Filtering lives in `map`** (return null to omit) — no `where` in v1 (YAGNI; niwat's windowing is in-map over child arrays).
+- **Post-map `groupBy`/`aggregate`**: supported, same as UNION (mapped stream → shared `groupAndReduce`). `onEmpty`, `strict`, `maxRows`, `output`, `partition` all inherit unchanged.
+- **Dependencies — all AUTO**: `{source} ∪ forward-ref targets ∪ collect froms` (better DX than UNION's manual `sources` requirement; explicit `sources` still additive). Feeds `_bySource` dispatch, so a write to ANY referenced collection triggers eager refresh / lazy stale-marking — the freshness half of #810 for free. Same set feeds `registry.edges()` → ViaGraph `'mv'` edges → cycle detection needs no change.
+- **Refresh** = full rebuild (parity with existing executor: re-run, diff `newIds`, tombstone via `_internalDelete`). Incremental per-primary-row refresh is a possible follow-up, out of scope.
+- **queryHash**: structural summary `JSON{projection:{source, legs:[sorted leg descriptors]}}` — the `map` body is NOT hashed (documented; identical limitation as UNION `map`).
+- **Tier posture**: the projection sees what the refreshing session sees (existing MV law; no new leak surface — collect legs read through the same collection read path).
+
+## Where the code lives
+
+All inside `src/with-formula/materialized-views/*` (the lazy-import chunk — must stay dynamically imported; no floor-bundle growth):
+- `types.ts` — `ProjectionSpec`, `ProjectionJoinLeg` + strategy field
+- `with-materialized-view.ts` — exactly-one-of-three + leg shape validation
+- `registry.ts` — third branch: dependencies + `summarizeProjectionPlan`
+- `executor.ts` — `materializeProjectionResult` (hydrate source → forward legs via existing helper → collect legs via hash-group → map → optional groupAndReduce → shared diff/write path)
+- No kernel-spine changes expected (dispatch is dependency-set-driven) → no line-ceiling bumps.
+
+## Tests
+
+`__tests__/materialized-views/projection-mv.test.ts`:
+1. niwat-shaped 5-leg acceptance (bills/clients/receipts/applications/creditNotes) — row content byte-exact vs hand-computed
+2. freshness: eager refresh on child write (new receipt updates bill row); lazy stale-marker + resolve-on-read
+3. map null-omission; empty collect arrays
+4. collect `maxRows` ceiling throws; missing ref() on `on` throws at first materialize
+5. config validation: two forms declared, dup `as`, empty legs
+6. cycle refusal: projection MV whose collect target is another MV's output forming a loop
+7. queryHash stability across re-open; change of leg set forces refresh
+8. surface goldens updated (`with-surface`, root barrel) for the new exported types
+
+## Out of scope
+
+- Reverse joins in the general query DSL (`Query.collect()`) — only the MV form
+- Incremental (per-primary-row) refresh
+- Cross-vault anything (that's `broadcastJoin` / klum-db#44's composition layer)

--- a/packages/hub/__tests__/materialized-views/projection-mv.test.ts
+++ b/packages/hub/__tests__/materialized-views/projection-mv.test.ts
@@ -1,0 +1,563 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createNoydb,
+  withMaterializedView,
+  ref,
+  MaterializedViewConfigError,
+  MaterializedViewCycleError,
+  JoinTooLargeError,
+} from '../../src/index.js'
+import { isMVStale } from '../../src/with-formula/materialized-views/stale.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/kernel/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none', required: false, flow: 'static' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/') as [string, string, string]
+        if (vname === v) { out[cname] = out[cname] ?? {}; out[cname][id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c]!)) { data.set(k(v, c, i), payload[c]![i]!) }
+      }
+    },
+  }
+}
+
+interface Client extends Record<string, unknown> { id: string; name: string }
+interface Bill extends Record<string, unknown> { id: string; clientId: string; amount: number; status: string }
+interface Receipt extends Record<string, unknown> { id: string; billId: string; amount: number }
+interface Application extends Record<string, unknown> { id: string; billId: string; applied: number }
+interface CreditNote extends Record<string, unknown> { id: string; billId: string; amount: number }
+interface Disbursement extends Record<string, unknown> { id: string; billId: string; amount: number }
+
+interface BillRow extends Record<string, unknown> {
+  billId: string
+  clientName: string
+  amount: number
+  receiptTotal: number
+  receiptCount: number
+  appliedTotal: number
+  creditTotal: number
+  disbursementTotal: number
+  outstanding: number
+}
+
+const sumOf = (rows: ReadonlyArray<Record<string, unknown>>, field: string): number =>
+  rows.reduce((acc, r) => acc + (r[field] as number), 0)
+
+/** The niwat-shaped 5-leg projection: 1 forward (client) + 4 collect legs. */
+function billRowsMV(refresh: 'eager' | 'lazy' | 'manual' = 'eager') {
+  return withMaterializedView<BillRow>({
+    name: 'billRows',
+    projection: {
+      source: 'bills',
+      joins: [
+        { field: 'clientId', as: 'client' },
+        { collect: 'receipts', on: 'billId', as: 'receipts' },
+        { collect: 'receiptBillApplications', on: 'billId', as: 'applications' },
+        { collect: 'creditNotes', on: 'billId', as: 'creditNotes' },
+        { collect: 'disbursements', on: 'billId', as: 'disbursements' },
+      ],
+      map: (r) => {
+        if (r.status === 'void') return null
+        const client = r.client as Client | null
+        const receipts = r.receipts as ReadonlyArray<Record<string, unknown>>
+        const applications = r.applications as ReadonlyArray<Record<string, unknown>>
+        const creditNotes = r.creditNotes as ReadonlyArray<Record<string, unknown>>
+        const disbursements = r.disbursements as ReadonlyArray<Record<string, unknown>>
+        const appliedTotal = sumOf(applications, 'applied')
+        const creditTotal = sumOf(creditNotes, 'amount')
+        return {
+          billId: r.id as string,
+          clientName: client?.name ?? '(unknown)',
+          amount: r.amount as number,
+          receiptTotal: sumOf(receipts, 'amount'),
+          receiptCount: receipts.length,
+          appliedTotal,
+          creditTotal,
+          disbursementTotal: sumOf(disbursements, 'amount'),
+          outstanding: (r.amount as number) - appliedTotal - creditTotal,
+        }
+      },
+    },
+    rowKey: (r) => r.billId,
+    refresh,
+  })
+}
+
+/** Open a vault with the niwat-shaped collections + refs declared. */
+async function openBillsVault(mv = billRowsMV(), secret = 'mv-projection-niwat-passphrase-2026') {
+  const db = await createNoydb({
+    store: memory(),
+    user: 'alice',
+    secret,
+    materializedViewStrategies: [mv],
+  })
+  const vault = await db.openVault('books')
+  vault.collection<Client>('clients')
+  vault.collection<Bill>('bills', { refs: { clientId: ref('clients') } })
+  vault.collection<Receipt>('receipts', { refs: { billId: ref('bills') } })
+  vault.collection<Application>('receiptBillApplications', { refs: { billId: ref('bills') } })
+  vault.collection<CreditNote>('creditNotes', { refs: { billId: ref('bills') } })
+  vault.collection<Disbursement>('disbursements', { refs: { billId: ref('bills') } })
+  return vault
+}
+
+describe('projection MV (#810) — niwat-shaped acceptance', () => {
+  it('materializes one row per bill with forward client + 4 collect arrays, byte-exact', async () => {
+    const vault = await openBillsVault()
+    const clients = vault.collection<Client>('clients')
+    const bills = vault.collection<Bill>('bills')
+    const receipts = vault.collection<Receipt>('receipts')
+    const applications = vault.collection<Application>('receiptBillApplications')
+    const creditNotes = vault.collection<CreditNote>('creditNotes')
+    const disbursements = vault.collection<Disbursement>('disbursements')
+
+    await clients.put('c1', { id: 'c1', name: 'Acme' })
+    await clients.put('c2', { id: 'c2', name: 'Globex' })
+    await bills.put('b1', { id: 'b1', clientId: 'c1', amount: 1000, status: 'open' })
+    await bills.put('b2', { id: 'b2', clientId: 'c2', amount: 500, status: 'open' })
+    await receipts.put('r1', { id: 'r1', billId: 'b1', amount: 400 })
+    await receipts.put('r2', { id: 'r2', billId: 'b1', amount: 100 })
+    await receipts.put('r3', { id: 'r3', billId: 'b2', amount: 500 })
+    await applications.put('a1', { id: 'a1', billId: 'b1', applied: 400 })
+    await applications.put('a2', { id: 'a2', billId: 'b1', applied: 100 })
+    await creditNotes.put('cn1', { id: 'cn1', billId: 'b1', amount: 50 })
+    await disbursements.put('d1', { id: 'd1', billId: 'b1', amount: 25 })
+
+    const out = vault.collection<BillRow & { _materializedFrom?: unknown }>('billRows')
+    const row1 = await out.get('b1')
+    expect(row1).not.toBeNull()
+    const { _materializedFrom, ...bare1 } = row1!
+    expect(_materializedFrom).toBeDefined()
+    expect(bare1).toEqual({
+      billId: 'b1',
+      clientName: 'Acme',
+      amount: 1000,
+      receiptTotal: 500,
+      receiptCount: 2,
+      appliedTotal: 500,
+      creditTotal: 50,
+      disbursementTotal: 25,
+      outstanding: 450,
+    })
+
+    const row2 = await out.get('b2')
+    const { _materializedFrom: _m2, ...bare2 } = row2!
+    expect(bare2).toEqual({
+      billId: 'b2',
+      clientName: 'Globex',
+      amount: 500,
+      receiptTotal: 500,
+      receiptCount: 1,
+      appliedTotal: 0,
+      creditTotal: 0,
+      disbursementTotal: 0,
+      outstanding: 500,
+    })
+  })
+
+  it('forward-leg freshness: renaming the client refreshes the bill row', async () => {
+    const vault = await openBillsVault(billRowsMV(), 'mv-projection-fwd-fresh-passphrase-2026')
+    const clients = vault.collection<Client>('clients')
+    const bills = vault.collection<Bill>('bills')
+
+    await clients.put('c1', { id: 'c1', name: 'Acme' })
+    await bills.put('b1', { id: 'b1', clientId: 'c1', amount: 100, status: 'open' })
+    expect((await vault.collection<BillRow>('billRows').get('b1'))?.clientName).toBe('Acme')
+
+    // Write to the FORWARD ref target — the dependency is auto-resolved
+    // from bills' ref(clientId → clients), so this must trigger refresh.
+    await clients.put('c1', { id: 'c1', name: 'Acme Renamed' })
+    expect((await vault.collection<BillRow>('billRows').get('b1'))?.clientName).toBe('Acme Renamed')
+  })
+})
+
+describe('projection MV (#810) — freshness', () => {
+  it('eager: a child (collect) write refreshes the bill row', async () => {
+    const vault = await openBillsVault(billRowsMV(), 'mv-projection-eager-child-passphrase-2026')
+    const clients = vault.collection<Client>('clients')
+    const bills = vault.collection<Bill>('bills')
+    const receipts = vault.collection<Receipt>('receipts')
+
+    await clients.put('c1', { id: 'c1', name: 'Acme' })
+    await bills.put('b1', { id: 'b1', clientId: 'c1', amount: 100, status: 'open' })
+    expect((await vault.collection<BillRow>('billRows').get('b1'))?.receiptCount).toBe(0)
+
+    await receipts.put('r1', { id: 'r1', billId: 'b1', amount: 60 })
+    const row = await vault.collection<BillRow>('billRows').get('b1')
+    expect(row?.receiptCount).toBe(1)
+    expect(row?.receiptTotal).toBe(60)
+  })
+
+  it('lazy: child write marks stale; first read materializes and clears the bit', async () => {
+    const vault = await openBillsVault(billRowsMV('lazy'), 'mv-projection-lazy-passphrase-2026')
+    const clients = vault.collection<Client>('clients')
+    const bills = vault.collection<Bill>('bills')
+    const receipts = vault.collection<Receipt>('receipts')
+
+    await clients.put('c1', { id: 'c1', name: 'Acme' })
+    await bills.put('b1', { id: 'b1', clientId: 'c1', amount: 100, status: 'open' })
+    await receipts.put('r1', { id: 'r1', billId: 'b1', amount: 30 })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const reg = vault._getMaterializedViewRegistry()!
+    expect(isMVStale(reg, 'billRows')).toBe(true)
+
+    // Resolve-on-read: first read of the output collection materializes.
+    const row = await vault.collection<BillRow>('billRows').get('b1')
+    expect(row?.receiptTotal).toBe(30)
+    expect(isMVStale(reg, 'billRows')).toBe(false)
+  })
+})
+
+describe('projection MV (#810) — map omission + empty collect arrays', () => {
+  it('map null → primary row omitted; onEmpty delete tombstones it after a status flip', async () => {
+    const vault = await openBillsVault(billRowsMV(), 'mv-projection-null-omit-passphrase-2026')
+    const clients = vault.collection<Client>('clients')
+    const bills = vault.collection<Bill>('bills')
+
+    await clients.put('c1', { id: 'c1', name: 'Acme' })
+    await bills.put('b1', { id: 'b1', clientId: 'c1', amount: 100, status: 'open' })
+    await bills.put('b2', { id: 'b2', clientId: 'c1', amount: 200, status: 'void' })
+
+    const out = vault.collection<BillRow>('billRows')
+    expect(await out.get('b1')).not.toBeNull()
+    expect(await out.get('b2')).toBeNull()
+
+    // Flip b1 to void — the previously-emitted row must be tombstoned.
+    await bills.put('b1', { id: 'b1', clientId: 'c1', amount: 100, status: 'void' })
+    expect(await out.get('b1')).toBeNull()
+  })
+
+  it('a primary row with no children gets empty collect arrays (not null)', async () => {
+    const vault = await openBillsVault(billRowsMV(), 'mv-projection-empty-collect-passphrase-2026')
+    await vault.collection<Client>('clients').put('c1', { id: 'c1', name: 'Acme' })
+    await vault.collection<Bill>('bills').put('b1', { id: 'b1', clientId: 'c1', amount: 100, status: 'open' })
+
+    const row = await vault.collection<BillRow>('billRows').get('b1')
+    expect(row?.receiptCount).toBe(0)
+    expect(row?.receiptTotal).toBe(0)
+    expect(row?.appliedTotal).toBe(0)
+    expect(row?.creditTotal).toBe(0)
+    expect(row?.disbursementTotal).toBe(0)
+  })
+})
+
+describe('projection MV (#810) — collect ceilings + ref requirement', () => {
+  it('exceeding a collect leg maxRows for one primary row throws JoinTooLargeError', async () => {
+    const mv = withMaterializedView<Record<string, unknown>>({
+      name: 'capped',
+      projection: {
+        source: 'bills',
+        joins: [{ collect: 'receipts', on: 'billId', as: 'receipts', maxRows: 2 }],
+        map: (r) => ({ billId: r.id, n: (r.receipts as unknown[]).length }),
+      },
+      rowKey: (r) => r.billId as string,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-projection-ceiling-passphrase-2026',
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('books')
+    vault.collection<Bill>('bills')
+    vault.collection<Receipt>('receipts', { refs: { billId: ref('bills') } })
+
+    await vault.collection<Bill>('bills').put('b1', { id: 'b1', clientId: 'c1', amount: 1, status: 'open' })
+    await vault.collection<Receipt>('receipts').put('r1', { id: 'r1', billId: 'b1', amount: 1 })
+    await vault.collection<Receipt>('receipts').put('r2', { id: 'r2', billId: 'b1', amount: 1 })
+    // Third child for the same primary row crosses the 2-row ceiling.
+    await expect(
+      vault.collection<Receipt>('receipts').put('r3', { id: 'r3', billId: 'b1', amount: 1 }),
+    ).rejects.toBeInstanceOf(JoinTooLargeError)
+  })
+
+  it('collect `on` without a ref() throws at first materialization', async () => {
+    const mv = withMaterializedView<Record<string, unknown>>({
+      name: 'norefs',
+      projection: {
+        source: 'bills',
+        joins: [{ collect: 'receipts', on: 'billId', as: 'receipts' }],
+        map: (r) => ({ billId: r.id }),
+      },
+      rowKey: (r) => r.billId as string,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-projection-noref-passphrase-2026',
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('books')
+    vault.collection<Bill>('bills')
+    vault.collection<Receipt>('receipts') // NO ref on billId
+
+    await expect(
+      vault.collection<Bill>('bills').put('b1', { id: 'b1', clientId: 'c1', amount: 1, status: 'open' }),
+    ).rejects.toThrow(/ref\(\)/)
+  })
+
+  it('collect `on` whose ref() targets a different collection throws at first materialization', async () => {
+    const mv = withMaterializedView<Record<string, unknown>>({
+      name: 'wrongtarget',
+      projection: {
+        source: 'bills',
+        joins: [{ collect: 'receipts', on: 'billId', as: 'receipts' }],
+        map: (r) => ({ billId: r.id }),
+      },
+      rowKey: (r) => r.billId as string,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-projection-wrongref-passphrase-2026',
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('books')
+    vault.collection<Bill>('bills')
+    vault.collection<Record<string, unknown>>('other')
+    vault.collection<Receipt>('receipts', { refs: { billId: ref('other', 'warn') } })
+
+    await expect(
+      vault.collection<Bill>('bills').put('b1', { id: 'b1', clientId: 'c1', amount: 1, status: 'open' }),
+    ).rejects.toBeInstanceOf(MaterializedViewConfigError)
+  })
+})
+
+describe('projection MV (#810) — config validation', () => {
+  const validProjection = {
+    source: 'bills',
+    joins: [{ collect: 'receipts', on: 'billId', as: 'receipts' }],
+    map: (r: Record<string, unknown>) => r,
+  }
+
+  it('rejects projection combined with query', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-both',
+        query: () => ({}) as never,
+        projection: validProjection,
+        rowKey: () => 'k',
+        refresh: 'eager',
+      }),
+    ).toThrow(MaterializedViewConfigError)
+  })
+
+  it('rejects projection combined with unionSources', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-both-union',
+        unionSources: [{ collection: 'a', map: (r) => r as Record<string, unknown> }],
+        projection: validProjection,
+        rowKey: () => 'k',
+        refresh: 'eager',
+      }),
+    ).toThrow(MaterializedViewConfigError)
+  })
+
+  it('rejects duplicate `as` aliases across legs', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-dup-as',
+        projection: {
+          source: 'bills',
+          joins: [
+            { field: 'clientId', as: 'x' },
+            { collect: 'receipts', on: 'billId', as: 'x' },
+          ],
+          map: (r: Record<string, unknown>) => r,
+        },
+        rowKey: () => 'k',
+        refresh: 'eager',
+      }),
+    ).toThrow(/distinct.*as|duplicate/i)
+  })
+
+  it('rejects an empty joins array', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-empty-legs',
+        projection: { source: 'bills', joins: [], map: (r: Record<string, unknown>) => r },
+        rowKey: () => 'k',
+        refresh: 'eager',
+      }),
+    ).toThrow(/at least (1|one)/i)
+  })
+
+  it('rejects a leg declaring neither field nor collect', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-leg-shape',
+        projection: {
+          source: 'bills',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          joins: [{ as: 'x' } as any],
+          map: (r: Record<string, unknown>) => r,
+        },
+        rowKey: () => 'k',
+        refresh: 'eager',
+      }),
+    ).toThrow(MaterializedViewConfigError)
+  })
+
+  it('rejects a leg declaring both field and collect', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-leg-both',
+        projection: {
+          source: 'bills',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          joins: [{ field: 'clientId', collect: 'receipts', on: 'billId', as: 'x' } as any],
+          map: (r: Record<string, unknown>) => r,
+        },
+        rowKey: () => 'k',
+        refresh: 'eager',
+      }),
+    ).toThrow(MaterializedViewConfigError)
+  })
+
+  it('rejects an empty projection source', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-source',
+        projection: { source: '', joins: validProjection.joins, map: (r: Record<string, unknown>) => r },
+        rowKey: () => 'k',
+        refresh: 'eager',
+      }),
+    ).toThrow(MaterializedViewConfigError)
+  })
+})
+
+describe('projection MV (#810) — cycle refusal', () => {
+  it('collect target fed by an MV over this projection output throws MaterializedViewCycleError', async () => {
+    const proj = withMaterializedView<Record<string, unknown>>({
+      name: 'projOut',
+      projection: {
+        source: 'bills',
+        joins: [{ collect: 'ledger', on: 'billId', as: 'entries' }],
+        map: (r) => ({ billId: r.id }),
+      },
+      rowKey: (r) => r.billId as string,
+      refresh: 'eager',
+    })
+    // Query-form MV reading projOut and writing INTO 'ledger' — the loop.
+    const loop = withMaterializedView<Record<string, unknown>>({
+      name: 'loopMV',
+      query: (db) => db.collection<Record<string, unknown>>('projOut').query(),
+      rowKey: (r) => r.billId as string,
+      refresh: 'eager',
+      output: { collection: 'ledger' },
+    })
+
+    await expect(
+      (async () => {
+        const db = await createNoydb({
+          store: memory(),
+          user: 'alice',
+          secret: 'mv-projection-cycle-passphrase-2026',
+          materializedViewStrategies: [proj, loop],
+        })
+        await db.openVault('books')
+      })(),
+    ).rejects.toBeInstanceOf(MaterializedViewCycleError)
+  })
+})
+
+describe('projection MV (#810) — queryHash', () => {
+  it('is stable across re-open with an identical strategy', async () => {
+    const store = memory()
+    const hashes: string[] = []
+    for (let i = 0; i < 2; i++) {
+      const db = await createNoydb({
+        store,
+        user: 'alice',
+        secret: 'mv-projection-hash-stable-passphrase-2026',
+        materializedViewStrategies: [billRowsMV()],
+      })
+      const vault = await db.openVault('books')
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      hashes.push(vault._getMaterializedViewRegistry()!.byName('billRows')!.queryHash)
+    }
+    expect(hashes[0]).toBe(hashes[1])
+  })
+
+  it('is insensitive to leg declaration order (sorted descriptors)', async () => {
+    const { summarizeProjectionPlan } = await import('../../src/with-formula/materialized-views/dependency-analyzer.js')
+    const a = withMaterializedView<Record<string, unknown>>({
+      name: 'h',
+      projection: {
+        source: 'bills',
+        joins: [
+          { field: 'clientId', as: 'client' },
+          { collect: 'receipts', on: 'billId', as: 'receipts' },
+        ],
+        map: (r) => r,
+      },
+      rowKey: (r) => String(r.id),
+      refresh: 'eager',
+    })
+    const b = withMaterializedView<Record<string, unknown>>({
+      name: 'h',
+      projection: {
+        source: 'bills',
+        joins: [
+          { collect: 'receipts', on: 'billId', as: 'receipts' },
+          { field: 'clientId', as: 'client' },
+        ],
+        map: (r) => r,
+      },
+      rowKey: (r) => String(r.id),
+      refresh: 'eager',
+    })
+    expect(summarizeProjectionPlan(a.spec)).toBe(summarizeProjectionPlan(b.spec))
+  })
+
+  it('changes when the leg set changes (forces refresh on next visit)', async () => {
+    const { summarizeProjectionPlan } = await import('../../src/with-formula/materialized-views/dependency-analyzer.js')
+    const one = withMaterializedView<Record<string, unknown>>({
+      name: 'h',
+      projection: {
+        source: 'bills',
+        joins: [{ collect: 'receipts', on: 'billId', as: 'receipts' }],
+        map: (r) => r,
+      },
+      rowKey: (r) => String(r.id),
+      refresh: 'eager',
+    })
+    const two = withMaterializedView<Record<string, unknown>>({
+      name: 'h',
+      projection: {
+        source: 'bills',
+        joins: [
+          { collect: 'receipts', on: 'billId', as: 'receipts' },
+          { collect: 'creditNotes', on: 'billId', as: 'creditNotes' },
+        ],
+        map: (r) => r,
+      },
+      rowKey: (r) => String(r.id),
+      refresh: 'eager',
+    })
+    expect(summarizeProjectionPlan(one.spec)).not.toBe(summarizeProjectionPlan(two.spec))
+    expect(summarizeProjectionPlan(two.spec)).toContain('creditNotes')
+  })
+})

--- a/packages/hub/__tests__/root-barrel-surface.golden.json
+++ b/packages/hub/__tests__/root-barrel-surface.golden.json
@@ -721,6 +721,8 @@
     "PlaintextTranslatorFn",
     "PolicyDenyReason",
     "PresencePeer",
+    "ProjectionJoinLeg",
+    "ProjectionSpec",
     "PruneOptions",
     "PublicEnvelope",
     "PublicEnvelopeField",

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -783,6 +783,8 @@ export type {
   MaterializedFromMeta,
   UnionSource,
   UnionArmJoin,
+  ProjectionSpec,
+  ProjectionJoinLeg,
 } from './with-formula/materialized-views/index.js'
 export {
   MaterializedViewCycleError,

--- a/packages/hub/src/kernel/errors.ts
+++ b/packages/hub/src/kernel/errors.ts
@@ -2486,12 +2486,17 @@ export class MaterializedViewTooLargeError extends NoydbError {
  * error fires before either check, at the moment the spec is being
  * normalized.
  *
- * Today the trigger cases are all about the `query` / `unionSources`
- * dichotomy:
- *   - both `query` and `unionSources` were set (mutually exclusive),
- *   - neither `query` nor `unionSources` was set,
+ * Today the trigger cases are all about the `query` / `unionSources` /
+ * `projection` trichotomy:
+ *   - more than one of `query` / `unionSources` / `projection` was set
+ *     (mutually exclusive),
+ *   - none of the three was set,
  *   - `unionSources` has fewer than 2 arms,
- *   - two arms in `unionSources` reference the same `collection`.
+ *   - two arms in `unionSources` reference the same `collection`,
+ *   - a malformed `projection` leg (dup / empty `as`, neither `field`
+ *     nor `collect`, empty leg list) — plus, at first materialization,
+ *     a collect leg whose `on` field lacks a `ref()` targeting the
+ *     projection source.
  *
  * The error message is prefixed with `[noy-db] withMaterializedView:`
  * so it's grep-friendly in logs and looks consistent with the existing

--- a/packages/hub/src/with-formula/materialized-views/dependency-analyzer.ts
+++ b/packages/hub/src/with-formula/materialized-views/dependency-analyzer.ts
@@ -134,7 +134,43 @@ export function summarizeQueryPlan(query: Query<any>): string {
 export function summarizeUnionPlan<T extends Record<string, unknown>>(
   spec: MaterializedViewStrategy<T>,
 ): string {
-  const arms = (spec.unionSources ?? [])
+  return `union(${summarizeUnionArms(spec)})${summarizeGroupingTail(spec)}`
+}
+
+/**
+ * Canonical string description of a projection MV's plan (#810), used
+ * as input to `computeQueryHash`.
+ *
+ * Leg descriptors ARE sorted (contrast with UNION arm order): every
+ * leg attaches under a distinct `as` alias, forward legs are
+ * one-to-one attachments and collect legs are independent
+ * hash-grouped passes, so declaration order never changes the
+ * materialized rows — a pure reorder must NOT force a refresh.
+ *
+ * The projection `map` is NOT fingerprinted (identical limitation as
+ * the UNION arm `map`); consumers must bump the MV's `name` when
+ * `map` semantics change non-equivalently.
+ */
+export function summarizeProjectionPlan<T extends Record<string, unknown>>(
+  spec: MaterializedViewStrategy<T>,
+): string {
+  const projection = spec.projection!
+  const legs = projection.joins
+    .map(leg =>
+      'collect' in leg
+        ? `collect:${leg.collect}.${leg.on}→${leg.as}`
+        : `field:${leg.field}→${leg.as}`,
+    )
+    .sort()
+  const body = JSON.stringify({ source: projection.source, legs })
+  return `projection(${body})${summarizeGroupingTail(spec)}`
+}
+
+/** Arm descriptors for `summarizeUnionPlan` — declaration order preserved (see its doc). */
+function summarizeUnionArms<T extends Record<string, unknown>>(
+  spec: MaterializedViewStrategy<T>,
+): string {
+  return (spec.unionSources ?? [])
     .map(s => {
       // Fold each arm's join legs into the summary so adding or
       // reordering joins (which changes the materialized rows) bumps
@@ -146,6 +182,16 @@ export function summarizeUnionPlan<T extends Record<string, unknown>>(
       return `${s.collection}${joins}`
     })
     .join(',')
+}
+
+/**
+ * Shared `|groupBy(…)|aggregate(…)|money(…)` tail for the UNION and
+ * projection summaries — both feed the same post-map grouping pipeline,
+ * so the same spec fields fold into both hashes with the same rules.
+ */
+function summarizeGroupingTail<T extends Record<string, unknown>>(
+  spec: MaterializedViewStrategy<T>,
+): string {
   const groupBy: string = Array.isArray(spec.groupBy)
     ? [...spec.groupBy].sort().join(',')
     : typeof spec.groupBy === 'string'
@@ -157,5 +203,5 @@ export function summarizeUnionPlan<T extends Record<string, unknown>>(
   // sorted — they're independent of each other (one descriptor per
   // output field), same rationale as aggregate keys.
   const moneyKeys = spec.moneyFields ? Object.keys(spec.moneyFields).sort().join(',') : ''
-  return `union(${arms})|groupBy(${groupBy})|aggregate(${aggKeys})|money(${moneyKeys})`
+  return `|groupBy(${groupBy})|aggregate(${aggKeys})|money(${moneyKeys})`
 }

--- a/packages/hub/src/with-formula/materialized-views/executor.ts
+++ b/packages/hub/src/with-formula/materialized-views/executor.ts
@@ -1,7 +1,8 @@
 import type { Collection } from '../../kernel/collection.js'
 import type { TxContext } from '../../with-commit/tx/transaction.js'
 import type { EncryptedEnvelope } from '../../kernel/types.js'
-import { MaterializedViewTooLargeError, LocaleNotSpecifiedError } from '../../kernel/errors.js'
+import { MaterializedViewTooLargeError, MaterializedViewConfigError, LocaleNotSpecifiedError, JoinTooLargeError } from '../../kernel/errors.js'
+import { DEFAULT_JOIN_MAX_ROWS } from '../../kernel/query/join.js'
 import type { MaterializedFromMeta, MVQueryContext, MaterializedViewStrategy } from './types.js'
 import type { RegisteredMV } from './registry.js'
 import { wrapDbWithPredicates } from './registry.js'
@@ -152,6 +153,23 @@ async function materializeUnionResult<TRow extends Record<string, unknown>>(
     }
   }
 
+  return finalizeMappedRows(spec, unified)
+}
+
+/**
+ * Shared post-map tail for the UNION and projection (#810) forms:
+ * optional `groupBy` (+ `aggregate`) over the mapped-row stream.
+ * Extracted verbatim from `materializeUnionResult` so both forms feed
+ * the identical grouping pipeline — i18n group-key resolution, the
+ * object-group-key guard, dedup-without-aggregate, and the shared
+ * `groupAndReduce` delegate.
+ *
+ * @internal
+ */
+function finalizeMappedRows<TRow extends Record<string, unknown>>(
+  spec: MaterializedViewStrategy<TRow>,
+  unified: TRow[],
+): ReadonlyArray<Record<string, unknown>> {
   if (!spec.groupBy) return unified
 
   const groupFields: readonly string[] =
@@ -210,6 +228,134 @@ async function materializeUnionResult<TRow extends Record<string, unknown>>(
 }
 
 /**
+ * Materialize a projection-form MV (#810): hydrate the primary source
+ * rows, resolve forward FK legs through the same `.join()` machinery
+ * the UNION arms use, attach reverse "collect" legs via one
+ * hash-grouped snapshot pass per leg, then run the projection `map`
+ * (null / undefined omits the primary row) and the shared post-map
+ * grouping tail.
+ *
+ * @internal
+ */
+async function materializeProjectionResult<TRow extends Record<string, unknown>>(
+  spec: MaterializedViewStrategy<TRow>,
+  db: MVQueryContext,
+): Promise<ReadonlyArray<Record<string, unknown>>> {
+  const projection = spec.projection!
+  const coll = db.collection<Record<string, unknown>>(projection.source)
+  // Forward legs chain through the query builder exactly like UNION arm
+  // joins — ref() resolution, dangling-mode semantics, presentation
+  // dressing, and ceilings all ride the existing `.join()` path. Cast to
+  // `any` for the same reason `materializeUnionResult` does.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let q: any = coll.query()
+  for (const leg of projection.joins) {
+    if ('collect' in leg) continue
+    q = q.join(leg.field, { as: leg.as, maxRows: leg.maxRows, strategy: leg.strategy })
+  }
+  let rows = q.toArray() as Array<Record<string, unknown>>
+  for (const leg of projection.joins) {
+    if (!('collect' in leg)) continue
+    rows = applyCollectLeg(rows, leg, spec.name, projection.source, db)
+  }
+  const mapped: TRow[] = []
+  for (const r of rows) {
+    const m = projection.map(r)
+    // null / undefined means "omit this primary row" — same contract
+    // as the UNION arm `map`.
+    if (m == null) continue
+    mapped.push(m)
+  }
+  return finalizeMappedRows(spec, mapped)
+}
+
+/**
+ * Attach one reverse "collect" leg (#810): every row of `leg.collect`
+ * whose `leg.on` field references a primary record's id lands in a
+ * possibly-empty ARRAY under `leg.as` on that primary row. One
+ * snapshot pass over the collect collection, hash-grouped by the `on`
+ * FK — O(N+M), mirroring the forward hash-join fallback.
+ *
+ * Semantic check (first materialization, not factory time — parity
+ * with join-time ref errors): `leg.on` must carry a `ref()` declared
+ * on the collect collection targeting the projection `source`.
+ *
+ * @internal
+ */
+function applyCollectLeg(
+  primaryRows: ReadonlyArray<Record<string, unknown>>,
+  leg: { readonly collect: string; readonly on: string; readonly as: string; readonly maxRows?: number },
+  mvName: string,
+  source: string,
+  db: MVQueryContext,
+): Array<Record<string, unknown>> {
+  const childColl = db.collection<Record<string, unknown>>(leg.collect)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const childQ = childColl.query() as any
+  const refDesc = childQ._joinContext?.()?.resolveRef(leg.on) as { target: string } | null | undefined
+  if (refDesc == null) {
+    throw new MaterializedViewConfigError(
+      `"${mvName}": projection collect leg "${leg.as}" requires a ref() on field "${leg.on}" of `
+      + `collection "${leg.collect}" targeting "${source}" — declare `
+      + `refs: { ${leg.on}: ref('${source}') } on collection "${leg.collect}", then retry`,
+    )
+  }
+  if (refDesc.target !== source) {
+    throw new MaterializedViewConfigError(
+      `"${mvName}": projection collect leg "${leg.as}" expects field "${leg.on}" of collection `
+      + `"${leg.collect}" to reference the projection source "${source}", but its ref() targets `
+      + `"${refDesc.target}"`,
+    )
+  }
+  const maxRows = leg.maxRows ?? DEFAULT_JOIN_MAX_ROWS
+  const groups = new Map<string, Array<Record<string, unknown>>>()
+  for (const child of childQ.toArray() as Array<Record<string, unknown>>) {
+    const key = coerceCollectKey(child[leg.on])
+    // Nullish / non-scalar FK values mean "no reference" — same
+    // narrowing as the forward join path's key coercion.
+    if (key === null) continue
+    const bucket = groups.get(key)
+    if (bucket) bucket.push(child)
+    else groups.set(key, [child])
+  }
+  const out: Array<Record<string, unknown>> = []
+  for (const row of primaryRows) {
+    const key = coerceCollectKey(row.id)
+    const children = key === null ? [] : groups.get(key) ?? []
+    if (children.length > maxRows) {
+      throw new JoinTooLargeError({
+        leftRows: primaryRows.length,
+        rightRows: children.length,
+        maxRows,
+        side: 'right',
+        message:
+          `projection MV "${mvName}": collect leg "${leg.as}" gathered ${children.length} ` +
+          `"${leg.collect}" rows for one "${source}" record, exceeding the ${maxRows}-row ` +
+          `per-primary-row ceiling. Raise the ceiling via { maxRows } on the leg if the ` +
+          `fan-out genuinely fits in memory, or restructure the child collection.`,
+      })
+    }
+    out.push({ ...row, [leg.as]: children })
+  }
+  return out
+}
+
+/**
+ * Coerce an unknown FK value into a collect-grouping key. Same
+ * narrowing as the join path's `coerceRefKey` (not exported from
+ * there): strings and numbers are legitimate ref values; anything
+ * else is "no reference" and returns `null`.
+ *
+ * @internal
+ */
+function coerceCollectKey(value: unknown): string | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value)
+  return null
+}
+
+/**
  * Run an MV's `query()` and write the result rows to the output
  * collection. Same-DEK encryption: routes through the standard
  * `Collection.put` pipeline, so the output collection's DEK is what
@@ -258,11 +404,15 @@ export const MaterializedViewExecutor = {
       ? wrapDbWithPredicates(baseCtx, spec.predicates)
       : baseCtx
     // UNION-form strategies: read every arm, map to the unified
-    // row shape, concatenate, then optionally groupBy + aggregate. The
-    // single-source `query()` path is untouched.
+    // row shape, concatenate, then optionally groupBy + aggregate.
+    // Projection-form strategies (#810): hydrate the primary source,
+    // attach forward + collect legs, map, then the same optional
+    // grouping tail. The single-source `query()` path is untouched.
     let rows: ReadonlyArray<Record<string, unknown>>
     if (spec.unionSources) {
       rows = await materializeUnionResult(spec, ctxForQuery)
+    } else if (spec.projection) {
+      rows = await materializeProjectionResult(spec, ctxForQuery)
     } else {
       const q = spec.query!(ctxForQuery)
       rows = await materializeQueryResult(q, spec.name, spec.i18nLocale, spec.i18nFields)

--- a/packages/hub/src/with-formula/materialized-views/index.ts
+++ b/packages/hub/src/with-formula/materialized-views/index.ts
@@ -12,6 +12,8 @@ export type {
   MaterializedFromMeta,
   UnionSource,
   UnionArmJoin,
+  ProjectionSpec,
+  ProjectionJoinLeg,
 } from './types.js'
 export type { RegisteredMV } from './registry.js'
 export type { MVExecutorAccessor, RefreshResult } from './executor.js'

--- a/packages/hub/src/with-formula/materialized-views/registry.ts
+++ b/packages/hub/src/with-formula/materialized-views/registry.ts
@@ -2,7 +2,7 @@ import { MaterializedViewSourceUnknownError } from '../../kernel/errors.js'
 import type { ViaGraph, FieldRef, EdgeKind, Grain } from '../../kernel/via/graph.js'
 import type { Clause, FieldClause } from '../../kernel/query/predicate.js'
 import type { DeclaredPredicate } from '../../kernel/query/builder.js'
-import { analyzeDependencies, summarizeQueryPlan, summarizeUnionPlan } from './dependency-analyzer.js'
+import { analyzeDependencies, summarizeQueryPlan, summarizeUnionPlan, summarizeProjectionPlan } from './dependency-analyzer.js'
 import { computeQueryHash } from './query-hash.js'
 import type { MaterializedViewStrategy, MVQueryContext } from './types.js'
 
@@ -55,6 +55,24 @@ export class MaterializedViewRegistry {
   private readonly _byName = new Map<string, RegisteredMV>()
   /** Keyed by dependency source-collection → MVs that depend on it. */
   private readonly _bySource = new Map<string, RegisteredMV[]>()
+  /**
+   * Projection MVs (#810) whose forward-leg ref() targets could not be
+   * resolved at registration time. A forward leg names only the FK
+   * FIELD; its dependency is the field's ref() TARGET, declared on the
+   * source collection — but registration runs at vault open, BEFORE
+   * user code declares collections (and their refs). Constructing the
+   * source collection here to look them up would be worse: a later
+   * `vault.collection(source, { refs })` call only registers refs on a
+   * cache miss, so an early construction would silently drop them.
+   * Instead each entry carries a non-constructive ref-registry probe;
+   * `mvsForSource` retries on every dispatch until every forward
+   * target has resolved (see `_resolvePendingForwardDeps`).
+   */
+  private readonly _pendingForwardDeps: Array<{
+    reg: RegisteredMV
+    fields: Set<string>
+    resolveTarget: (field: string) => string | null
+  }> = []
 
   /**
    * Register an MV. Invokes `spec.query()` once at registration time to
@@ -94,6 +112,10 @@ export class MaterializedViewRegistry {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let qAny: any = null
     let isQuery = false
+    // Projection-form (#810): forward legs whose ref() target wasn't
+    // resolvable at registration time — folded in lazily, see
+    // `_pendingForwardDeps`.
+    const pendingForwardFields: string[] = []
     if (spec.unionSources) {
       dependencies = new Set(spec.unionSources.map(s => s.collection))
       // Per-arm joins resolve right-side collections that aren't among
@@ -102,6 +124,21 @@ export class MaterializedViewRegistry {
       // collection triggers MV refresh (and contributes a cycle edge).
       if (spec.sources) for (const s of spec.sources) dependencies.add(s)
       queryPlanSummary = summarizeUnionPlan(spec)
+    } else if (spec.projection) {
+      // Projection-form (#810): dependencies are all AUTO — the primary
+      // source, every collect leg's collection (both literal names), and
+      // every forward leg's ref() target. Forward targets usually can't
+      // resolve yet (refs are declared after vault open) — those go
+      // through the pending-resolution path below. Explicit `sources`
+      // remains additive, same as the other two forms.
+      const projection = spec.projection
+      dependencies = new Set([projection.source])
+      for (const leg of projection.joins) {
+        if ('collect' in leg) dependencies.add(leg.collect)
+        else pendingForwardFields.push(leg.field)
+      }
+      if (spec.sources) for (const s of spec.sources) dependencies.add(s)
+      queryPlanSummary = summarizeProjectionPlan(spec)
     } else {
       const q = spec.query!(dbForQuery)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -170,8 +207,8 @@ export class MaterializedViewRegistry {
     }
     // #638 Task 2 — 'aggregate' only for the explicit-sources aggregate shape
     // (groupBy().aggregate() with no chainable plan); a row-per-source-row
-    // Query<T> or a unionSources MV is 'record'.
-    const grain: Grain = spec.unionSources || isQuery ? 'record' : 'aggregate'
+    // Query<T>, unionSources, or projection MV is 'record'.
+    const grain: Grain = spec.unionSources || spec.projection || isQuery ? 'record' : 'aggregate'
     const reg: RegisteredMV = { spec, outputCollection, dependencies, queryHash, partitionClauses, grain }
 
     this._byName.set(spec.name, reg)
@@ -180,11 +217,63 @@ export class MaterializedViewRegistry {
       if (arr) arr.push(reg)
       else this._bySource.set(dep, [reg])
     }
+    if (pendingForwardFields.length > 0) {
+      // Non-constructive ref-registry probe: the Vault (the real
+      // MVQueryContext) carries its RefRegistry as a private field,
+      // reachable structurally at runtime. Test stubs without one simply
+      // never resolve — forward deps then come only from explicit `sources`.
+      const refRegistry = (db as unknown as {
+        refRegistry?: { getOutbound(collection: string): Record<string, { target: string }> }
+      }).refRegistry
+      const source = spec.projection!.source
+      this._pendingForwardDeps.push({
+        reg,
+        fields: new Set(pendingForwardFields),
+        resolveTarget: (field) => refRegistry?.getOutbound(source)[field]?.target ?? null,
+      })
+      // Immediate attempt — covers refs already declared by the time
+      // this MV registers (re-registration flows, test wiring).
+      this._resolvePendingForwardDeps()
+    }
   }
 
   /** All MVs that depend on `source`, in registration order. */
   mvsForSource(source: string): ReadonlyArray<RegisteredMV> {
+    if (this._pendingForwardDeps.length > 0) this._resolvePendingForwardDeps()
     return this._bySource.get(source) ?? []
+  }
+
+  /**
+   * Retry ref() resolution for every pending projection forward leg
+   * (#810). A field resolves once its source collection's refs have
+   * been declared; the target then folds into the owning MV's
+   * dependency set and `_bySource`, so subsequent writes to it
+   * dispatch a refresh. Idempotent and cheap — the pending list
+   * empties as fields resolve, and `mvsForSource` skips the call
+   * entirely once it's empty.
+   *
+   * Late-resolved targets do NOT retro-feed `edges()` — the cycle
+   * pass runs once at vault open, before refs exist. A cycle routed
+   * exclusively through a forward leg is therefore not detected at
+   * open (collect + source edges, the literal names, are).
+   */
+  private _resolvePendingForwardDeps(): void {
+    for (let i = this._pendingForwardDeps.length - 1; i >= 0; i--) {
+      const entry = this._pendingForwardDeps[i]!
+      for (const field of [...entry.fields]) {
+        const target = entry.resolveTarget(field)
+        if (target === null) continue
+        entry.fields.delete(field)
+        if (entry.reg.dependencies.has(target)) continue
+        // `dependencies` is declared ReadonlySet for consumers; the
+        // registry owns the underlying Set and is the one writer.
+        ;(entry.reg.dependencies as Set<string>).add(target)
+        const arr = this._bySource.get(target)
+        if (arr) arr.push(entry.reg)
+        else this._bySource.set(target, [entry.reg])
+      }
+      if (entry.fields.size === 0) this._pendingForwardDeps.splice(i, 1)
+    }
   }
 
   /** Single MV by name, or `undefined`. */

--- a/packages/hub/src/with-formula/materialized-views/types.ts
+++ b/packages/hub/src/with-formula/materialized-views/types.ts
@@ -123,6 +123,72 @@ export interface UnionArmJoin {
 }
 
 /**
+ * Projection-form registration (#810): one output row per record of a
+ * primary `source` collection, enriched with forward FK legs and
+ * reverse one-to-many "collect" legs BEFORE `map` shapes the MV row.
+ * The niwat federated read-model shape — a bill row carrying its
+ * client lookup plus the receipt / application / credit-note sets
+ * that point back at it.
+ */
+export interface ProjectionSpec<TRow extends Record<string, unknown>> {
+  /** Primary collection. One output row per primary record (unless {@link map} omits). */
+  readonly source: string
+  /** Join legs attached to each primary row BEFORE {@link map} runs. */
+  readonly joins: ReadonlyArray<ProjectionJoinLeg>
+  /**
+   * Pure projection: primary row + leg attachments → MV row. Called
+   * once per primary record at materialization time, AFTER every leg
+   * has attached under its `as` alias.
+   *
+   * Returning `null` or `undefined` **omits** the primary record from
+   * the materialized output entirely (same contract as the UNION arm
+   * `map`) — filtering lives here; there is no `where` on the
+   * projection form.
+   */
+  readonly map: (row: Record<string, unknown>) => TRow | null | undefined
+}
+
+/**
+ * One join leg of a projection MV. Discriminated by the presence of
+ * `collect` (reverse leg) vs `field` (forward leg); `as` aliases must
+ * be unique across legs and non-empty.
+ *
+ * - **Forward FK leg** — identical shape + machinery as
+ *   {@link UnionArmJoin} / `Query.join()`: resolves a `ref()`-declared
+ *   FK on the projection source into an attached right-side record
+ *   (record | null) under `as`.
+ * - **Reverse "collect" leg** — every row of `collect` whose `on`
+ *   field references the primary record's id, attached as a
+ *   possibly-empty ARRAY under `as`. `on` must carry a `ref()`
+ *   declared on the `collect` collection targeting the projection
+ *   `source` — checked at first materialization (parity with
+ *   join-time ref errors). `maxRows` here is a PER-PRIMARY-ROW
+ *   fan-out ceiling (default: the join default); exceeding it throws
+ *   `JoinTooLargeError`.
+ */
+export type ProjectionJoinLeg =
+  | {
+      /** FK field on the projection source (must have a `ref()` declared). */
+      readonly field: string
+      /** Alias under which the resolved right-side record attaches. */
+      readonly as: string
+      /** Per-side row ceiling override. `undefined` → the join default. */
+      readonly maxRows?: number
+      /** Planner strategy override. `undefined` → auto-select. */
+      readonly strategy?: JoinStrategy
+    }
+  | {
+      /** Sibling collection to collect from. */
+      readonly collect: string
+      /** FK field on `collect` (`ref()` targeting the projection source required). */
+      readonly on: string
+      /** Alias under which the collected array attaches. */
+      readonly as: string
+      /** Per-primary-row fan-out ceiling. `undefined` → the join default. */
+      readonly maxRows?: number
+    }
+
+/**
  * Registration shape passed to `withMaterializedView()`.
  *
  * @typeParam TRow - the materialized row type (the query's result row)
@@ -171,6 +237,25 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    * {@link sources} is ignored.
    */
   unionSources?: ReadonlyArray<UnionSource<TRow>>
+  /**
+   * Projection-form registration (#810): one output row per primary
+   * record of `projection.source`, enriched with forward FK legs and
+   * reverse one-to-many "collect" legs before `projection.map` shapes
+   * the MV row. Post-map {@link groupBy} + {@link aggregate} are
+   * supported exactly as in UNION mode.
+   *
+   * Mutually exclusive with {@link query} and {@link unionSources} —
+   * a strategy must declare exactly one of the three forms.
+   * Registration throws `MaterializedViewConfigError` otherwise.
+   *
+   * Dependencies are all AUTO: `{source} ∪ forward ref() targets ∪
+   * collect collections` (explicit {@link sources} remains additive).
+   * Forward targets resolve from the source collection's `ref()`
+   * declarations; those are declared by user code AFTER the vault
+   * opens (registration time), so the registry folds them into the
+   * dependency set on the first MV dispatch that finds them declared.
+   */
+  projection?: ProjectionSpec<TRow>
   /**
    * Group-key field(s) for UNION mode. Applied to the
    * concatenated mapped-row stream from {@link unionSources} before

--- a/packages/hub/src/with-formula/materialized-views/with-materialized-view.ts
+++ b/packages/hub/src/with-formula/materialized-views/with-materialized-view.ts
@@ -9,19 +9,23 @@ import type { MaterializedViewStrategy, MaterializedViewStrategyHandle } from '.
  * user `onDelete` guards on the output collection aren't tripped by
  * housekeeping.
  *
- * Two registration modes:
+ * Three registration modes:
  *   - **single-source** — declare `query: (db) => Query<TRow>`; the
  *     dependency analyzer derives source collections from the plan.
  *   - **UNION** — declare `unionSources: [{ collection, map }, ...]`
  *     plus optional `groupBy` + `aggregate`; the executor reads each
  *     arm, maps to the unified row shape, concatenates, then groups
  *     and aggregates.
+ *   - **projection** (#810) — declare `projection: { source, joins,
+ *     map }`; one output row per primary record, enriched with
+ *     forward FK legs and reverse "collect" legs before `map` runs.
  *
- * The two modes are mutually exclusive — exactly one of `query` /
- * `unionSources` must be set at registration time.
+ * The three modes are mutually exclusive — exactly one of `query` /
+ * `unionSources` / `projection` must be set at registration time.
  *
- * See docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md (single-source v2)
- * and docs/superpowers/specs/2026-05-21-dim14-mv-multikey-and-union.md (UNION).
+ * See docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md (single-source v2),
+ * docs/superpowers/specs/2026-05-21-dim14-mv-multikey-and-union.md (UNION),
+ * and docs/superpowers/specs/2026-07-25-join-projection-mv-design.md (projection).
  */
 export function withMaterializedView<TRow extends Record<string, unknown>>(
   spec: MaterializedViewStrategy<TRow>,
@@ -29,16 +33,17 @@ export function withMaterializedView<TRow extends Record<string, unknown>>(
   if (!spec.name || spec.name.length === 0) {
     throw new ValidationError('withMaterializedView: name is required')
   }
-  // Mutual exclusion: query and unionSources cannot coexist.
-  if (spec.query && spec.unionSources) {
+  // Mutual exclusion: exactly one of the three forms must be declared.
+  const declaredForms = [spec.query, spec.unionSources, spec.projection]
+    .filter((f) => f !== undefined).length
+  if (declaredForms > 1) {
     throw new MaterializedViewConfigError(
-      'query and unionSources are mutually exclusive — pick one',
+      'query, unionSources, and projection are mutually exclusive — pick one',
     )
   }
-  // Strategy must declare one of the two.
-  if (!spec.query && !spec.unionSources) {
+  if (declaredForms === 0) {
     throw new MaterializedViewConfigError(
-      'strategy must declare either query or unionSources',
+      'strategy must declare exactly one of query, unionSources, or projection',
     )
   }
   if (spec.query !== undefined && typeof spec.query !== 'function') {
@@ -111,6 +116,102 @@ export function withMaterializedView<TRow extends Record<string, unknown>>(
         `withMaterializedView "${spec.name}": predicates are not supported on UNION strategies — `
         + `UNION mode does not use a Query<T> chain, so .wherePredicate() cannot fire. `
         + `Use the query() form, or open an issue if per-arm predicates are needed`,
+      )
+    }
+  }
+  // Projection-form invariants (#810). Shape checks only — the
+  // semantic ref() check on collect legs (the `on` field must carry a
+  // ref() targeting the projection source) runs at first
+  // materialization, parity with join-time ref errors.
+  if (spec.projection) {
+    const projection = spec.projection
+    if (typeof projection.source !== 'string' || projection.source.length === 0) {
+      throw new MaterializedViewConfigError(
+        `withMaterializedView "${spec.name}": projection.source must be a non-empty collection name`,
+      )
+    }
+    if (typeof projection.map !== 'function') {
+      throw new MaterializedViewConfigError(
+        `withMaterializedView "${spec.name}": projection is missing a \`map\` function`,
+      )
+    }
+    if (!Array.isArray(projection.joins) || projection.joins.length < 1) {
+      throw new MaterializedViewConfigError(
+        `withMaterializedView "${spec.name}": projection.joins must declare at least 1 leg — `
+        + `a leg-less single-source MV is the query() form's job`,
+      )
+    }
+    const seenAs = new Set<string>()
+    for (const leg of projection.joins) {
+      const l = leg as { field?: unknown; collect?: unknown; on?: unknown; as?: unknown }
+      const isForward = l.field !== undefined
+      const isCollect = l.collect !== undefined
+      if (isForward && isCollect) {
+        throw new MaterializedViewConfigError(
+          `withMaterializedView "${spec.name}": a projection leg cannot declare both \`field\` `
+          + `(forward) and \`collect\` (reverse) — split it into two legs`,
+        )
+      }
+      if (!isForward && !isCollect) {
+        throw new MaterializedViewConfigError(
+          `withMaterializedView "${spec.name}": each projection leg must declare either \`field\` `
+          + `(forward FK) or \`collect\` (reverse one-to-many)`,
+        )
+      }
+      if (isForward && (typeof l.field !== 'string' || l.field.length === 0)) {
+        throw new MaterializedViewConfigError(
+          `withMaterializedView "${spec.name}": a forward projection leg must declare a non-empty \`field\``,
+        )
+      }
+      if (isCollect) {
+        if (typeof l.collect !== 'string' || l.collect.length === 0) {
+          throw new MaterializedViewConfigError(
+            `withMaterializedView "${spec.name}": a collect projection leg must declare a non-empty \`collect\` collection name`,
+          )
+        }
+        if (typeof l.on !== 'string' || l.on.length === 0) {
+          throw new MaterializedViewConfigError(
+            `withMaterializedView "${spec.name}": collect leg for "${l.collect}" must declare a non-empty \`on\` FK field`,
+          )
+        }
+      }
+      if (typeof l.as !== 'string' || l.as.length === 0) {
+        throw new MaterializedViewConfigError(
+          `withMaterializedView "${spec.name}": each projection leg must declare a non-empty \`as\` alias`,
+        )
+      }
+      if (seenAs.has(l.as)) {
+        throw new MaterializedViewConfigError(
+          `withMaterializedView "${spec.name}": projection legs must attach under distinct \`as\` aliases (duplicate: "${l.as}")`,
+        )
+      }
+      seenAs.add(l.as)
+    }
+    // Post-map grouping invariants — same rules as UNION (the mapped
+    // stream feeds the same shared groupAndReduce tail).
+    if (Array.isArray(spec.groupBy) && spec.groupBy.length === 0) {
+      throw new MaterializedViewConfigError(
+        `withMaterializedView "${spec.name}": groupBy must not be an empty array — omit it or provide at least one field name`,
+      )
+    }
+    if (spec.aggregate && !spec.groupBy) {
+      throw new MaterializedViewConfigError(
+        `withMaterializedView "${spec.name}": projection strategy with aggregate requires groupBy — `
+        + `use groupBy to declare the bucketing keys, or remove aggregate for a row-per-primary-record MV`,
+      )
+    }
+    if (spec.moneyFields && !spec.aggregate) {
+      throw new MaterializedViewConfigError(
+        `withMaterializedView "${spec.name}": moneyFields requires aggregate — `
+        + `moneyFields rewrites sum/min/max reducers over money output fields, `
+        + `so it is meaningless without an aggregate spec`,
+      )
+    }
+    if (spec.predicates) {
+      throw new MaterializedViewConfigError(
+        `withMaterializedView "${spec.name}": predicates are not supported on projection strategies — `
+        + `projection mode does not use a Query<T> chain, so .wherePredicate() cannot fire. `
+        + `Filter inside projection.map (return null to omit) instead`,
       )
     }
   }


### PR DESCRIPTION
Closes #810. Milestone: Federated read-model: hub support [api].

## What

`withMaterializedView` gains a third, mutually-exclusive strategy form — **`projection`** — for join/projection MVs: one output row per primary-collection record, enriched with FK-resolved attachments from sibling collections in the same vault, shaped by a pure `map` function, auto-maintained when the primary **or any referenced source** changes.

```ts
withMaterializedView<BillRow>({
  name: 'billRows',
  projection: {
    source: 'bills',
    joins: [
      { field: 'clientId', as: 'client' },                    // forward FK (existing machinery)
      { collect: 'receipts', on: 'billId', as: 'receipts' },  // NEW: reverse one-to-many
      { collect: 'creditNotes', on: 'billId', as: 'creditNotes' },
    ],
    map: (r) => projectBillRow(r),   // null omits the row
  },
  rowKey: (r) => r.billId,
  refresh: 'eager',
})
```

- **Forward legs** reuse the UNION-arm `.join()` path (ref()-declared FK, `maxRows`/`strategy` pass-through).
- **Collect legs** (new): one hash-group pass over the sibling (O(N+M)), attached as an array; `on` must carry a `ref()` targeting the source (checked at first materialization); per-primary-row ceiling → `JoinTooLargeError`.
- **Dependencies fully automatic** — source + collect names at registration; forward `ref()` targets folded lazily on first dispatch (refs are declared after vault open; see spec's implementation note for the two documented residuals). Writes to any referenced collection trigger eager refresh / lazy stale-marking.
- Post-map `groupBy`/`aggregate` shares the UNION tail; the refresh/diff/tombstone writer is untouched; everything stays in the lazy-import MV chunk (no floor-bundle growth, no kernel-spine line-ceiling changes).

## Consumer

The niwat federated read-model (klum-db#44): per-shard bill/payment/dashboard projections become native auto-maintained MVs instead of app-side custom-refresh compute — the acceptance test mirrors the real 5-leg bill row.

## Spec

`docs/superpowers/specs/2026-07-25-join-projection-mv-design.md` (committed on this branch, incl. the accepted deviation).

## Verification

- `projection-mv.test.ts`: 20/20 (niwat 5-leg acceptance byte-exact, eager child-write freshness, lazy stale+resolve-on-read, null-omission/tombstone-on-flip, collect ceiling, missing-ref error, 7 config-validation cases, cycle refusal, queryHash stability)
- Full hub suite: 523 files / 4395 tests pass · typecheck (3 tsconfigs) · lint · `check:architecture` ✓ · hub build (incl. DTS) pass
- knip: pre-existing exit 1 on pristine branch, zero findings intersect this diff
- Changeset: `@noy-db/hub` minor (local, gitignored dir per repo convention)
