### PR TITLE
feat(hub): share-link grammar — @noy-db/hub/share-link subpath (#806)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -15,6 +15,7 @@
         "src/kernel/{to,on,at,in,by,ui,with}/index.ts",
         "src/**/active.ts",
         "src/kernel/util/index.ts",
+        "src/share-link/index.ts",
         "src/with-fork/snapshots/index.ts",
         "src/with-party/session/index.ts",
         "src/with-party/team/index.ts",

--- a/packages/hub/__tests__/share-link-surface-golden.test.ts
+++ b/packages/hub/__tests__/share-link-surface-golden.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Golden export-surface freeze for the `@noy-db/hub/share-link` subpath
+ * (#806 — the portal share-link grammar).
+ *
+ * The share-link grammar is a frozen CONTRACT by nature: links are
+ * minted into chat messages, QR codes, and bookmarks that outlive any
+ * release, and three surfaces (LIFF permalink, PWA, vendor console)
+ * parse the same shape. This test freezes the subpath's export list
+ * against a checked-in baseline (`share-link-surface.golden.json`) so
+ * drift fails CI — adding requires a visible baseline update,
+ * removing / renaming fails loudly.
+ *
+ * MECHANISM — identical to the `/as` and `/to` golden tests (see their
+ * headers for the rationale): runtime `Object.keys` freezes the VALUE
+ * exports; a source-parse of the `export type { … } from` blocks
+ * freezes the TYPE-only exports (erased at runtime); a compile-time
+ * `import type` list asserts every baselined type still resolves so a
+ * removal also breaks `typecheck`.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import * as shareLink from '../src/share-link/index.js'
+import type { ShareLink, ShareLinkParts, ShareLinkErrorCode } from '../src/share-link/index.js'
+
+interface Surface {
+  readonly values: readonly string[]
+  readonly types: readonly string[]
+}
+
+function read(url: string): string {
+  return readFileSync(fileURLToPath(new URL(url, import.meta.url)), 'utf8')
+}
+
+/** Strip comments, then collect names from `export [type] { … } from` blocks. */
+function parseExports(src: string): { values: string[]; types: string[] } {
+  const clean = src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1')
+  const collect = (re: RegExp): string[] => {
+    const out = new Set<string>()
+    for (const m of clean.matchAll(re)) {
+      for (const part of (m[1] ?? '').split(',')) {
+        const name = part.trim().split(/\s+as\s+/).pop()?.trim()
+        if (name) out.add(name)
+      }
+    }
+    return [...out].sort()
+  }
+  return {
+    types: collect(/export\s+type\s*\{([^}]*)\}\s*from/g),
+    values: collect(/export\s*\{([^}]*)\}\s*from/g),
+  }
+}
+
+const baseline: Surface = JSON.parse(read('./share-link-surface.golden.json')) as Surface
+const parsed = parseExports(read('../src/share-link/index.ts'))
+
+describe('@noy-db/hub/share-link — golden export surface', () => {
+  it('value exports match the frozen baseline (runtime enumeration)', () => {
+    const runtime = Object.keys(shareLink)
+      .filter((k) => (shareLink as Record<string, unknown>)[k] !== undefined)
+      .sort()
+    expect(runtime).toEqual([...baseline.values].sort())
+  })
+
+  it('value exports in source match the baseline (source parse)', () => {
+    expect(parsed.values).toEqual([...baseline.values].sort())
+  })
+
+  it('type exports match the frozen baseline (source parse)', () => {
+    expect(parsed.types).toEqual([...baseline.types].sort())
+  })
+})
+
+// Compile-time exhaustiveness: every baselined type must still be exported.
+type _FrozenTypes = [ShareLink, ShareLinkParts, ShareLinkErrorCode]

--- a/packages/hub/__tests__/share-link-surface.golden.json
+++ b/packages/hub/__tests__/share-link-surface.golden.json
@@ -1,0 +1,14 @@
+{
+  "subpath": "@noy-db/hub/share-link",
+  "source": "src/share-link/index.ts",
+  "values": [
+    "ShareLinkParseError",
+    "buildShareLink",
+    "parseShareLink"
+  ],
+  "types": [
+    "ShareLink",
+    "ShareLinkParts",
+    "ShareLinkErrorCode"
+  ]
+}

