### PR TITLE
feat(hub): StoreCredentials 'password' variant for connection-auth stores (#795)

### DIFF
--- a/docs/subsystems/broker.md
+++ b/docs/subsystems/broker.md
@@ -9,8 +9,8 @@
 ## What it does
 
 The credential broker lets a client **passphrase-bound to a vault** obtain short-lived,
-rolling cloud-storage credentials (AWS access keys today; a vendor-neutral token shape is
-reserved for a later slice) **without ever putting a long-lived secret in the client**. A
+rolling cloud-storage credentials (AWS access keys today; vendor-neutral token and
+password/connection-auth shapes are reserved for later slices) **without ever putting a long-lived secret in the client**. A
 32-byte seed is generated once, encrypted under the vault's own `_broker` collection DEK, and
 never leaves the device. A **derived proof key** — never the seed itself — is registered with
 a broker host at enrolment; from then on the client re-derives the same key, signs a
@@ -111,7 +111,20 @@ export type StoreCredentials =
   | { readonly kind: 'aws'; readonly accessKeyId: string; readonly secretAccessKey: string
       readonly sessionToken?: string; readonly expiresAt?: string }
   | { readonly kind: 'token'; readonly token: string; readonly expiresAt?: string } // a later slice
+  | { readonly kind: 'password'; readonly username: string; readonly password: string
+      readonly domain?: string; readonly expiresAt?: string } // connection auth (#795)
 ```
+
+Which store families consume which `kind`:
+
+| `kind` | Consuming stores | Notes |
+|---|---|---|
+| `'aws'` | `to-aws-s3`, `to-aws-dynamo`, `as-aws-s3` | Feeds the AWS SDK's identity provider (access key + secret + optional session token). |
+| `'token'` | `to-turso`, `to-cloudflare-d1`, `to-webdav`, `to-supabase`, `to-drive` (bearer/API-token stores) | Reserved shape; adoption tracked in noy-db-to. |
+| `'password'` | `to-postgres`, `to-mysql` (connection `user`+`password` — omit `domain`); `to-smb` (NTLM `username`/`password`/`domain`) | `expiresAt` applies when the "password" is a short-lived cloud IAM auth token. |
+
+Key-shaped auth (`kind: 'key'`) is deliberately **not** in the union — `to-ssh` is keys-only
+by design and may refuse brokered keys entirely; it stays a separate decision.
 
 ## Opt-in
 
@@ -281,8 +294,10 @@ export async function handleCredentials(req: { vaultId: string; brokerId: string
 - **`profile` and `endpointOrigin` are bound into the MAC.** A proof captured at one `profile`
   (e.g. `'read'`) cannot be replayed at another (`'admin'`); a proof cannot be relayed to a
   different broker endpoint reusing the same `brokerId`.
-- **`kind:'token'` stores** (postgres/turso/supabase/webdav) are not wired yet — the
-  `StoreCredentials` type reserves the shape, but no store owns its refresh loop for it today.
+- **`kind:'token'` stores** (turso/supabase/webdav/cloudflare-d1/drive) and **`kind:'password'`
+  stores** (postgres/mysql user+password, smb NTLM) are not wired yet — the `StoreCredentials`
+  type reserves the shapes, but no store owns its refresh loop for them today (adoption is
+  tracked in noy-db-to).
 - **Sealed-to-instance delivery** (encrypting the credential response to a specific device's
   keypair) is deferred to a future slice — see Non-goals.
 

--- a/packages/hub/__tests__/broker/seed.test.ts
+++ b/packages/hub/__tests__/broker/seed.test.ts
@@ -53,6 +53,20 @@ describe('broker seed lifecycle', () => {
     expect(creds).toMatchObject({ kind: 'aws' })
   })
 
+  it("#795: a host minting kind:'password' connection-auth creds passes through verbatim (username/password/domain/expiresAt)", async () => {
+    const store = memoryStore()
+    const owner = await createOwnerKeyring(store, VAULT, 'owner', 'owner-pw')
+    const expiresAt = new Date(Date.now() + 3600_000).toISOString()
+    const host = makeTestHost({
+      credentials: () => ({ kind: 'password', username: 'svc-noydb', password: 'pw-rolled', domain: 'CORP', expiresAt }),
+    })
+    const cfg = config(host)
+
+    await enrollSeed(ctx(store, owner, cfg))
+    const creds = await mintStoreCredentials(ctx(store, owner, cfg), 'read')
+    expect(creds).toEqual({ kind: 'password', username: 'svc-noydb', password: 'pw-rolled', domain: 'CORP', expiresAt })
+  })
+
   it('V23: a partial enrol (host 401s /enroll) leaves registered !== true; credentialSource fails fast with BrokerEnrolmentError, not an opaque proof error', async () => {
     const store = memoryStore()
     const owner = await createOwnerKeyring(store, VAULT, 'owner', 'owner-pw')

--- a/packages/hub/__tests__/store-credentials.test-d.ts
+++ b/packages/hub/__tests__/store-credentials.test-d.ts
@@ -1,0 +1,67 @@
+/**
+ * Type-level tests for the `StoreCredentials` union on the `@noy-db/hub/to`
+ * seam (#479 landed `'aws' | 'token'`; #795 added the additive `'password'`
+ * connection-auth variant for to-postgres/to-mysql user+password and to-smb
+ * NTLM via `domain`). Validated by `pnpm --filter @noy-db/hub typecheck`
+ * (`tsconfig.typetest.json`) — vitest never runs this file.
+ *
+ * Key-shaped auth (`kind: 'key'`) is deliberately absent — to-ssh is
+ * keys-only by design and may refuse brokered keys entirely (#795 defers it).
+ */
+import { describe, it, expectTypeOf } from 'vitest'
+import type { StoreCredentials, StoreCredentialSource } from '../src/port/to/index.js'
+
+describe("StoreCredentials — the #795 kind:'password' variant", () => {
+  it('accepts the full NTLM shape (username/password/domain/expiresAt)', () => {
+    expectTypeOf<{
+      kind: 'password'
+      username: string
+      password: string
+      domain: string
+      expiresAt: string
+    }>().toMatchTypeOf<StoreCredentials>()
+  })
+
+  it('`domain` and `expiresAt` are optional — the bare postgres/mysql shape is assignable', () => {
+    expectTypeOf<{
+      kind: 'password'
+      username: string
+      password: string
+    }>().toMatchTypeOf<StoreCredentials>()
+  })
+
+  it('narrowing on the discriminant exposes username/password', () => {
+    const narrow = (creds: StoreCredentials): string => {
+      if (creds.kind === 'password') {
+        expectTypeOf(creds.username).toEqualTypeOf<string>()
+        expectTypeOf(creds.password).toEqualTypeOf<string>()
+        expectTypeOf(creds.domain).toEqualTypeOf<string | undefined>()
+        return creds.username
+      }
+      return creds.kind
+    }
+    expectTypeOf(narrow).returns.toEqualTypeOf<string>()
+  })
+
+  it('the union is exactly aws | token | password (exhaustiveness)', () => {
+    expectTypeOf<StoreCredentials['kind']>().toEqualTypeOf<'aws' | 'token' | 'password'>()
+    // A switch on `kind` covering all three arms leaves `never` — a fourth
+    // variant added later must consciously extend this check.
+    const exhaust = (creds: StoreCredentials): string => {
+      switch (creds.kind) {
+        case 'aws': return creds.accessKeyId
+        case 'token': return creds.token
+        case 'password': return creds.username
+        default: return creds satisfies never
+      }
+    }
+    expectTypeOf(exhaust).returns.toEqualTypeOf<string>()
+  })
+
+  it('a password-minting source satisfies StoreCredentialSource', () => {
+    const source = async (): Promise<StoreCredentials> => ({
+      kind: 'password', username: 'svc', password: 'pw',
+    })
+    expectTypeOf(source).toMatchTypeOf<StoreCredentialSource>()
+  })
+})

--- a/packages/hub/src/kernel/types.ts
+++ b/packages/hub/src/kernel/types.ts
@@ -2235,6 +2235,11 @@ export type StoreCredentials =
   | { readonly kind: 'token'                     // postgres/turso/supabase/webdav/bearer — a LATER slice
       readonly token: string
       readonly expiresAt?: string }
+  | { readonly kind: 'password'                  // connection-auth stores: to-postgres/to-mysql user+password; to-smb NTLM via `domain`
+      readonly username: string
+      readonly password: string
+      readonly domain?: string                   // NTLM domain (to-smb); postgres/mysql omit it
+      readonly expiresAt?: string }              // ISO 8601 — cloud IAM auth tokens are password-shaped and expire
 
 /** Refresh hook a store calls when it has no credentials or they are near expiry. */
 export type StoreCredentialSource = () => Promise<StoreCredentials>


### PR DESCRIPTION
Closes #795. Milestone: Store contract: credentials v2 [port].

## What

The #479 credential-broker union on the `@noy-db/hub/to` seam gains its third, additive arm:

```ts
| { kind: 'password'; username: string; password: string; domain?: string; expiresAt?: string }
```

- **Consumers**: to-postgres / to-mysql (`user`+`password`; cloud IAM auth tokens are password-shaped and expire → `expiresAt`), to-smb NTLM (`domain`). This unblocks the rest of the noy-db-to adoption wave.
- **`kind: 'key'` deliberately absent** — to-ssh is keys-only by design and brokered key material is a separate decision (per the issue).
- Broker docs (`docs/subsystems/broker.md`) gain a kind → consuming-store-family table + the explicit key-deferral note.
- Type-level suite (`store-credentials.test-d.ts`): assignability (bare + NTLM shapes), narrowing, and an exhaustiveness `satisfies never` switch so a fourth variant can't land unnoticed. Runtime: broker seed round-trip minting `kind: 'password'` verbatim.
- The one existing discriminant consumer (`as-aws-s3` `mapAws`) is a non-exhaustive guard that rejects non-aws kinds by message — correct for the new variant, no change needed.
- **No golden bump**: `to-surface` / root-barrel goldens freeze export names only; this adds a shape, not an export (verified by running them, not assuming).

## Verification

Full hub suite **525 files / 4437 tests pass** · typecheck (incl. the new test-d via typetest project) · lint · build · `check:architecture` ✓ · knip byte-identical before/after. Changeset: `@noy-db/hub` minor (local, gitignored dir).
