### PR TITLE
feat(hub): cover custom slot — namespaced integrator data + total-size caps (#800)

### DIFF
--- a/packages/hub/__tests__/cover-custom.test.ts
+++ b/packages/hub/__tests__/cover-custom.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Cover `custom` slot (#800) — namespaced integrator extension slot
+ * plus the total-size caps (`maxCustomBytes`, `maxCoverBytes`).
+ * Covers: namespace-level patch semantics, schema gating (opt-in,
+ * excluded from defaults), key-pattern + JSON-value validation, the
+ * locale-map-bomb regression for the whole-document cap, and the
+ * additive wire path (pod header round-trip, old-reader tolerance).
+ *
+ * @see https://github.com/vLannaAi/noy-db-docs/blob/main/content/docs/services/public-envelope.md
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope } from '../src/kernel/types.js'
+import { ValidationError } from '../src/kernel/errors.js'
+import {
+  resolveSchema,
+  validateCoverInput,
+  isCover,
+  mergeCustom,
+  validateCoverSize,
+  resolveLocale,
+  COVER_FIELDS,
+  DEFAULT_COVER_SCHEMA,
+  type Cover,
+  type JsonValue,
+} from '../src/with-party/directory/cover/index.js'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { writeNoydbBundle, readPodCover } from '../src/with-pod/bundle.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c, col, id) { return gc(c, col).get(id) },
+    async put(c, col, id, env) { gc(c, col).set(id, env) },
+    async delete(c, col, id) { gc(c, col).delete(id) },
+    async list(c, col) { return [...gc(c, col).keys()] },
+    async loadAll(c) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      const comp = store.get(c) ?? new Map()
+      for (const [col, recs] of comp) {
+        out[col] = Object.fromEntries(recs)
+      }
+      return out
+    },
+    async saveAll(c, data: Record<string, Record<string, EncryptedEnvelope>>) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [col, recs] of Object.entries(data)) {
+        comp.set(col, new Map(Object.entries(recs)))
+      }
+      store.set(c, comp)
+    },
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}
+
+const SECRET = 'correct horse battery staple printer toaster'
+
+/** Schema enabling the display fields AND the opt-in custom slot. */
+const CUSTOM_ENABLED = {
+  fields: ['name', 'description', 'icon', 'defaultLocale', 'custom'],
+} as const
+
+async function customDb(store: NoydbStore, coverOverrides: object = {}) {
+  return createNoydb({
+    store,
+    user: 'alice',
+    secret: SECRET,
+    cover: { ...CUSTOM_ENABLED, ...coverOverrides },
+  })
+}
+
+/** `n` nested object levels around a string leaf. */
+function nest(n: number): JsonValue {
+  return n === 0 ? 'leaf' : { child: nest(n - 1) }
+}
+
+describe('schema defaults — custom is opt-in', () => {
+  it("COVER_FIELDS contains 'custom' but DEFAULT_COVER_SCHEMA.fields does not", () => {
+    expect(COVER_FIELDS).toContain('custom')
+    expect(DEFAULT_COVER_SCHEMA.fields).not.toContain('custom')
+    expect(DEFAULT_COVER_SCHEMA.fields).toEqual([
+      'name', 'description', 'icon', 'createdAt', 'updatedAt', 'defaultLocale',
+    ])
+  })
+
+  it('resolveSchema(true) excludes custom and carries the default caps', () => {
+    const r = resolveSchema(true)!
+    expect(r.fields).not.toContain('custom')
+    expect(r.maxCustomBytes).toBe(8 * 1024)
+    expect(r.maxCoverBytes).toBe(300 * 1024)
+  })
+
+  it('cap overrides merge onto defaults', () => {
+    const r = resolveSchema({ maxCustomBytes: 64, maxCoverBytes: 1024 })!
+    expect(r.maxCustomBytes).toBe(64)
+    expect(r.maxCoverBytes).toBe(1024)
+    expect(r.maxIconBytes).toBe(256 * 1024)
+  })
+})
+
+describe('validateCoverInput — custom gating + key pattern + values', () => {
+  const enabled = resolveSchema(CUSTOM_ENABLED)!
+  const defaults = resolveSchema(true)!
+
+  it('rejects custom when the schema does not enable it (default field set)', () => {
+    expect(() =>
+      validateCoverInput({ custom: { 'noydb.viewer': { theme: 'dark' } } }, defaults),
+    ).toThrow(ValidationError)
+  })
+
+  it('accepts custom when the schema lists it explicitly', () => {
+    expect(() =>
+      validateCoverInput({ custom: { 'noydb.viewer': { theme: 'dark' } } }, enabled),
+    ).not.toThrow()
+  })
+
+  it('accepts dotted, reverse-DNS and dashed namespace keys', () => {
+    for (const key of ['noydb.viewer', 'com.acme.registry', 'acme-viewer']) {
+      expect(() =>
+        validateCoverInput({ custom: { [key]: { ok: true } } }, enabled),
+      ).not.toThrow()
+    }
+  })
+
+  it('rejects bare-word, empty and whitespace namespace keys', () => {
+    for (const key of ['config', '', 'has space', 'noydb.']) {
+      expect(() =>
+        validateCoverInput({ custom: { [key]: { ok: true } } }, enabled),
+      ).toThrow(ValidationError)
+    }
+  })
+
+  it('the key-pattern error names the offending key', () => {
+    expect(() =>
+      validateCoverInput({ custom: { config: 1 } }, enabled),
+    ).toThrow(/"config"/)
+  })
+
+  it('rejects a non-object custom value', () => {
+    expect(() =>
+      validateCoverInput({ custom: ['nope'] as never }, enabled),
+    ).toThrow(ValidationError)
+  })
+
+  it('accepts nesting at the depth cap (8), rejects depth 9', () => {
+    expect(() =>
+      validateCoverInput({ custom: { 'noydb.viewer': nest(8) } }, enabled),
+    ).not.toThrow()
+    expect(() =>
+      validateCoverInput({ custom: { 'noydb.viewer': nest(9) } }, enabled),
+    ).toThrow(/noydb\.viewer/)
+  })
+
+  it('rejects a circular reference', () => {
+    const a: Record<string, unknown> = { x: 1 }
+    a['self'] = a
+    expect(() =>
+      validateCoverInput({ custom: { 'noydb.viewer': a as never } }, enabled),
+    ).toThrow(/noydb\.viewer/)
+  })
+
+  it('rejects undefined inside an object', () => {
+    expect(() =>
+      validateCoverInput(
+        { custom: { 'noydb.viewer': { theme: undefined } as never } },
+        enabled,
+      ),
+    ).toThrow(ValidationError)
+  })
+
+  it('rejects bigint and function values', () => {
+    expect(() =>
+      validateCoverInput({ custom: { 'noydb.viewer': { n: 10n } as never } }, enabled),
+    ).toThrow(ValidationError)
+    expect(() =>
+      validateCoverInput({ custom: { 'noydb.viewer': (() => 1) as never } }, enabled),
+    ).toThrow(ValidationError)
+  })
+
+  it('accepts null as a namespace value (the delete directive)', () => {
+    expect(() =>
+      validateCoverInput({ custom: { 'noydb.viewer': null } }, enabled),
+    ).not.toThrow()
+  })
+})
+
+describe('mergeCustom — namespace-level patch', () => {
+  it('returns {} when neither side has custom', () => {
+    expect(mergeCustom(undefined, undefined)).toEqual({})
+  })
+
+  it('preserves existing custom when the patch is absent', () => {
+    expect(mergeCustom({ 'noydb.viewer': { theme: 'dark' } }, undefined))
+      .toEqual({ custom: { 'noydb.viewer': { theme: 'dark' } } })
+  })
+
+  it('replaces provided namespaces, preserves absent ones', () => {
+    const merged = mergeCustom(
+      { 'noydb.viewer': { theme: 'dark' }, 'com.acme.registry': { tenant: 'eu' } },
+      { 'noydb.viewer': { theme: 'light' } },
+    )
+    expect(merged).toEqual({
+      custom: {
+        'noydb.viewer': { theme: 'light' },
+        'com.acme.registry': { tenant: 'eu' },
+      },
+    })
+  })
+
+  it('null deletes a namespace and never persists', () => {
+    const merged = mergeCustom(
+      { 'noydb.viewer': { theme: 'dark' }, 'com.acme.registry': { tenant: 'eu' } },
+      { 'noydb.viewer': null },
+    )
+    expect(merged).toEqual({ custom: { 'com.acme.registry': { tenant: 'eu' } } })
+  })
+
+  it('deleting the last namespace drops the custom field entirely', () => {
+    expect(mergeCustom({ 'noydb.viewer': { theme: 'dark' } }, { 'noydb.viewer': null }))
+      .toEqual({})
+    expect(mergeCustom(undefined, { 'noydb.viewer': null })).toEqual({})
+  })
+})
+
+describe('validateCoverSize — post-merge caps', () => {
+  it('rejects an oversized custom object with actual vs cap in the message', () => {
+    const schema = resolveSchema({ ...CUSTOM_ENABLED, maxCustomBytes: 64 })!
+    const cover: Cover = {
+      _noydb_public: 1,
+      version: 1,
+      custom: { 'noydb.viewer': { padding: 'x'.repeat(64) } },
+    }
+    const size = JSON.stringify(cover.custom).length
+    expect(() => validateCoverSize(cover, schema))
+      .toThrow(new RegExp(`64-byte.*${size}`))
+  })
+
+  it('rejects a cover document over maxCoverBytes with actual vs cap in the message', () => {
+    const schema = resolveSchema({ maxCoverBytes: 128 })!
+    const cover: Cover = {
+      _noydb_public: 1,
+      version: 1,
+      name: 'n'.repeat(150),
+    }
+    const size = JSON.stringify(cover).length
+    expect(() => validateCoverSize(cover, schema))
+      .toThrow(new RegExp(`128-byte.*${size}`))
+  })
+
+  it('accepts a document within both caps', () => {
+    const schema = resolveSchema(CUSTOM_ENABLED)!
+    const cover: Cover = {
+      _noydb_public: 1,
+      version: 1,
+      name: 'Acme',
+      custom: { 'noydb.viewer': { theme: 'dark' } },
+    }
+    expect(() => validateCoverSize(cover, schema)).not.toThrow()
+  })
+})
+
+describe('Noydb integration — custom patch semantics', () => {
+  it('replace-provided / preserve-absent across writes', async () => {
+    const db = await customDb(inlineMemory())
+    await db.openVault('acme')
+    await db.setCover('acme', {
+      name: 'Acme 2026',
+      custom: {
+        'noydb.viewer': { theme: 'dark' },
+        'com.acme.registry': { tenant: 'eu-west' },
+      },
+    })
+    const second = await db.setCover('acme', {
+      custom: { 'noydb.viewer': { theme: 'light', defaultCollection: 'invoices' } },
+    })
+    expect(second.custom).toEqual({
+      'noydb.viewer': { theme: 'light', defaultCollection: 'invoices' },
+      'com.acme.registry': { tenant: 'eu-west' },
+    })
+    expect(second.name).toBe('Acme 2026') // display fields also preserved
+  })
+
+  it('null deletes a namespace; deleting the last one drops custom', async () => {
+    const db = await customDb(inlineMemory())
+    await db.openVault('acme')
+    await db.setCover('acme', {
+      custom: {
+        'noydb.viewer': { theme: 'dark' },
+        'com.acme.registry': { tenant: 'eu-west' },
+      },
+    })
+    const afterDelete = await db.setCover('acme', {
+      custom: { 'com.acme.registry': null },
+    })
+    expect(afterDelete.custom).toEqual({ 'noydb.viewer': { theme: 'dark' } })
+    expect(afterDelete.custom).not.toHaveProperty('com.acme.registry')
+
+    const empty = await db.setCover('acme', { custom: { 'noydb.viewer': null } })
+    expect(empty.custom).toBeUndefined()
+  })
+
+  it('null on a fresh cover never persists as a namespace value', async () => {
+    const db = await customDb(inlineMemory())
+    await db.openVault('acme')
+    const written = await db.setCover('acme', {
+      name: 'Acme',
+      custom: { 'noydb.viewer': null },
+    })
+    expect(written.custom).toBeUndefined()
+    const read = await db.getCover('acme')
+    expect(read?.custom).toBeUndefined()
+  })
+
+  it('a write without custom preserves the previous custom', async () => {
+    const db = await customDb(inlineMemory())
+    await db.openVault('acme')
+    await db.setCover('acme', { custom: { 'noydb.viewer': { theme: 'dark' } } })
+    const second = await db.setCover('acme', { name: 'Acme v2' })
+    expect(second.custom).toEqual({ 'noydb.viewer': { theme: 'dark' } })
+  })
+
+  it('version bumps, createdAt is preserved, updatedAt refreshes on custom-only writes', async () => {
+    const db = await customDb(inlineMemory())
+    await db.openVault('acme')
+    const first = await db.setCover('acme', { custom: { 'noydb.viewer': { v: 1 } } })
+    await new Promise((r) => setTimeout(r, 5))
+    const second = await db.setCover('acme', { custom: { 'noydb.viewer': { v: 2 } } })
+    expect(second.version).toBe(first.version + 1)
+    expect(second.createdAt).toBe(first.createdAt)
+    expect(Date.parse(second.updatedAt!)).toBeGreaterThanOrEqual(Date.parse(first.updatedAt!))
+  })
+
+  it('cover: true shorthand rejects custom (opt-in only)', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: SECRET, cover: true })
+    await db.openVault('acme')
+    await expect(
+      db.setCover('acme', { custom: { 'noydb.viewer': { theme: 'dark' } } }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+})
+
+describe('Noydb integration — size caps', () => {
+  it('rejects an oversized custom write (maxCustomBytes)', async () => {
+    const db = await customDb(inlineMemory(), { maxCustomBytes: 64 })
+    await db.openVault('acme')
+    await expect(
+      db.setCover('acme', { custom: { 'noydb.viewer': { pad: 'x'.repeat(100) } } }),
+    ).rejects.toThrow(/64-byte/)
+  })
+
+  it('a small patch that tips the MERGED custom over the cap is rejected', async () => {
+    const db = await customDb(inlineMemory(), { maxCustomBytes: 100 })
+    await db.openVault('acme')
+    await db.setCover('acme', { custom: { 'noydb.viewer': { pad: 'x'.repeat(40) } } })
+    // Alone this namespace fits; merged with the existing one it doesn't.
+    await expect(
+      db.setCover('acme', { custom: { 'com.acme.registry': { pad: 'y'.repeat(40) } } }),
+    ).rejects.toThrow(/100-byte/)
+    // Replacing the existing namespace with a smaller value still works.
+    const ok = await db.setCover('acme', { custom: { 'noydb.viewer': { pad: 'z' } } })
+    expect(ok.custom).toEqual({ 'noydb.viewer': { pad: 'z' } })
+  })
+
+  it('locale-map bomb regression — a name map with thousands of keys is rejected by maxCoverBytes', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: SECRET, cover: true })
+    await db.openVault('acme')
+    // 2 000 locale keys × 200-char values: every VALUE is within
+    // maxStringChars, but the serialized document is ~430 KB — over
+    // the 300 KB whole-document default cap.
+    const bomb = Object.fromEntries(
+      Array.from({ length: 2000 }, (_, i) => [
+        `x-${String(i).padStart(4, '0')}`,
+        'a'.repeat(200),
+      ]),
+    )
+    await expect(db.setCover('acme', { name: bomb })).rejects.toThrow(/307200-byte/)
+  })
+})
+
+describe('wire — additive, no format bump', () => {
+  it('a cover with custom round-trips through the pod header (writePod → readPodCover)', async () => {
+    const store = inlineMemory()
+    const db = await customDb(store)
+    const vault = await db.openVault('acme')
+    await db.setCover('acme', {
+      name: { en: 'Acme 2026', th: 'อะคมี 2026' },
+      defaultLocale: 'en',
+      custom: { 'noydb.viewer': { defaultCollection: 'invoices', theme: 'dark' } },
+    })
+    const bundleBytes = await writeNoydbBundle(vault)
+    const env = readPodCover(bundleBytes)
+    expect(env?.custom).toEqual({
+      'noydb.viewer': { defaultCollection: 'invoices', theme: 'dark' },
+    })
+    // Locale resolution keeps custom intact.
+    const th = readPodCover(bundleBytes, { locale: 'th' })
+    expect(th?.name).toBe('อะคมี 2026')
+    expect(th?.custom).toEqual({
+      'noydb.viewer': { defaultCollection: 'invoices', theme: 'dark' },
+    })
+  }, 60_000)
+
+  it('old-reader path — isCover still recognises a document carrying custom', async () => {
+    const store = inlineMemory()
+    const db = await customDb(store)
+    await db.openVault('acme')
+    await db.setCover('acme', { custom: { 'noydb.viewer': { theme: 'dark' } } })
+    const envelope = await store.get('acme', '_meta', 'public-envelope')
+    const parsed = JSON.parse(envelope!._data) as unknown
+    expect(isCover(parsed)).toBe(true)
+    expect((parsed as Cover).custom).toEqual({ 'noydb.viewer': { theme: 'dark' } })
+  })
+
+  it('resolveLocale passes custom through untouched', () => {
+    const cover: Cover = {
+      _noydb_public: 1,
+      version: 1,
+      name: { en: 'Acme', th: 'อะคมี' },
+      defaultLocale: 'en',
+      custom: { 'noydb.viewer': { theme: 'dark' } },
+    }
+    const resolved = resolveLocale(cover, 'th')
+    expect(resolved.name).toBe('อะคมี')
+    expect(resolved.custom).toEqual({ 'noydb.viewer': { theme: 'dark' } })
+  })
+
+  it('getCover with a locale keeps custom', async () => {
+    const db = await customDb(inlineMemory())
+    await db.openVault('acme')
+    await db.setCover('acme', {
+      name: { en: 'Acme', th: 'อะคมี' },
+      defaultLocale: 'en',
+      custom: { 'noydb.viewer': { theme: 'dark' } },
+    })
+    const th = await db.getCover('acme', { locale: 'th' })
+    expect(th?.name).toBe('อะคมี')
+    expect(th?.custom).toEqual({ 'noydb.viewer': { theme: 'dark' } })
+  })
+})