--- a/packages/hub/__tests__/share-link.test.ts
+++ b/packages/hub/__tests__/share-link.test.ts
@@ -1,0 +1,325 @@
+/**
+ * #806 — portal share-link grammar + parse/build helper.
+ *
+ * One canonical link shape addresses vault / period / collection /
+ * record across the LIFF permalink, PWA, and vendor-console surfaces:
+ *
+ *   /r/{vaultHandle}/{collection}/{recordId}[?period=…][&v=…][#g={token}]
+ *
+ * Covered here: build/parse round-trips for every part combination and
+ * input form (relative, based, full URL, URL instance, LIFF permalink),
+ * the fragment-only grant-token transport rule, and the fail-closed
+ * catalogue (unknown prefix, missing/extra/empty/non-canonical
+ * segments, non-ULID vault handles, dot-segment + %2F injection,
+ * duplicate/unknown query keys, malformed fragments).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  buildShareLink,
+  parseShareLink,
+  ShareLinkParseError,
+  type ShareLinkParts,
+} from '../src/share-link/index.js'
+
+const VAULT = '01HZY3Q4X0T9GJK5M8N2P7RSTV' // valid Crockford ULID shape
+const LIFF_BASE = 'https://liff.line.me/1656008674-Ab1Cd2Ef'
+const PWA_BASE = 'https://portal.example.com'
+
+function expectParseError(input: string | URL, code: string): void {
+  let caught: unknown
+  try {
+    parseShareLink(input)
+  } catch (e) {
+    caught = e
+  }
+  expect(caught, `expected ${String(input)} to fail closed`).toBeInstanceOf(ShareLinkParseError)
+  expect((caught as ShareLinkParseError).code).toBe(code)
+}
+
+describe('#806 share-link — build/parse round-trip', () => {
+  const combos: Array<[string, ShareLinkParts]> = [
+    ['minimal', { vaultHandle: VAULT, collection: 'invoices', recordId: 'inv-001' }],
+    ['period', { vaultHandle: VAULT, collection: 'invoices', recordId: 'inv-001', period: '2026-Q2' }],
+    ['version', { vaultHandle: VAULT, collection: 'invoices', recordId: 'inv-001', version: 0 }],
+    ['grant token', { vaultHandle: VAULT, collection: 'invoices', recordId: 'inv-001', grantToken: 'tok_abc123' }],
+    ['period+version', { vaultHandle: VAULT, collection: 'invoices', recordId: 'inv-001', period: '2026-Q2', version: 7 }],
+    ['period+token', { vaultHandle: VAULT, collection: 'invoices', recordId: 'inv-001', period: '2026-Q2', grantToken: 'tok_abc123' }],
+    ['version+token', { vaultHandle: VAULT, collection: 'invoices', recordId: 'inv-001', version: 12, grantToken: 'tok_abc123' }],
+    ['all parts', { vaultHandle: VAULT, collection: 'invoices', recordId: 'inv-001', period: '2026-Q2', version: 12, grantToken: 'tok_abc123' }],
+  ]
+
+  it.each(combos)('round-trips with %s', (_name, parts) => {
+    const link = buildShareLink(parts)
+    expect(link.startsWith('/r/')).toBe(true)
+    expect(parseShareLink(link)).toEqual(parts)
+  })
+
+  it('parse result carries no absent optional keys', () => {
+    const parsed = parseShareLink(`/r/${VAULT}/invoices/inv-001`)
+    expect(Object.keys(parsed).sort()).toEqual(['collection', 'recordId', 'vaultHandle'])
+  })
+
+  it('canonical part order: period before v, fragment last', () => {
+    const link = buildShareLink({
+      vaultHandle: VAULT, collection: 'c', recordId: 'r',
+      period: 'p1', version: 3, grantToken: 't',
+    })
+    expect(link).toBe(`/r/${VAULT}/c/r?period=p1&v=3#g=t`)
+  })
+})
+
+describe('#806 share-link — the three surfaces (base + input forms)', () => {
+  const parts: ShareLinkParts = {
+    vaultHandle: VAULT, collection: 'invoices', recordId: 'inv-001',
+    period: '2026-Q2', version: 3, grantToken: 'tok_abc123',
+  }
+
+  it('base is prepended verbatim and the result still parses (PWA origin)', () => {
+    const link = buildShareLink(parts, PWA_BASE)
+    expect(link.startsWith(`${PWA_BASE}/r/${VAULT}/`)).toBe(true)
+    expect(parseShareLink(link)).toEqual(parts)
+  })
+
+  it('LIFF permalink base round-trips (prefix tolerance on parse)', () => {
+    const link = buildShareLink(parts, LIFF_BASE)
+    expect(link.startsWith(`${LIFF_BASE}/r/`)).toBe(true)
+    expect(parseShareLink(link)).toEqual(parts)
+  })
+
+  it('accepts a URL instance', () => {
+    expect(parseShareLink(new URL(buildShareLink(parts, PWA_BASE)))).toEqual(parts)
+    expect(parseShareLink(new URL(buildShareLink(parts, LIFF_BASE)))).toEqual(parts)
+  })
+
+  it('LIFF fallback takes the FIRST /r/ segment boundary', () => {
+    // Collection literally named "r" after the real /r/ prefix — the
+    // fallback must not re-anchor deeper into the path.
+    const parsed = parseShareLink(`${LIFF_BASE}/r/${VAULT}/r/rec`)
+    expect(parsed).toEqual({ vaultHandle: VAULT, collection: 'r', recordId: 'rec' })
+  })
+
+  it('LIFF fallback fires only when the direct parse fails', () => {
+    // Same-origin path starting with /r/ is parsed directly even though
+    // a second /r/ appears later as data.
+    const parsed = parseShareLink(`${PWA_BASE}/r/${VAULT}/docs/r`)
+    expect(parsed).toEqual({ vaultHandle: VAULT, collection: 'docs', recordId: 'r' })
+  })
+})
+
+describe('#806 share-link — grant-token transport rule (fragment only)', () => {
+  it('the token never appears in the path or query on build', () => {
+    const token = 'SECRET-single-use-token'
+    const link = buildShareLink({
+      vaultHandle: VAULT, collection: 'c', recordId: 'r',
+      period: 'p', version: 1, grantToken: token,
+    })
+    const [serverVisible, fragment] = link.split('#') as [string, string]
+    expect(serverVisible).not.toContain(token)
+    expect(fragment).toBe(`g=${token}`)
+  })
+
+  it('a token offered via query is refused, never accepted', () => {
+    expectParseError(`/r/${VAULT}/c/r?g=token`, 'UNKNOWN_QUERY_KEY')
+  })
+
+  it('token round-trips through the fragment, encoded', () => {
+    const grantToken = 'tok/with?reserved#chars&=+%'
+    const link = buildShareLink({ vaultHandle: VAULT, collection: 'c', recordId: 'r', grantToken })
+    expect(link.split('#')[0]).not.toContain('with?reserved')
+    expect(parseShareLink(link).grantToken).toBe(grantToken)
+  })
+})
+
+describe('#806 share-link — fail closed: prefixes and URL forms', () => {
+  it.each([
+    ['no leading slash', `r/${VAULT}/c/r`, 'UNKNOWN_PREFIX'],
+    ['wrong prefix', `/records/${VAULT}/c/r`, 'UNKNOWN_PREFIX'],
+    ['no /r/ anywhere in a full URL', `${PWA_BASE}/x/${VAULT}/c/r`, 'UNKNOWN_PREFIX'],
+    ['bare /r with nothing after', '/r', 'UNKNOWN_PREFIX'],
+    ['non-http(s) scheme', `ftp://host/r/${VAULT}/c/r`, 'UNKNOWN_PREFIX'],
+    ['scheme-relative-ish garbage', `liff.line.me/app/r/${VAULT}/c/r`, 'UNKNOWN_PREFIX'],
+  ])('%s → UNKNOWN_PREFIX', (_n, input, code) => {
+    expectParseError(input, code)
+  })
+
+  it('URL instance with a non-http(s) protocol fails closed', () => {
+    expectParseError(new URL(`line://app/r/${VAULT}/c/r`), 'UNKNOWN_PREFIX')
+  })
+
+  it('never falls back to a default vault: result is a throw, not a value', () => {
+    expect(() => parseShareLink('/r/')).toThrow(ShareLinkParseError)
+    expect(() => parseShareLink(PWA_BASE)).toThrow(ShareLinkParseError)
+  })
+})
+
+describe('#806 share-link — fail closed: path segments', () => {
+  it.each([
+    ['missing recordId', `/r/${VAULT}/c`, 'MALFORMED_PATH'],
+    ['missing collection + recordId', `/r/${VAULT}`, 'MALFORMED_PATH'],
+    ['extra trailing segment', `/r/${VAULT}/c/r/extra`, 'MALFORMED_PATH'],
+    ['trailing slash after full path', `/r/${VAULT}/c/r/`, 'MALFORMED_PATH'],
+    ['empty vault segment', '/r//c/r', 'MALFORMED_SEGMENT'],
+    ['empty collection segment', `/r/${VAULT}//r`, 'MALFORMED_SEGMENT'],
+    ['empty recordId (trailing slash)', `/r/${VAULT}/c/`, 'MALFORMED_SEGMENT'],
+    ['non-canonical + in segment', `/r/${VAULT}/a+b/r`, 'MALFORMED_SEGMENT'],
+    ['non-canonical %61 (over-encoded)', `/r/${VAULT}/%61bc/r`, 'MALFORMED_SEGMENT'],
+    ['lowercase hex escape', `/r/${VAULT}/a%2fb/r`, 'MALFORMED_SEGMENT'],
+    ['truncated percent escape', `/r/${VAULT}/a%2/r`, 'MALFORMED_SEGMENT'],
+    ['invalid percent escape', `/r/${VAULT}/a%GGb/r`, 'MALFORMED_SEGMENT'],
+    ['raw @ is not canonical', `/r/${VAULT}/a@b/r`, 'MALFORMED_SEGMENT'],
+  ])('%s → fail closed', (_n, input, code) => {
+    expectParseError(input, code)
+  })
+
+  it.each([
+    ['too short', VAULT.slice(0, 25)],
+    ['too long', `${VAULT}0`],
+    ['lowercase', VAULT.toLowerCase()],
+    ['excluded Crockford letters', `${VAULT.slice(0, 22)}ILOU`],
+    ['not a ulid at all', 'customer-vault'],
+  ])('non-ULID vault handle (%s) → INVALID_VAULT_HANDLE', (_n, handle) => {
+    expectParseError(`/r/${handle}/c/r`, 'INVALID_VAULT_HANDLE')
+  })
+
+  it('dot-segment injection collapses under URL normalization and fails closed', () => {
+    // "/.." eats the vault segment → wrong arity, never a re-anchored path.
+    expectParseError(`/r/${VAULT}/../r`, 'MALFORMED_PATH')
+    expectParseError(`/r/${VAULT}/%2E%2E/r`, 'MALFORMED_PATH')
+    expectParseError(`/r/${VAULT}/c/..`, 'MALFORMED_PATH')
+  })
+
+  it('double-encoded %252E decodes ONCE to the literal string "%2E%2E" — no second decode, no dot segment', () => {
+    // Single decode is the contract: the value is the opaque collection
+    // name "%2E%2E", never re-decoded into "..".
+    expect(parseShareLink(`/r/${VAULT}/%252E%252E/r`)).toEqual({
+      vaultHandle: VAULT, collection: '%2E%2E', recordId: 'r',
+    })
+  })
+
+  it('buildShareLink refuses "." and ".." segments outright', () => {
+    for (const bad of ['.', '..']) {
+      expect(() => buildShareLink({ vaultHandle: VAULT, collection: bad, recordId: 'r' }))
+        .toThrow(ShareLinkParseError)
+      expect(() => buildShareLink({ vaultHandle: VAULT, collection: 'c', recordId: bad }))
+        .toThrow(ShareLinkParseError)
+    }
+  })
+
+  it('%2F inside a segment decodes to a slash WITHOUT creating extra segments', () => {
+    const parts: ShareLinkParts = { vaultHandle: VAULT, collection: 'a/b', recordId: 'x/y/z' }
+    const link = buildShareLink(parts)
+    expect(link).toBe(`/r/${VAULT}/a%2Fb/x%2Fy%2Fz`)
+    expect(parseShareLink(link)).toEqual(parts)
+    // Direct wire form, same guarantee.
+    expect(parseShareLink(`/r/${VAULT}/a%2Fb/rec`)).toEqual({
+      vaultHandle: VAULT, collection: 'a/b', recordId: 'rec',
+    })
+  })
+})
+
+describe('#806 share-link — fail closed: query', () => {
+  it.each([
+    ['duplicate period', `/r/${VAULT}/c/r?period=a&period=b`, 'DUPLICATE_QUERY_KEY'],
+    ['duplicate v', `/r/${VAULT}/c/r?v=1&v=2`, 'DUPLICATE_QUERY_KEY'],
+    ['unknown key', `/r/${VAULT}/c/r?foo=1`, 'UNKNOWN_QUERY_KEY'],
+    ['tracking key', `/r/${VAULT}/c/r?period=a&utm_source=line`, 'UNKNOWN_QUERY_KEY'],
+    ['case-sensitive keys', `/r/${VAULT}/c/r?Period=a`, 'UNKNOWN_QUERY_KEY'],
+    ['bare key without =', `/r/${VAULT}/c/r?period`, 'MALFORMED_QUERY'],
+    ['empty key', `/r/${VAULT}/c/r?=x`, 'MALFORMED_QUERY'],
+    ['dangling &', `/r/${VAULT}/c/r?period=a&`, 'MALFORMED_QUERY'],
+    ['empty period value', `/r/${VAULT}/c/r?period=`, 'MALFORMED_QUERY'],
+    ['non-canonical period (+ as space)', `/r/${VAULT}/c/r?period=a+b`, 'MALFORMED_QUERY'],
+  ])('%s → fail closed', (_n, input, code) => {
+    expectParseError(input, code)
+  })
+
+  it.each([
+    ['leading zero', '01'],
+    ['negative', '-1'],
+    ['float', '1.5'],
+    ['exponent', '1e3'],
+    ['non-numeric', 'abc'],
+    ['empty', ''],
+    ['beyond 2^53-1', '9007199254740992'],
+  ])('version "%s" → INVALID_VERSION', (_n, v) => {
+    expectParseError(`/r/${VAULT}/c/r?v=${v}`, 'INVALID_VERSION')
+  })
+
+  it('version at exactly 2^53-1 parses', () => {
+    expect(parseShareLink(`/r/${VAULT}/c/r?v=9007199254740991`).version).toBe(9007199254740991)
+  })
+})
+
+describe('#806 share-link — fail closed: fragment', () => {
+  it.each([
+    ['unknown fragment shape', `/r/${VAULT}/c/r#token`, 'MALFORMED_FRAGMENT'],
+    ['wrong fragment key', `/r/${VAULT}/c/r#t=abc`, 'MALFORMED_FRAGMENT'],
+    ['empty token', `/r/${VAULT}/c/r#g=`, 'MALFORMED_FRAGMENT'],
+    ['non-canonical token', `/r/${VAULT}/c/r#g=a+b`, 'MALFORMED_FRAGMENT'],
+  ])('%s → MALFORMED_FRAGMENT', (_n, input, code) => {
+    expectParseError(input, code)
+  })
+
+  it('a lone "#" is treated as no fragment', () => {
+    expect(parseShareLink(`/r/${VAULT}/c/r#`).grantToken).toBeUndefined()
+  })
+})
+
+describe('#806 share-link — buildShareLink fail closed (INVALID_PARTS)', () => {
+  const good: ShareLinkParts = { vaultHandle: VAULT, collection: 'c', recordId: 'r' }
+
+  const badParts: Array<[string, ShareLinkParts]> = [
+    ['non-ULID vaultHandle', { ...good, vaultHandle: 'nope' }],
+    ['empty collection', { ...good, collection: '' }],
+    ['empty recordId', { ...good, recordId: '' }],
+    ['empty period', { ...good, period: '' }],
+    ['empty grantToken', { ...good, grantToken: '' }],
+    ['negative version', { ...good, version: -1 }],
+    ['float version', { ...good, version: 1.5 }],
+    ['unsafe-integer version', { ...good, version: 2 ** 53 }],
+  ]
+
+  it.each(badParts)('%s throws INVALID_PARTS', (_n, parts) => {
+    let caught: unknown
+    try {
+      buildShareLink(parts)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(ShareLinkParseError)
+    expect((caught as ShareLinkParseError).code).toBe('INVALID_PARTS')
+  })
+})
+
+describe('#806 share-link — i18n-safe encoding', () => {
+  it('Unicode collection/record/period round-trip (Thai, Polish, emoji)', () => {
+    const parts: ShareLinkParts = {
+      vaultHandle: VAULT,
+      collection: 'ลูกค้า',
+      recordId: 'faktura-śląsk-🧾',
+      period: 'ปี-2569',
+    }
+    const link = buildShareLink(parts, LIFF_BASE)
+    expect(parseShareLink(link)).toEqual(parts)
+    // The wire form is pure percent-encoded ASCII after the base.
+    expect(link.slice(LIFF_BASE.length)).toMatch(/^[\x21-\x7E]+$/)
+  })
+
+  it('property-ish: tricky strings round-trip as every opaque part', () => {
+    const tricky = [
+      'a b', 'a/b', 'a\\b', 'a?b', 'a#b', 'a&b', 'a=b', 'a%b', '%2F',
+      '..x', 'x..', 'a.b.c', '+', '&', '=', '?', '#', '%', ' ',
+      "a'b", 'a(b)*c!~', 'ID_with-mixed.chars', 'ปี-2569/ไตรมาส:1',
+      '🧾🔗', 'ｱｲｳ ｴｵ', 'x'.repeat(512),
+    ]
+    for (const s of tricky) {
+      const parts: ShareLinkParts = {
+        vaultHandle: VAULT, collection: s, recordId: s, period: s, grantToken: s,
+      }
+      const link = buildShareLink(parts)
+      expect(parseShareLink(link), `round-trip failed for ${JSON.stringify(s)}`).toEqual(parts)
+      // And through a full-URL carry, as each surface would transport it.
+      expect(parseShareLink(`${LIFF_BASE}${link}`)).toEqual(parts)
+    }
+  })
+})

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -120,6 +120,10 @@
       "types": "./dist/kernel/util/index.d.ts",
       "default": "./dist/util/index.js"
     },
+    "./share-link": {
+      "types": "./dist/share-link/index.d.ts",
+      "default": "./dist/share-link/index.js"
+    },
     "./attestation": {
       "types": "./dist/with-audit/attestation/index.d.ts",
       "default": "./dist/attestation/index.js"

--- a/packages/hub/src/share-link/index.ts
+++ b/packages/hub/src/share-link/index.ts
@@ -1,0 +1,20 @@
+/**
+ * `@noy-db/hub/share-link` — the portal share-link grammar (#806).
+ *
+ * A standalone subpath: pure string/`URL` code addressing
+ * `vault / period / collection / record` as one canonical link shape
+ * (`/r/{vaultHandle}/{collection}/{recordId}?period=…&v=…#g={token}`)
+ * shared by the LIFF permalink, PWA, and vendor-console surfaces. The
+ * single-use grant token travels ONLY in the URL fragment (the
+ * on-magic-link transport rule — fragments never reach server logs).
+ *
+ * No crypto, no store, no hub floor — import this from a LIFF shell,
+ * a PWA, or klum-db without dragging anything else. The grammar is a
+ * frozen contract: the export surface is pinned by
+ * `__tests__/share-link-surface-golden.test.ts`.
+ *
+ * @module
+ */
+
+export { buildShareLink, parseShareLink, ShareLinkParseError } from './share-link.js'
+export type { ShareLink, ShareLinkParts, ShareLinkErrorCode } from './share-link.js'

--- a/packages/hub/src/share-link/share-link.ts
+++ b/packages/hub/src/share-link/share-link.ts
@@ -1,0 +1,385 @@
+/**
+ * Portal share-link grammar + parse/build helper (#806).
+ *
+ * ONE canonical link grammar addresses `vault / period / collection /
+ * record` across all three portal surfaces — the LIFF permalink path
+ * (`https://liff.line.me/{liffId}/r/…`), the installed-PWA same-origin
+ * path (`https://{portal-origin}/r/…`), and the vendor backend console.
+ * The link SHAPE is identical everywhere; only the origin prefix
+ * differs, and callers own the prefix.
+ *
+ * ## Grammar (frozen — see `__tests__/share-link-surface.golden.json`)
+ *
+ * ```
+ * share-link = [ base ] "/r/" vault "/" collection "/" record
+ *              [ "?" query ] [ "#" fragment ]
+ * vault      = ULID                        ; 26 uppercase Crockford base32 chars
+ * collection = segment                     ; opaque, non-empty after decode
+ * record     = segment                     ; opaque, non-empty after decode
+ * query      = pair *( "&" pair )          ; keys unique; ONLY these two keys
+ * pair       = "period=" component         ; opaque period id
+ *            / "v=" version                ; record version
+ * version    = "0" / %x31-39 *DIGIT        ; base-10 integer, ≤ 2^53 − 1
+ * fragment   = "g=" component              ; single-use grant token (opaque)
+ * ```
+ *
+ * `segment` / `component` are strict-canonical `encodeURIComponent`
+ * output: decoding then re-encoding MUST reproduce the raw text exactly
+ * (uppercase-hex escapes, `+` is a literal plus never a space, `%2F`
+ * inside a segment never creates an extra segment). Path segments
+ * additionally may not decode to `.` or `..`. Links produced by
+ * {@link buildShareLink} always satisfy this; hand-written links using
+ * only unreserved characters (`inv-001`, ULIDs, …) do too.
+ *
+ * ## Transport rule for the grant token
+ *
+ * The optional single-use grant token travels ONLY in the URL fragment
+ * (`#g={token}`) — never in the path or query — because fragments are
+ * not sent to servers, so the token never reaches server logs, CDNs, or
+ * LINE's infrastructure. Same rule `on-magic-link` follows. The token is
+ * fully OPAQUE here: no validation beyond non-empty, no decoding of its
+ * semantics — grant semantics live in `on-magic-link` (not imported).
+ *
+ * ## Fail closed
+ *
+ * {@link parseShareLink} throws a typed {@link ShareLinkParseError} for
+ * ANYTHING that is not exactly the grammar above — unknown prefix,
+ * missing/extra/empty/malformed segments, a non-ULID vault handle,
+ * duplicate or unknown query keys, malformed fragments. There is never a
+ * default-vault (or any other) fallback; the app maps the error to a 404.
+ *
+ * Zero dependencies on the hub floor: pure string/`URL` code, no crypto,
+ * no store — LIFF shells, PWAs, and klum-db can import this subpath
+ * without dragging anything else. (The one internal import is the pure,
+ * leaf ULID shape check shared with the pod format.)
+ */
+
+import { isULID } from '../with-pod/ulid.js'
+
+/** Machine-readable {@link ShareLinkParseError} discriminant. */
+export type ShareLinkErrorCode =
+  | 'MALFORMED_URL'
+  | 'UNKNOWN_PREFIX'
+  | 'MALFORMED_PATH'
+  | 'MALFORMED_SEGMENT'
+  | 'INVALID_VAULT_HANDLE'
+  | 'MALFORMED_QUERY'
+  | 'DUPLICATE_QUERY_KEY'
+  | 'UNKNOWN_QUERY_KEY'
+  | 'INVALID_VERSION'
+  | 'MALFORMED_FRAGMENT'
+  | 'INVALID_PARTS'
+
+/**
+ * Typed failure for the share-link grammar. Thrown by
+ * {@link parseShareLink} for any input outside the grammar (fail closed —
+ * map to an app-level 404, never a default-vault fallback), and by
+ * {@link buildShareLink} with code `'INVALID_PARTS'` when the caller
+ * hands it parts that could not round-trip.
+ *
+ * Standalone (`extends Error`, not `NoydbError`) so this subpath stays
+ * import-light; the `code` field follows the same machine-readable
+ * convention as the kernel error classes.
+ */
+export class ShareLinkParseError extends Error {
+  /** Machine-readable error code. Stable across library versions. */
+  readonly code: ShareLinkErrorCode
+
+  constructor(code: ShareLinkErrorCode, message: string) {
+    super(message)
+    this.name = 'ShareLinkParseError'
+    this.code = code
+  }
+}
+
+/**
+ * The logical address a share link carries. Input to
+ * {@link buildShareLink}; {@link parseShareLink} returns the same shape
+ * (as the readonly {@link ShareLink} alias) with optional fields OMITTED
+ * (not `undefined`) when absent from the link.
+ */
+export interface ShareLinkParts {
+  /** Vault handle — a 26-character uppercase Crockford-base32 ULID. */
+  vaultHandle: string
+  /** Collection name — opaque, non-empty. */
+  collection: string
+  /** Record id — opaque, non-empty. */
+  recordId: string
+  /** Optional period id (`?period=`) — opaque, non-empty. */
+  period?: string
+  /** Optional record version (`?v=`) — non-negative safe integer. */
+  version?: number
+  /**
+   * Optional single-use grant token (`#g=`) — opaque, non-empty. Carried
+   * ONLY in the URL fragment; semantics belong to `on-magic-link`.
+   */
+  grantToken?: string
+}
+
+/** A successfully parsed share link. See {@link ShareLinkParts}. */
+export type ShareLink = Readonly<ShareLinkParts>
+
+// Dummy base for parsing bare `/r/…` paths with the WHATWG URL parser.
+// `.invalid` is reserved (RFC 2606) — it can never collide with a real
+// origin, and the host is discarded anyway (only path/query/fragment
+// matter to the grammar).
+const DUMMY_BASE = 'https://share-link.invalid'
+
+/**
+ * Canonical encoding of a QUERY value. `encodeURIComponent`, plus `'`
+ * → `%27`: the WHATWG URL parser percent-encodes the apostrophe inside
+ * the query component of special (http/https) URLs — if we emitted a
+ * raw `'`, any URL-object round-trip (browser address bar, `new URL`)
+ * would rewrite the link into a form the strict parser then rejects.
+ * Path and fragment components don't need this — every character the
+ * URL parser escapes there is already escaped by `encodeURIComponent`.
+ */
+function encodeQueryValue(value: string): string {
+  return encodeURIComponent(value).replace(/'/g, '%27')
+}
+
+/**
+ * Strict-canonical decode: `raw` must be exactly what the given
+ * canonical `encode` produces for the decoded text — no `+`-for-space,
+ * no lowercase hex escapes, no unencoded reserved characters,
+ * non-empty. `redact` keeps the raw text out of the error message
+ * (grant tokens).
+ */
+function decodeCanonical(
+  raw: string,
+  code: ShareLinkErrorCode,
+  what: string,
+  { redact = false, encode = encodeURIComponent }: {
+    redact?: boolean
+    encode?: (value: string) => string
+  } = {},
+): string {
+  const shown = redact ? '(redacted)' : `"${raw}"`
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(raw)
+  } catch {
+    throw new ShareLinkParseError(code, `${what}: malformed percent-encoding in ${shown}`)
+  }
+  if (decoded === '') {
+    throw new ShareLinkParseError(code, `${what}: empty`)
+  }
+  if (encode(decoded) !== raw) {
+    throw new ShareLinkParseError(
+      code,
+      `${what}: ${shown} is not canonical encodeURIComponent output`,
+    )
+  }
+  return decoded
+}
+
+/** Path-segment decode — canonical, plus the dot-segment refusal. */
+function decodePathSegment(raw: string, what: string): string {
+  const decoded = decodeCanonical(raw, 'MALFORMED_SEGMENT', what)
+  if (decoded === '.' || decoded === '..') {
+    throw new ShareLinkParseError('MALFORMED_SEGMENT', `${what}: "${decoded}" is a dot segment`)
+  }
+  return decoded
+}
+
+/** `v=` value → non-negative safe integer. Canonical base-10 only. */
+function parseVersion(raw: string): number {
+  if (!/^(?:0|[1-9][0-9]*)$/.test(raw)) {
+    throw new ShareLinkParseError(
+      'INVALID_VERSION',
+      `version "${raw}" is not a canonical base-10 integer`,
+    )
+  }
+  const version = Number(raw)
+  if (!Number.isSafeInteger(version)) {
+    throw new ShareLinkParseError('INVALID_VERSION', `version "${raw}" exceeds 2^53 - 1`)
+  }
+  return version
+}
+
+/** Resolve string | URL input to a URL object, fail closed. */
+function toUrl(input: string | URL): URL {
+  if (input instanceof URL) {
+    if (input.protocol !== 'http:' && input.protocol !== 'https:') {
+      throw new ShareLinkParseError(
+        'UNKNOWN_PREFIX',
+        `unsupported protocol "${input.protocol}" — share links are http(s) URLs or bare /r/ paths`,
+      )
+    }
+    return input
+  }
+  if (input.startsWith('/')) {
+    try {
+      return new URL(input, DUMMY_BASE)
+    } catch {
+      throw new ShareLinkParseError('MALFORMED_URL', 'unparseable share path')
+    }
+  }
+  if (/^https?:\/\//i.test(input)) {
+    try {
+      return new URL(input)
+    } catch {
+      throw new ShareLinkParseError('MALFORMED_URL', 'unparseable share URL')
+    }
+  }
+  throw new ShareLinkParseError(
+    'UNKNOWN_PREFIX',
+    'input is neither a "/"-rooted share path nor an http(s) URL',
+  )
+}
+
+/**
+ * Parse a share link — full URL, `URL` instance, or bare `/r/…` path.
+ *
+ * A LIFF permalink prefix is tolerated: when the path does not start
+ * with `/r/` directly, the share path is taken from the FIRST `/r/`
+ * segment boundary (`https://liff.line.me/{liffId}/r/…` → `/r/…`). No
+ * fuzzy matching beyond that single rule.
+ *
+ * Fail closed: anything outside the grammar throws
+ * {@link ShareLinkParseError}. Never a default-vault fallback.
+ */
+export function parseShareLink(input: string | URL): ShareLink {
+  const url = toUrl(input)
+
+  let pathname = url.pathname
+  if (!pathname.startsWith('/r/')) {
+    // LIFF permalink tolerance — only after the direct parse failed. An
+    // indexOf hit is always a whole `r` segment (the match is slash-
+    // delimited on both sides), so this cannot fire mid-segment.
+    const idx = pathname.indexOf('/r/')
+    if (idx === -1) {
+      throw new ShareLinkParseError(
+        'UNKNOWN_PREFIX',
+        `path "${pathname}" has no /r/ share prefix`,
+      )
+    }
+    pathname = pathname.slice(idx)
+  }
+
+  // "/r/{vault}/{collection}/{record}" splits into exactly 5 parts:
+  // ['', 'r', vault, collection, record].
+  const rawSegments = pathname.split('/')
+  if (rawSegments.length !== 5) {
+    throw new ShareLinkParseError(
+      'MALFORMED_PATH',
+      `expected /r/{vaultHandle}/{collection}/{recordId} — got ${rawSegments.length - 2} segment(s) after /r/`,
+    )
+  }
+
+  const vaultHandle = decodePathSegment(rawSegments[2]!, 'vault handle')
+  if (!isULID(vaultHandle)) {
+    throw new ShareLinkParseError(
+      'INVALID_VAULT_HANDLE',
+      `vault handle "${vaultHandle}" is not a ULID`,
+    )
+  }
+  const collection = decodePathSegment(rawSegments[3]!, 'collection')
+  const recordId = decodePathSegment(rawSegments[4]!, 'record id')
+
+  // Query — manual parse of url.search (NOT URLSearchParams, whose
+  // form-urlencoded rules decode "+" as a space and hide duplicates).
+  let period: string | undefined
+  let version: number | undefined
+  if (url.search !== '') {
+    const seen = new Set<string>()
+    for (const pair of url.search.slice(1).split('&')) {
+      const eq = pair.indexOf('=')
+      if (eq <= 0) {
+        throw new ShareLinkParseError('MALFORMED_QUERY', `query pair "${pair}" is not key=value`)
+      }
+      const key = pair.slice(0, eq)
+      const rawValue = pair.slice(eq + 1)
+      if (key !== 'period' && key !== 'v') {
+        throw new ShareLinkParseError('UNKNOWN_QUERY_KEY', `unknown query key "${key}"`)
+      }
+      if (seen.has(key)) {
+        throw new ShareLinkParseError('DUPLICATE_QUERY_KEY', `duplicate query key "${key}"`)
+      }
+      seen.add(key)
+      if (key === 'period') {
+        period = decodeCanonical(rawValue, 'MALFORMED_QUERY', 'period', {
+          encode: encodeQueryValue,
+        })
+      } else {
+        version = parseVersion(rawValue)
+      }
+    }
+  }
+
+  // Fragment — the ONLY place a grant token may appear.
+  let grantToken: string | undefined
+  if (url.hash !== '' && url.hash !== '#') {
+    const fragment = url.hash.slice(1)
+    if (!fragment.startsWith('g=')) {
+      throw new ShareLinkParseError(
+        'MALFORMED_FRAGMENT',
+        'fragment is not a g={token} grant carrier',
+      )
+    }
+    grantToken = decodeCanonical(fragment.slice(2), 'MALFORMED_FRAGMENT', 'grant token', {
+      redact: true,
+    })
+  }
+
+  return {
+    vaultHandle,
+    collection,
+    recordId,
+    ...(period !== undefined ? { period } : {}),
+    ...(version !== undefined ? { version } : {}),
+    ...(grantToken !== undefined ? { grantToken } : {}),
+  }
+}
+
+/** Build-side part validation. Returns the (narrowed) string value. */
+function requirePart(value: unknown, what: string, dotSegmentRefused = false): string {
+  if (typeof value !== 'string' || value === '') {
+    throw new ShareLinkParseError('INVALID_PARTS', `${what} must be a non-empty string`)
+  }
+  if (dotSegmentRefused && (value === '.' || value === '..')) {
+    throw new ShareLinkParseError('INVALID_PARTS', `${what}: "${value}" is a dot segment`)
+  }
+  return value
+}
+
+/**
+ * Build a RELATIVE share link (`/r/…`) from typed parts. Callers prefix
+ * their surface origin — the LIFF permalink base, the PWA origin, or the
+ * vendor console — either themselves or via `base`, which is prepended
+ * VERBATIM (no validation, no joining logic; pass it without a trailing
+ * slash, e.g. `https://liff.line.me/{liffId}`).
+ *
+ * The grant token, when present, is emitted ONLY as the `#g=` fragment.
+ * Invalid parts throw {@link ShareLinkParseError} with code
+ * `'INVALID_PARTS'` — every built link is guaranteed to round-trip
+ * through {@link parseShareLink}.
+ */
+export function buildShareLink(parts: ShareLinkParts, base?: string): string {
+  const { vaultHandle, collection, recordId, period, version, grantToken } = parts
+
+  if (typeof vaultHandle !== 'string' || !isULID(vaultHandle)) {
+    throw new ShareLinkParseError('INVALID_PARTS', 'vaultHandle is not a ULID')
+  }
+  const path = `/r/${vaultHandle}/${encodeURIComponent(
+    requirePart(collection, 'collection', true),
+  )}/${encodeURIComponent(requirePart(recordId, 'recordId', true))}`
+
+  const query: string[] = []
+  if (period !== undefined) {
+    query.push(`period=${encodeQueryValue(requirePart(period, 'period'))}`)
+  }
+  if (version !== undefined) {
+    if (typeof version !== 'number' || !Number.isSafeInteger(version) || version < 0) {
+      throw new ShareLinkParseError('INVALID_PARTS', 'version must be a non-negative safe integer')
+    }
+    query.push(`v=${version}`)
+  }
+
+  const fragment =
+    grantToken !== undefined
+      ? `#g=${encodeURIComponent(requirePart(grantToken, 'grantToken'))}`
+      : ''
+
+  return (base ?? '') + path + (query.length > 0 ? `?${query.join('&')}` : '') + fragment
+}