--- a/packages/hub/__tests__/cover.test.ts
+++ b/packages/hub/__tests__/cover.test.ts
@@ -50,10 +50,14 @@ describe('resolveSchema', () => {
 
   it('returns full defaults for shorthand `true`', () => {
     const r = resolveSchema(true)!
-    expect(r.fields).toEqual(COVER_FIELDS)
+    // #800: the default field set is the six display fields — the
+    // opt-in 'custom' slot is in COVER_FIELDS but NOT the defaults.
+    expect(r.fields).toEqual(COVER_FIELDS.filter((f) => f !== 'custom'))
     expect(r.maxIconBytes).toBe(256 * 1024)
     expect(r.iconMimeTypes).toEqual(['image/png', 'image/svg+xml'])
     expect(r.maxStringChars).toBe(200)
+    expect(r.maxCustomBytes).toBe(8 * 1024)
+    expect(r.maxCoverBytes).toBe(300 * 1024)
   })
 
   it('merges partial overrides onto defaults', () => {

--- a/packages/hub/__tests__/root-barrel-surface.golden.json
+++ b/packages/hub/__tests__/root-barrel-surface.golden.json
@@ -651,6 +651,7 @@
     "JoinableSource",
     "JsonPatch",
     "JsonPatchOp",
+    "JsonValue",
     "KeyringAuthenticator",
     "KeyringAuthenticatorWrappingDEKs",
     "KeyringAuthenticatorWrappingKEK",

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -571,6 +571,7 @@ export type {
   CoverText,
   CoverSchema,
   CoverField,
+  JsonValue,
   ResolvedCoverSchema,
   SetCoverInput,
 } from './with-party/directory/cover/index.js'

--- a/packages/hub/src/kernel/noydb.ts
+++ b/packages/hub/src/kernel/noydb.ts
@@ -2009,6 +2009,10 @@ export class Noydb {
    * `createdAt` is set on the first write and preserved on every
    * subsequent write. `updatedAt` is refreshed on every write.
    * `version` is monotonic — increments on every successful write.
+   *
+   * `custom` (opt-in via `fields: [..., 'custom']`) patches at the
+   * namespace level — provided namespaces replace their previous
+   * value, absent ones are preserved, `null` deletes (#800).
    */
   async setCover(
     vault: string,
@@ -2022,7 +2026,7 @@ export class Noydb {
           'Pass `cover: true` (or a schema object) to `createNoydb`.',
       )
     }
-    const { loadCover, saveCover, resolveSchema, validateCoverInput } =
+    const { loadCover, saveCover, resolveSchema, validateCoverInput, mergeCustom, validateCoverSize } =
       await import('../with-party/directory/cover/index.js')
     const schema = resolveSchema(coverOption)!
     validateCoverInput(input, schema)
@@ -2038,7 +2042,11 @@ export class Noydb {
       ...(input.description !== undefined ? { description: input.description } : (existing?.description !== undefined ? { description: existing.description } : {})),
       ...(input.icon !== undefined ? { icon: input.icon } : (existing?.icon !== undefined ? { icon: existing.icon } : {})),
       ...(input.defaultLocale !== undefined ? { defaultLocale: input.defaultLocale } : (existing?.defaultLocale !== undefined ? { defaultLocale: existing.defaultLocale } : {})),
+      // #800: namespace-level patch — provided namespaces replace, absent are preserved, `null` deletes.
+      ...mergeCustom(existing?.custom, input.custom),
     }
+    // #800: size caps run against the WOULD-BE-PERSISTED (post-merge) document.
+    validateCoverSize(next, schema)
     await saveCover(this.options.store, vault, next)
     return next
   }

--- a/packages/hub/src/with-party/directory/cover/custom.ts
+++ b/packages/hub/src/with-party/directory/cover/custom.ts
@@ -1,0 +1,149 @@
+/**
+ * The cover's namespaced `custom` extension slot (#800) — input
+ * validation, the namespace-level patch merge, and the post-merge
+ * size caps.
+ *
+ * Like everything on the cover, `custom` is plaintext, public by
+ * design, and unauthenticated — payloads are hints (display defaults,
+ * routing suggestions, registry pointers), never an input to
+ * security, authorization, or data-integrity decisions.
+ *
+ * @see https://github.com/vLannaAi/noy-db-docs/blob/main/content/docs/services/public-envelope.md
+ *
+ * @module
+ */
+import { ValidationError } from '../../../kernel/errors.js'
+import type { Cover, JsonValue, ResolvedCoverSchema } from './types.js'
+
+/**
+ * Namespace keys must be reverse-DNS or package-style identifiers —
+ * at least one dot/dash-separated segment (`noydb.viewer`,
+ * `com.acme.registry` pass; a bare `config` fails), so two frameworks
+ * can't collide on a bare word.
+ */
+const CUSTOM_KEY_PATTERN = /^[a-z0-9]+([.-][a-z0-9]+)+$/i
+
+/** Maximum nesting depth of a namespace payload (containers, not leaves). */
+const MAX_CUSTOM_DEPTH = 8
+
+/**
+ * Validate the owner-supplied `custom` input: the field must be a
+ * plain object, every key must match {@link CUSTOM_KEY_PATTERN}, and
+ * every value must be JSON-serializable (no functions, `undefined`,
+ * symbols, bigints, or cycles) within the depth cap. `null` is
+ * accepted — it is the delete-this-namespace directive and never
+ * persists. Throws `ValidationError` on the first violation.
+ */
+export function validateCustomInput(custom: Record<string, JsonValue>): void {
+  if (custom === null || typeof custom !== 'object' || Array.isArray(custom)) {
+    throw new ValidationError(
+      `setCover: custom must be a { [namespace]: value } object, got ${
+        Array.isArray(custom) ? 'array' : typeof custom
+      }.`,
+    )
+  }
+  for (const [ns, value] of Object.entries(custom)) {
+    if (!CUSTOM_KEY_PATTERN.test(ns)) {
+      throw new ValidationError(
+        `setCover: custom namespace "${ns}" is invalid. Keys must be ` +
+          'reverse-DNS or package-style identifiers with at least one ' +
+          'dot/dash-separated segment (e.g. "noydb.viewer", "com.acme.registry").',
+      )
+    }
+    assertJsonValue(value, ns, 1, new Set())
+  }
+}
+
+function assertJsonValue(
+  value: unknown,
+  ns: string,
+  depth: number,
+  seen: Set<object>,
+): void {
+  if (value === null) return
+  const t = typeof value
+  if (t === 'string' || t === 'number' || t === 'boolean') return
+  if (t !== 'object') {
+    throw new ValidationError(
+      `setCover: custom["${ns}"] contains a non-JSON value (${t}). ` +
+        'Only strings, numbers, booleans, null, arrays, and plain objects are allowed.',
+    )
+  }
+  const container = value as object
+  if (seen.has(container)) {
+    throw new ValidationError(
+      `setCover: custom["${ns}"] contains a circular reference.`,
+    )
+  }
+  if (depth > MAX_CUSTOM_DEPTH) {
+    throw new ValidationError(
+      `setCover: custom["${ns}"] nests deeper than the ${MAX_CUSTOM_DEPTH}-level cap.`,
+    )
+  }
+  seen.add(container)
+  const children = Array.isArray(container) ? container : Object.values(container)
+  for (const child of children) {
+    assertJsonValue(child, ns, depth + 1, seen)
+  }
+  seen.delete(container)
+}
+
+/**
+ * Namespace-level patch merge for `setCover`: provided namespaces
+ * replace their previous value, absent namespaces are preserved, and
+ * an explicit `null` deletes that namespace (so `null` never persists
+ * as a namespace value). A whole-`custom`-absent patch preserves the
+ * previous custom, consistent with the other cover fields. Rationale:
+ * framework A must never need read-modify-write of framework B's data.
+ *
+ * Returns a spreadable fragment — `{ custom }` when the merge leaves
+ * at least one namespace, `{}` when it leaves none (the field is
+ * dropped from the persisted document rather than stored empty).
+ */
+export function mergeCustom(
+  existing: Record<string, JsonValue> | undefined,
+  patch: Record<string, JsonValue> | undefined,
+): { custom: Record<string, JsonValue> } | Record<string, never> {
+  if (patch === undefined) {
+    return existing !== undefined ? { custom: existing } : {}
+  }
+  const merged: Record<string, JsonValue> = { ...existing }
+  for (const [ns, value] of Object.entries(patch)) {
+    if (value === null) {
+      delete merged[ns]
+    } else {
+      merged[ns] = value
+    }
+  }
+  return Object.keys(merged).length > 0 ? { custom: merged } : {}
+}
+
+/**
+ * Post-merge size caps — validates the WOULD-BE-PERSISTED document
+ * (after the namespace merge), so a small patch can't tip the stored
+ * cover over a cap unnoticed. `maxCoverBytes` bounds the entire
+ * serialized document, which also closes the unbounded locale-map
+ * key-count hole for `name` / `description`. Sizes are measured as
+ * `JSON.stringify` length. Throws `ValidationError` on violation.
+ */
+export function validateCoverSize(
+  cover: Cover,
+  schema: ResolvedCoverSchema,
+): void {
+  if (cover.custom !== undefined) {
+    const customSize = JSON.stringify(cover.custom).length
+    if (customSize > schema.maxCustomBytes) {
+      throw new ValidationError(
+        `setCover: custom exceeds the ${schema.maxCustomBytes}-byte cap ` +
+          `(got ${customSize} bytes serialized, after merging with the stored namespaces).`,
+      )
+    }
+  }
+  const totalSize = JSON.stringify(cover).length
+  if (totalSize > schema.maxCoverBytes) {
+    throw new ValidationError(
+      `setCover: the cover document exceeds the ${schema.maxCoverBytes}-byte cap ` +
+        `(got ${totalSize} bytes serialized).`,
+    )
+  }
+}

--- a/packages/hub/src/with-party/directory/cover/index.ts
+++ b/packages/hub/src/with-party/directory/cover/index.ts
@@ -11,6 +11,7 @@ export type {
   CoverText,
   CoverSchema,
   CoverField,
+  JsonValue,
   ResolvedCoverSchema,
 } from './types.js'
 export {
@@ -21,6 +22,8 @@ export {
 
 export type { SetCoverInput } from './schema.js'
 export { validateCoverInput, isCover } from './schema.js'
+
+export { mergeCustom, validateCoverSize } from './custom.js'
 
 export {
   loadCover,

--- a/packages/hub/src/with-party/directory/cover/schema.ts
+++ b/packages/hub/src/with-party/directory/cover/schema.ts
@@ -6,9 +6,11 @@
  * @module
  */
 import { ValidationError } from '../../../kernel/errors.js'
+import { validateCustomInput } from './custom.js'
 import type {
   Cover,
   CoverText,
+  JsonValue,
   ResolvedCoverSchema,
   CoverField,
 } from './types.js'
@@ -19,6 +21,14 @@ export interface SetCoverInput {
   readonly description?: CoverText
   readonly icon?: string
   readonly defaultLocale?: string
+  /**
+   * Namespace-level patch for the cover's `custom` slot (#800):
+   * provided namespaces replace their previous value, absent
+   * namespaces are preserved, an explicit `null` deletes that
+   * namespace. Requires `'custom'` in the schema's `fields` list —
+   * the `cover: true` shorthand does NOT enable it.
+   */
+  readonly custom?: Record<string, JsonValue>
 }
 
 const DATA_URL_PREFIX = /^data:([a-zA-Z0-9.+-]+\/[a-zA-Z0-9.+-]+);base64,/
@@ -42,7 +52,7 @@ export function validateCoverInput(
   // Reject any key not in the schema's allowed-field list.
   for (const key of Object.keys(input)) {
     const known: CoverField | undefined =
-      key === 'name' || key === 'description' || key === 'icon' || key === 'defaultLocale'
+      key === 'name' || key === 'description' || key === 'icon' || key === 'defaultLocale' || key === 'custom'
         ? key
         : undefined
     if (!known) {
@@ -72,6 +82,9 @@ export function validateCoverInput(
     throw new ValidationError(
       `setCover: defaultLocale must be a string (BCP-47), got ${typeof input.defaultLocale}.`,
     )
+  }
+  if (input.custom !== undefined) {
+    validateCustomInput(input.custom)
   }
 }
 

--- a/packages/hub/src/with-party/directory/cover/types.ts
+++ b/packages/hub/src/with-party/directory/cover/types.ts
@@ -22,6 +22,19 @@
 export type CoverText = string | Record<string, string>
 
 /**
+ * A JSON-serializable value — what a `custom` namespace payload may
+ * hold. No functions, `undefined`, symbols, bigints, or cycles; the
+ * validator additionally caps nesting depth at 8 levels.
+ */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue }
+
+/**
  * Persisted shape — both `_meta/public-envelope` (the frozen wire
  * name) and the bundle header carry this. The version number is
  * monotonic per vault and helps cache invalidators detect change
@@ -40,6 +53,16 @@ export interface Cover {
   readonly updatedAt?: string
   /** BCP-47 fallback locale for renderers when the user's locale isn't covered. */
   readonly defaultLocale?: string
+  /**
+   * Namespaced integrator slot (#800) — e.g.
+   * `{ 'noydb.viewer': { defaultCollection: 'invoices' } }`. Keys must
+   * be reverse-DNS / package-style (`noydb.viewer`, `com.acme.registry`).
+   * Like everything on the cover it is plaintext, public, and
+   * unauthenticated — payloads are hints, never authority. Opt-in:
+   * excluded from `DEFAULT_COVER_SCHEMA.fields`, so `cover: true`
+   * does NOT enable it.
+   */
+  readonly custom?: Record<string, JsonValue>
 }
 
 /** Field names the developer can allow in `CoverSchema.fields`. */
@@ -50,6 +73,7 @@ export const COVER_FIELDS = [
   'createdAt',
   'updatedAt',
   'defaultLocale',
+  'custom',
 ] as const
 
 export type CoverField = (typeof COVER_FIELDS)[number]
@@ -76,14 +100,35 @@ export interface CoverSchema {
   readonly iconMimeTypes?: ReadonlyArray<string>
   /** Maximum length of `name` / `description` per locale. Default 200. */
   readonly maxStringChars?: number
+  /**
+   * Maximum serialized size (`JSON.stringify` length) of the whole
+   * would-be-persisted `custom` object, measured AFTER the namespace
+   * patch merge. Default 8 KB.
+   */
+  readonly maxCustomBytes?: number
+  /**
+   * Maximum serialized size of the ENTIRE would-be-persisted cover
+   * document. The consumer-protection cap — bounds what a pre-auth
+   * reader must fetch and parse, and closes the unbounded locale-map
+   * key-count hole for `name` / `description`. Default 300 KB
+   * (headroom over the 256 KB icon cap + text fields).
+   */
+  readonly maxCoverBytes?: number
 }
 
-/** Default schema values; merged onto every developer-supplied schema. */
+/**
+ * Default schema values; merged onto every developer-supplied schema.
+ * NOTE: `fields` is the six display fields, deliberately NOT
+ * {@link COVER_FIELDS} — the opt-in `'custom'` slot is excluded, so
+ * the `cover: true` shorthand never exposes it by accident.
+ */
 export const DEFAULT_COVER_SCHEMA = {
-  fields: COVER_FIELDS,
+  fields: ['name', 'description', 'icon', 'createdAt', 'updatedAt', 'defaultLocale'],
   maxIconBytes: 256 * 1024,
   iconMimeTypes: ['image/png', 'image/svg+xml'] as const,
   maxStringChars: 200,
+  maxCustomBytes: 8 * 1024,
+  maxCoverBytes: 300 * 1024,
 } as const satisfies Required<CoverSchema>
 
 /** Resolved schema after merging developer override onto defaults. */
@@ -92,6 +137,8 @@ export interface ResolvedCoverSchema {
   readonly maxIconBytes: number
   readonly iconMimeTypes: ReadonlyArray<string>
   readonly maxStringChars: number
+  readonly maxCustomBytes: number
+  readonly maxCoverBytes: number
 }
 
 /**
@@ -109,6 +156,8 @@ export function resolveSchema(
       maxIconBytes: DEFAULT_COVER_SCHEMA.maxIconBytes,
       iconMimeTypes: DEFAULT_COVER_SCHEMA.iconMimeTypes,
       maxStringChars: DEFAULT_COVER_SCHEMA.maxStringChars,
+      maxCustomBytes: DEFAULT_COVER_SCHEMA.maxCustomBytes,
+      maxCoverBytes: DEFAULT_COVER_SCHEMA.maxCoverBytes,
     }
   }
   return {
@@ -116,6 +165,8 @@ export function resolveSchema(
     maxIconBytes: schema.maxIconBytes ?? DEFAULT_COVER_SCHEMA.maxIconBytes,
     iconMimeTypes: schema.iconMimeTypes ?? DEFAULT_COVER_SCHEMA.iconMimeTypes,
     maxStringChars: schema.maxStringChars ?? DEFAULT_COVER_SCHEMA.maxStringChars,
+    maxCustomBytes: schema.maxCustomBytes ?? DEFAULT_COVER_SCHEMA.maxCustomBytes,
+    maxCoverBytes: schema.maxCoverBytes ?? DEFAULT_COVER_SCHEMA.maxCoverBytes,
   }
 }
 

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -1151,7 +1151,12 @@ const KERNEL_SURFACE_BUDGET = {
   // setCover/getCover are the canonical methods; the old setPublicEnvelope/
   // getPublicEnvelope remain as @deprecated one-line delegators for one
   // pre-release window, then this ceiling ratchets back down with them.
-  'packages/hub/src/kernel/noydb.ts': 2411,
+  // Bumped 2411→2419 (#800 cover custom slot + size caps): thin call-sites only —
+  // one `...mergeCustom(existing?.custom, input.custom)` spread in the setCover
+  // field-by-field rebuild plus a post-merge `validateCoverSize(next, schema)`
+  // call (+ JSDoc). The merge/validation logic itself lives in
+  // with-party/directory/cover/custom.ts.
+  'packages/hub/src/kernel/noydb.ts': 2419,
 }
 
 function checkKernelSurface() {


### PR DESCRIPTION
Closes #800. Milestone: Cover: rename + integrator slot [api]. Stacked on #815 (cover rename, merged).

## What

The cover gains its sanctioned integrator extension slot and the consumer-protection caps:

- **`custom?: Record<string, JsonValue>`** — namespaced keys (`/^[a-z0-9]+([.-][a-z0-9]+)+$/i`: `noydb.viewer`, `com.acme.registry`; bare words rejected), JSON-serializable values only, container depth cap 8.
- **Opt-in, never default**: `'custom'` is a valid `CoverField` but excluded from `DEFAULT_COVER_SCHEMA.fields` — `cover: true` does not enable it; the developer must list it explicitly.
- **Namespace-level patch merge** in `setCover` (the issue's ⚠️ decision, resolved as specced): provided namespaces replace, absent are preserved, `null` deletes — framework A never read-modify-writes framework B's data.
- **Caps, validated post-merge on the would-be-persisted document**: `maxCustomBytes` (default 8 KB) and `maxCoverBytes` (default 300 KB). The whole-document cap closes the pre-existing unbounded locale-map key-count hole (`validateText` capped per-value length but not key count) — regression-tested with a 2000-key locale bomb.
- **Wire purely additive**: `isCover` + pod-header validator already tolerate unknown keys; pod round-trip (`writePod` → `readPodCover`) and old-reader tolerance covered; `resolveLocale` passes `custom` through.

Contract (docs follow-up in noy-db-docs#122): the cover — `custom` included — is plaintext, public by design, unauthenticated; payloads are hints, never authority.

## Verification

- 35 new tests (`cover-custom.test.ts`): patch semantics, schema gating, key pattern, value validation, both caps incl. merge-tips-over-cap, locale-map-bomb regression, pod round-trip, metadata behavior unchanged
- Full hub suite **525 files / 4436 tests pass** · typecheck · lint · build · `check:architecture` ✓ · goldens: only root barrel consciously updated (+`JsonValue`)
- Ceiling bump: `noydb.ts` 2411→2419 (call-sites only; merge/validation logic lives in `cover/custom.ts`)
- Changeset: `@noy-db/hub` minor (local, gitignored dir)