--- a/packages/hub/tsup.entries.mjs
+++ b/packages/hub/tsup.entries.mjs
@@ -32,6 +32,7 @@ export const ENTRIES = {
   'overlay-views/index': 'src/with-formula/overlay-views/index.ts',
   'sync/index': 'src/with-party/sync/index.ts',
   'util/index': 'src/kernel/util/index.ts',
+  'share-link/index': 'src/share-link/index.ts',
   'attestation/index': 'src/with-audit/attestation/index.ts',
   'classified/index': 'src/via/classified/index.ts',
   'satellites/index': 'src/with-shape/satellites/index.ts',


### PR DESCRIPTION
Closes #806. Milestone: LINE/LIFF client portal [api].

## What

The portal's one canonical share-link shape, as a new zero-dependency subpath `@noy-db/hub/share-link`:

```
[base] /r/{vaultULID}/{collection}/{recordId} [?period=…&v=…] [#g={grantToken}]
```

- `buildShareLink(parts, base?)` / `parseShareLink(string | URL)` — strict-canonical `encodeURIComponent` round-trips; parse accepts bare paths, http(s) URLs, `URL` instances, and LIFF permalinks (first-`/r/`-boundary fallback only after direct parse fails).
- **Fragment-only grant tokens** (`#g=…`) — never in path/query, so they never reach server logs/CDNs; the token is opaque here, semantics stay in on-magic-link (no import).
- **Fail closed**: 11 machine-readable `ShareLinkParseError` codes; no default-vault fallback; `%2F` inside a segment never splits; dot segments refused on build and parse; double-encoding decodes exactly once (tested as contract); error messages redact token values.
- Grammar frozen by its own surface golden (mirrors the `/as`-door golden pattern); not on the root barrel (floor stays clean, `/util` convention).
- One WHATWG quirk canonicalized: URL parsers percent-encode `'` in http(s) query components, so query values use `'`→`%27` as canonical — otherwise build→`new URL`→parse would self-reject.

Consumers: `in-liff` deep-link ingestion (#802), PWA route capture (#803), klum-db vendor addressing (klum-db#43).

## Verification

81 grammar tests + 3 golden. Full hub suite **528 files / 4541 tests pass** · typecheck · lint · build (dist smoke incl. Thai + `%2F` round-trip via LIFF base) · `check:architecture` ✓ · bundle-check all scenarios pass (zero-dep module, floor untouched) · knip zero new findings. Changeset: `@noy-db/hub` minor.
