### PR TITLE
feat(on-oidc): LINE/LIFF hardening + per-device enrollment, firm re-invite only (#804, #805)

### DIFF
--- a/packages/on-oidc/__tests__/device-enrollment.test.ts
+++ b/packages/on-oidc/__tests__/device-enrollment.test.ts
@@ -1,0 +1,387 @@
+/**
+ * #805 — second-device/partition enrollment tests for @noy-db/on-oidc.
+ *
+ * The firm re-invite is the ONLY way to add a device (no device-to-device
+ * handoff — deliberate security decision: a compromised client device must
+ * not be able to escalate into persistent multi-device access).
+ *
+ * Covers:
+ * - Two-partition enrollment: one sub, two deviceSecrets/deviceIds, both
+ *   unlock independently against a deviceId-aware mock connector
+ * - Device management: listOidcDevices / revokeOidcDevice
+ * - Independent revocation: revoke A → A fails with the re-invite guidance
+ *   (KeyConnectorError 404), B still unlocks
+ * - No-self-propagation property: nothing in the public API lets an
+ *   enrolled device mint credentials for a new device without a fresh
+ *   invite-derived UnlockedKeyring
+ * - Backward compat: a legacy server that ignores deviceId degrades to a
+ *   single last-write-wins entry; a legacy enrollment record (no deviceId)
+ *   still unlocks
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as api from '../src/index.js'
+import {
+  enrollOidc,
+  enrollOidcFromInvite,
+  unlockOidc,
+  listOidcDevices,
+  revokeOidcDevice,
+  KeyConnectorError,
+  OidcTokenError,
+  OidcDeviceSecretNotFoundError,
+} from '../src/index.js'
+import type { OidcEnrollment, OidcProviderConfig, UnlockedKeyring } from '../src/index.js'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function b64url(obj: object): string {
+  return btoa(JSON.stringify(obj))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+function makeIdToken(overrides: { sub?: string; exp?: number } = {}): string {
+  const now = Math.floor(Date.now() / 1000)
+  const header = b64url({ alg: 'ES256', typ: 'JWT', kid: 'kid-1' })
+  const payload = b64url({
+    iss: 'https://access.line.me',
+    sub: 'U4af4980629abcdef0123456789abcdef',
+    aud: '1656934047',
+    iat: now,
+    exp: now + 3600,
+    ...overrides,
+  })
+  return `${header}.${payload}.fakesig`
+}
+
+async function makeInviteKeyring(userId: string): Promise<UnlockedKeyring> {
+  const dek = await globalThis.crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt'],
+  )
+  return {
+    userId,
+    displayName: userId,
+    role: 'member',
+    permissions: { invoices: 'ro' },
+    deks: new Map([['invoices', dek]]),
+    kek: null, // invite-seeded session — the portal client has no passphrase
+    salt: new Uint8Array(32).fill(7),
+    authenticators: [],
+  } as unknown as UnlockedKeyring
+}
+
+/**
+ * Minimal in-memory Storage — each instance simulates one PARTITION
+ * (LINE in-app WebView / external browser / installed PWA each have
+ * isolated storage; that isolation is exactly why re-invite exists).
+ */
+function makeStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() { return map.size },
+    clear: () => map.clear(),
+    getItem: (k: string) => map.get(k) ?? null,
+    key: (i: number) => [...map.keys()][i] ?? null,
+    removeItem: (k: string) => { map.delete(k) },
+    setItem: (k: string, v: string) => { map.set(k, v) },
+  } as Storage
+}
+
+const TEST_CONFIG: OidcProviderConfig = {
+  name: 'LINE',
+  issuer: 'https://access.line.me',
+  clientId: '1656934047',
+  keyConnectorUrl: 'https://kc.example.com',
+}
+
+// ─── Mock connectors ──────────────────────────────────────────────────────────
+
+/** deviceId-aware connector: entries keyed by (implicit sub ×) deviceId. */
+function makeDeviceAwareConnector() {
+  const entries = new Map<string, { encryptedServerHalf: string; iv: string; createdAt: string }>()
+  const LEGACY = '__no-device-id__'
+
+  const mockFetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+    const u = new URL(String(url))
+    const method = (init?.method ?? 'GET').toUpperCase()
+
+    if (method === 'PUT' && u.pathname === '/kek-fragment') {
+      const body = JSON.parse(init?.body as string) as {
+        encryptedServerHalf: string; iv: string; deviceId?: string
+      }
+      entries.set(body.deviceId ?? LEGACY, {
+        encryptedServerHalf: body.encryptedServerHalf,
+        iv: body.iv,
+        createdAt: new Date().toISOString(),
+      })
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    }
+
+    if (method === 'GET' && u.pathname === '/kek-fragment/devices') {
+      const devices = [...entries.entries()]
+        .filter(([id]) => id !== LEGACY)
+        .map(([deviceId, e]) => ({ deviceId, createdAt: e.createdAt }))
+      return new Response(JSON.stringify({ devices }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    if (method === 'GET' && u.pathname === '/kek-fragment') {
+      const entry = entries.get(u.searchParams.get('deviceId') ?? LEGACY)
+      if (!entry) return new Response('Not found', { status: 404 })
+      return new Response(
+        JSON.stringify({ encryptedServerHalf: entry.encryptedServerHalf, iv: entry.iv }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+
+    if (method === 'DELETE' && u.pathname === '/kek-fragment') {
+      const deviceId = u.searchParams.get('deviceId')
+      if (deviceId) entries.delete(deviceId)
+      return new Response(null, { status: 204 })
+    }
+
+    return new Response('Method not allowed', { status: 405 })
+  })
+
+  return { mockFetch, entries }
+}
+
+/** Legacy v1 connector: IGNORES deviceId — one slot per sub, last write wins. */
+function makeLegacySingleSlotConnector() {
+  let stored: { encryptedServerHalf: string; iv: string } | null = null
+  let putCount = 0
+
+  const mockFetch = vi.fn(async (url: string | URL, init?: RequestInit) => {
+    const u = new URL(String(url))
+    const method = (init?.method ?? 'GET').toUpperCase()
+    if (method === 'PUT' && u.pathname === '/kek-fragment') {
+      const body = JSON.parse(init?.body as string) as { encryptedServerHalf: string; iv: string }
+      stored = { encryptedServerHalf: body.encryptedServerHalf, iv: body.iv }
+      putCount += 1
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    }
+    if (method === 'GET' && u.pathname === '/kek-fragment') {
+      if (!stored) return new Response('Not found', { status: 404 })
+      return new Response(JSON.stringify(stored), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response('Not found', { status: 404 })
+  })
+
+  return { mockFetch, getPutCount: () => putCount }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+// ─── Two-partition enrollment ─────────────────────────────────────────────────
+
+describe('two-partition enrollment (one sub, per-device serverHalf entries)', () => {
+  it('each partition gets its own deviceId + deviceSecret; both unlock independently', async () => {
+    const token = makeIdToken()
+    const { mockFetch, entries } = makeDeviceAwareConnector()
+    vi.stubGlobal('fetch', mockFetch)
+
+    // Partition A: first enrollment (e.g. LINE in-app WebView).
+    const storageA = makeStorage()
+    const enrollmentA = await enrollOidc(
+      await makeInviteKeyring('portal-somchai'), 'company-a', TEST_CONFIG, token, { storage: storageA },
+    )
+
+    // Partition B: installed PWA — fresh FIRM re-invite, invite-seeded
+    // keyring, new deviceSecret + deviceId. Same keyring identity, no new
+    // principal.
+    const storageB = makeStorage()
+    const enrollmentB = await enrollOidcFromInvite(
+      await makeInviteKeyring('portal-somchai'), 'company-a', TEST_CONFIG, token, { storage: storageB },
+    )
+
+    expect(enrollmentA.deviceId).toBeTruthy()
+    expect(enrollmentB.deviceId).toBeTruthy()
+    expect(enrollmentA.deviceId).not.toBe(enrollmentB.deviceId)
+    expect(entries.size).toBe(2) // two (sub, deviceId) entries on the connector
+
+    const unlockedA = await unlockOidc(enrollmentA, TEST_CONFIG, token, { storage: storageA })
+    const unlockedB = await unlockOidc(enrollmentB, TEST_CONFIG, token, { storage: storageB })
+    expect(unlockedA.userId).toBe('portal-somchai')
+    expect(unlockedB.userId).toBe('portal-somchai')
+  })
+
+  it('listOidcDevices enumerates both device entries', async () => {
+    const token = makeIdToken()
+    const { mockFetch } = makeDeviceAwareConnector()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const a = await enrollOidc(
+      await makeInviteKeyring('u1'), 'company-a', TEST_CONFIG, token, { storage: makeStorage() },
+    )
+    const b = await enrollOidcFromInvite(
+      await makeInviteKeyring('u1'), 'company-a', TEST_CONFIG, token, { storage: makeStorage() },
+    )
+
+    const devices = await listOidcDevices(TEST_CONFIG, token)
+    const ids = devices.map((d) => d.deviceId).sort()
+    expect(ids).toEqual([a.deviceId, b.deviceId].sort())
+  })
+})
+
+// ─── Independent revocation ───────────────────────────────────────────────────
+
+describe('independent device revocation', () => {
+  it('revoking A makes A fail with re-invite guidance (404); B still unlocks', async () => {
+    const token = makeIdToken()
+    const { mockFetch } = makeDeviceAwareConnector()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const storageA = makeStorage()
+    const storageB = makeStorage()
+    const enrollmentA = await enrollOidc(
+      await makeInviteKeyring('u1'), 'company-a', TEST_CONFIG, token, { storage: storageA },
+    )
+    const enrollmentB = await enrollOidcFromInvite(
+      await makeInviteKeyring('u1'), 'company-a', TEST_CONFIG, token, { storage: storageB },
+    )
+
+    await revokeOidcDevice(TEST_CONFIG, token, enrollmentA.deviceId!)
+
+    // A: fragment gone → 404 mapped to the documented re-invite flow. The
+    // guidance points at the FIRM (custodian) re-invite — never at a
+    // device-to-device handoff.
+    const failure = await unlockOidc(enrollmentA, TEST_CONFIG, token, { storage: storageA })
+      .then(() => null, (e: unknown) => e as KeyConnectorError)
+    expect(failure).toBeInstanceOf(KeyConnectorError)
+    expect(failure!.status).toBe(404)
+    expect(failure!.message).toMatch(/re-invite/i)
+    expect(failure!.message).toMatch(/custodian/i)
+    expect(failure!.message).toMatch(/cannot hand off/i)
+
+    // B is untouched — revocation is per-device.
+    const unlockedB = await unlockOidc(enrollmentB, TEST_CONFIG, token, { storage: storageB })
+    expect(unlockedB.userId).toBe('u1')
+
+    const devices = await listOidcDevices(TEST_CONFIG, token)
+    expect(devices.map((d) => d.deviceId)).toEqual([enrollmentB.deviceId])
+  })
+
+  it('expired token → OidcTokenError from listOidcDevices/revokeOidcDevice BEFORE any network call', async () => {
+    const expired = makeIdToken({ exp: Math.floor(Date.now() / 1000) - 60 })
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+
+    await expect(listOidcDevices(TEST_CONFIG, expired)).rejects.toThrow(OidcTokenError)
+    await expect(revokeOidcDevice(TEST_CONFIG, expired, 'dev-1')).rejects.toThrow(OidcTokenError)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})
+
+// ─── No-self-propagation property ─────────────────────────────────────────────
+
+describe('no self-propagation (firm re-invite is the ONLY new-device path)', () => {
+  it('a fresh partition cannot unlock even with a valid token + live server entries — it fails locally before any network call', async () => {
+    const token = makeIdToken()
+    const { mockFetch } = makeDeviceAwareConnector()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const storageA = makeStorage()
+    const enrollmentA = await enrollOidc(
+      await makeInviteKeyring('u1'), 'company-a', TEST_CONFIG, token, { storage: storageA },
+    )
+    const callsAfterEnroll = mockFetch.mock.calls.length
+
+    // Fresh partition: valid token, knowledge of the enrollment record,
+    // live serverHalf entries for the sub — but NO device secret. The only
+    // way forward is a fresh invite-derived UnlockedKeyring (firm re-invite).
+    const freshPartition = makeStorage()
+    await expect(
+      unlockOidc(enrollmentA, TEST_CONFIG, token, { storage: freshPartition }),
+    ).rejects.toThrow(OidcDeviceSecretNotFoundError)
+    expect(mockFetch.mock.calls.length).toBe(callsAfterEnroll)
+  })
+
+  it('the public API surface has no handoff/mint primitive — enrollment REQUIRES an UnlockedKeyring, which only invite/passphrase paths produce', () => {
+    // Frozen value-export list. Everything that creates a NEW device entry
+    // (enrollOidc / enrollOidcFromInvite) takes an UnlockedKeyring parameter;
+    // the only function RETURNING an UnlockedKeyring is unlockOidc, which
+    // requires this partition's own prior enrollment (device secret). No
+    // export lets an enrolled device mint credentials for another device.
+    const valueExports = Object.keys(api).sort()
+    expect(valueExports).toEqual([
+      'KeyConnectorError',
+      'OidcDeviceSecretNotFoundError',
+      'OidcTokenError',
+      'ValidationError',
+      'enrollOidc',
+      'enrollOidcFromInvite',
+      'isIdTokenExpired',
+      'knownProviders',
+      'listOidcDevices',
+      'parseIdTokenClaims',
+      'revokeOidcDevice',
+      'unlockOidc',
+    ])
+  })
+})
+
+// ─── Backward compatibility (legacy single-entry server) ─────────────────────
+
+describe('backward compat — server that ignores deviceId', () => {
+  it('degrades to last-write-wins: the most recently enrolled partition unlocks', async () => {
+    const token = makeIdToken()
+    const { mockFetch, getPutCount } = makeLegacySingleSlotConnector()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const storageA = makeStorage()
+    const storageB = makeStorage()
+    await enrollOidc(
+      await makeInviteKeyring('u1'), 'company-a', TEST_CONFIG, token, { storage: storageA },
+    )
+    // Second enrollment clobbers the single per-sub slot (documented
+    // degradation of the v1 contract).
+    const enrollmentB = await enrollOidcFromInvite(
+      await makeInviteKeyring('u1'), 'company-a', TEST_CONFIG, token, { storage: storageB },
+    )
+    expect(getPutCount()).toBe(2)
+
+    const unlockedB = await unlockOidc(enrollmentB, TEST_CONFIG, token, { storage: storageB })
+    expect(unlockedB.userId).toBe('u1')
+  })
+
+  it('a legacy enrollment record (no deviceId anywhere) still unlocks', async () => {
+    const token = makeIdToken()
+    const { mockFetch } = makeLegacySingleSlotConnector()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const storage = makeStorage()
+    const enrollment = await enrollOidc(
+      await makeInviteKeyring('u1'), 'company-a', TEST_CONFIG, token, { storage },
+    )
+
+    // Simulate a pre-#805 client's persisted state: enrollment record
+    // without deviceId AND no partition-stored device id.
+    const { deviceId: _dropped, ...legacyFields } = enrollment
+    const legacyEnrollment = legacyFields as OidcEnrollment
+    storage.removeItem(`noydb:oidc:device-id:${enrollment.sub}`)
+
+    const unlocked = await unlockOidc(legacyEnrollment, TEST_CONFIG, token, { storage })
+    expect(unlocked.userId).toBe('u1')
+
+    // The GET went out with no deviceId query — legacy wire shape.
+    const getCall = mockFetch.mock.calls.find(([, init]) =>
+      ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase() === 'GET')
+    expect(String(getCall![0])).toBe('https://kc.example.com/kek-fragment')
+  })
+})

--- a/packages/on-oidc/__tests__/line-liff.test.ts
+++ b/packages/on-oidc/__tests__/line-liff.test.ts
@@ -1,0 +1,274 @@
+/**
+ * #804 — LINE/LIFF hardening tests for @noy-db/on-oidc.
+ *
+ * Uses happy-dom (for localStorage) and a fetch mock for the key-connector
+ * server — no real LINE or network anywhere (CI law).
+ *
+ * Covers:
+ * - `knownProviders.line` vs the real LINE LIFF token contract (issuer,
+ *   channel-scoped aud, ES256 JWKS endpoint)
+ * - A recorded-shape LINE LIFF ID-token FIXTURE (structurally real: correct
+ *   iss/aud/exp/sub layout, ES256 header, fake signature — client-side
+ *   checks are structural only per the package's documented split of
+ *   responsibilities)
+ * - Token lifecycle: expiry surfaces as OidcTokenError BEFORE any network
+ *   call; an unlocked session SURVIVES token expiry
+ * - Invite-seeded enrollment: an invite-sourced UnlockedKeyring (no
+ *   passphrase anywhere, `kek: null`) enrolls and round-trips fine
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  enrollOidc,
+  unlockOidc,
+  parseIdTokenClaims,
+  isIdTokenExpired,
+  knownProviders,
+  OidcTokenError,
+} from '../src/index.js'
+import type { UnlockedKeyring } from '../src/index.js'
+
+// ─── LINE LIFF ID-token fixture ───────────────────────────────────────────────
+//
+// Recorded SHAPE of a LIFF ID token (https://access.line.me issuer):
+//   header  : { alg: 'ES256', typ: 'JWT', kid }        — LINE signs with ES256
+//   payload : { iss, sub: 'U'+32hex, aud: channelId,   — aud IS the LINE Login
+//               exp: iat+3600, iat, amr: ['linesso'],    channel ID (numeric
+//               name, picture, email? }                  string); ~1h lifetime
+//   signature: fake — signature verification is the key-connector server's
+//              job against https://api.line.me/oauth2/v2.1/certs; this
+//              package's client-side checks are structural only.
+
+const LINE_CHANNEL_ID = '1656934047'
+const LINE_SUB = 'U4af4980629abcdef0123456789abcdef'
+
+function b64url(obj: object): string {
+  return btoa(JSON.stringify(obj))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+function makeLineIdToken(overrides: {
+  sub?: string
+  aud?: string
+  iat?: number
+  exp?: number
+} = {}): string {
+  const now = Math.floor(Date.now() / 1000)
+  const header = b64url({ alg: 'ES256', typ: 'JWT', kid: 'a2c4e6f8-line-key-1' })
+  const payload = b64url({
+    iss: 'https://access.line.me',
+    sub: LINE_SUB,
+    aud: LINE_CHANNEL_ID,
+    exp: now + 3600,
+    iat: now,
+    amr: ['linesso'],
+    name: 'Somchai T.',
+    picture: 'https://profile.line-scdn.net/0h4af4980629abcdef',
+    email: 'somchai@example.com',
+    ...overrides,
+  })
+  return `${header}.${payload}.RmFrZUVTMjU2U2lnbmF0dXJl`
+}
+
+// ─── Keyring helpers ──────────────────────────────────────────────────────────
+
+async function makeDek(): Promise<CryptoKey> {
+  return globalThis.crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+/** A passphrase-unlocked keyring (owner session). */
+async function makeKeyring(): Promise<UnlockedKeyring> {
+  const dek = await makeDek()
+  return {
+    userId: 'alice',
+    displayName: 'Alice',
+    role: 'owner',
+    permissions: { invoices: 'rw', clients: 'rw' },
+    deks: new Map([['invoices', dek], ['clients', dek]]),
+    kek: null,
+    salt: new Uint8Array(32).fill(9),
+    authenticators: [],
+  } as unknown as UnlockedKeyring
+}
+
+/**
+ * The shape an INVITE-SEEDED unlocked keyring has: minted by the firm via
+ * `@noy-db/on-magic-link`'s `issueInvite` → recipient's `acceptInvite`.
+ * The portal client NEVER had a passphrase — and the keyring carries no
+ * passphrase-derived KEK (`kek: null`). Only DEKs/salt/identity matter to
+ * enrollment.
+ */
+async function makeInviteSourcedKeyring(): Promise<UnlockedKeyring> {
+  const dek = await makeDek()
+  return {
+    userId: 'portal-client-somchai',
+    displayName: 'Somchai (portal)',
+    role: 'member',
+    permissions: { invoices: 'ro', etax: 'ro' },
+    deks: new Map([['invoices', dek], ['etax', dek]]),
+    kek: null,
+    salt: new Uint8Array(32).fill(3),
+    authenticators: [],
+  } as unknown as UnlockedKeyring
+}
+
+// ─── Key-connector mock (replay: returns PUT ciphertext verbatim on GET) ─────
+
+function makeKeyConnectorMock() {
+  let stored: { encryptedServerHalf: string; iv: string } | null = null
+  return vi.fn(async (_url: string | URL, init?: RequestInit) => {
+    const method = (init?.method ?? 'GET').toUpperCase()
+    if (method === 'PUT') {
+      stored = JSON.parse(init?.body as string)
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    }
+    if (method === 'GET') {
+      if (!stored) return new Response('Not found', { status: 404 })
+      return new Response(JSON.stringify(stored), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response('Method not allowed', { status: 405 })
+  })
+}
+
+const LINE_CONFIG = knownProviders.line(LINE_CHANNEL_ID, 'https://kc.example.com')
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+// ─── knownProviders.line vs the LIFF contract ────────────────────────────────
+
+describe('knownProviders.line — LIFF contract', () => {
+  it('matches LINE\'s real endpoints (issuer, authorize, token, JWKS)', () => {
+    expect(LINE_CONFIG.issuer).toBe('https://access.line.me')
+    expect(LINE_CONFIG.authorizationEndpoint).toBe('https://access.line.me/oauth2/v2.1/authorize')
+    expect(LINE_CONFIG.tokenEndpoint).toBe('https://api.line.me/oauth2/v2.1/token')
+    expect(LINE_CONFIG.jwksUri).toBe('https://api.line.me/oauth2/v2.1/certs')
+  })
+
+  it('clientId is the channel ID — LIFF tokens carry it as aud', () => {
+    expect(LINE_CONFIG.clientId).toBe(LINE_CHANNEL_ID)
+    const claims = parseIdTokenClaims(makeLineIdToken())
+    expect(claims.aud).toBe(LINE_CONFIG.clientId)
+  })
+})
+
+// ─── Recorded-shape fixture parsing ──────────────────────────────────────────
+
+describe('LINE LIFF ID-token fixture', () => {
+  it('parseIdTokenClaims extracts the LIFF claim layout', () => {
+    const claims = parseIdTokenClaims(makeLineIdToken())
+    expect(claims.iss).toBe('https://access.line.me')
+    expect(claims.sub).toBe(LINE_SUB)
+    expect(claims.aud).toBe(LINE_CHANNEL_ID)
+    expect(claims.exp - claims.iat).toBe(3600) // ~1h lifetime, no silent refresh
+    expect(claims.email).toBe('somchai@example.com')
+  })
+
+  it('enroll + unlock round-trips with the LINE fixture token', async () => {
+    const keyring = await makeKeyring()
+    const token = makeLineIdToken()
+    vi.stubGlobal('fetch', makeKeyConnectorMock())
+
+    const enrollment = await enrollOidc(keyring, 'company-a', LINE_CONFIG, token)
+    expect(enrollment.sub).toBe(LINE_SUB)
+    expect(enrollment.providerName).toBe('LINE')
+
+    const unlocked = await unlockOidc(enrollment, LINE_CONFIG, token)
+    expect(unlocked.userId).toBe('alice')
+    expect(unlocked.deks.size).toBe(2)
+  })
+})
+
+// ─── Token lifecycle ─────────────────────────────────────────────────────────
+
+describe('token lifecycle (LIFF ~1h expiry, no silent refresh)', () => {
+  it('expired token → OidcTokenError from enrollOidc BEFORE any network call', async () => {
+    const keyring = await makeKeyring()
+    const expired = makeLineIdToken({ exp: Math.floor(Date.now() / 1000) - 60 })
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+
+    await expect(
+      enrollOidc(keyring, 'company-a', LINE_CONFIG, expired),
+    ).rejects.toThrow(OidcTokenError)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('expired token → OidcTokenError from unlockOidc BEFORE any network call', async () => {
+    const keyring = await makeKeyring()
+    const token = makeLineIdToken()
+    vi.stubGlobal('fetch', makeKeyConnectorMock())
+    const enrollment = await enrollOidc(keyring, 'company-a', LINE_CONFIG, token)
+
+    const mockFetch = vi.fn()
+    vi.stubGlobal('fetch', mockFetch)
+    const expired = makeLineIdToken({ exp: Math.floor(Date.now() / 1000) - 60 })
+    await expect(
+      unlockOidc(enrollment, LINE_CONFIG, expired),
+    ).rejects.toThrow(OidcTokenError)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('an unlocked session SURVIVES token expiry — the token is only needed at serverHalf-fetch time', async () => {
+    const keyring = await makeKeyring()
+    const token = makeLineIdToken()
+    const mockFetch = makeKeyConnectorMock()
+    vi.stubGlobal('fetch', mockFetch)
+
+    const enrollment = await enrollOidc(keyring, 'company-a', LINE_CONFIG, token)
+    const unlocked = await unlockOidc(enrollment, LINE_CONFIG, token)
+    const callsAtUnlock = mockFetch.mock.calls.length
+
+    // Two hours pass — the LIFF token is now well past its ~1h exp.
+    const later = Date.now() + 2 * 3600 * 1000
+    vi.spyOn(Date, 'now').mockReturnValue(later)
+    expect(isIdTokenExpired(token)).toBe(true)
+
+    // The session keeps working: DEKs stay usable, nothing re-checks the
+    // token, nothing phones the key-connector again.
+    const dek = unlocked.deks.get('invoices')!
+    const iv = globalThis.crypto.getRandomValues(new Uint8Array(12))
+    const pt = new TextEncoder().encode('post-expiry-write')
+    const ct = await globalThis.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, dek, pt)
+    const rt = await globalThis.crypto.subtle.decrypt({ name: 'AES-GCM', iv }, dek, ct)
+    expect(new TextDecoder().decode(rt)).toBe('post-expiry-write')
+    expect(mockFetch.mock.calls.length).toBe(callsAtUnlock)
+  })
+})
+
+// ─── Invite-seeded enrollment (portal client has NO passphrase) ──────────────
+
+describe('invite-seeded enrollment', () => {
+  it('an invite-sourced UnlockedKeyring (kek: null) enrolls and round-trips', async () => {
+    const keyring = await makeInviteSourcedKeyring()
+    const token = makeLineIdToken()
+    vi.stubGlobal('fetch', makeKeyConnectorMock())
+
+    // The KEK material arrived via the firm's magic-link invite
+    // (acceptInvite → UnlockedKeyring) — enrollOidc binds the LINE sub to
+    // it without ever seeing a passphrase.
+    const enrollment = await enrollOidc(keyring, 'company-a', LINE_CONFIG, token)
+    expect(enrollment.sub).toBe(LINE_SUB)
+
+    const unlocked = await unlockOidc(enrollment, LINE_CONFIG, token)
+    expect(unlocked.userId).toBe('portal-client-somchai')
+    expect(unlocked.role).toBe('member')
+    expect(unlocked.permissions).toEqual({ invoices: 'ro', etax: 'ro' })
+    expect(unlocked.deks.has('etax')).toBe(true)
+  })
+})

--- a/packages/on-oidc/src/index.ts
+++ b/packages/on-oidc/src/index.ts
@@ -14,23 +14,65 @@
  *   serverHalf ⊕ deviceHalf = KEK
  *
  * At enrollment time:
- *   1. The full KEK is available (user is authenticated via passphrase).
+ *   1. The full key material is available — the caller holds an
+ *      `UnlockedKeyring`. HOW it was unlocked does not matter: a
+ *      passphrase-derived session works, and so does an invite-seeded one
+ *      (the firm mints a magic-link invite via `@noy-db/on-magic-link`'s
+ *      `issueInvite`; the recipient's `acceptInvite` yields the unlocked
+ *      session — the portal client never has a passphrase of its own).
  *   2. `deviceHalf` is derived: HKDF(deviceSecret, "noydb-oidc-device-v1", sub)
  *      where `deviceSecret` is a per-device random value stored in IndexedDB
- *      or localStorage (never transmitted).
+ *      or localStorage (never transmitted). A stable random `deviceId` is
+ *      generated beside it and stored with it — it identifies THIS
+ *      partition's entry on the key-connector.
  *   3. `serverHalf = KEK ⊕ deviceHalf`.
  *   4. `serverHalf` is encrypted with the OIDC access token and sent to the
- *      key-connector server endpoint. The server stores it indexed by `sub`
- *      (the OIDC subject claim).
+ *      key-connector server endpoint. The server stores it indexed by
+ *      `(sub, deviceId)` — one entry per enrolled device/partition.
  *   5. The server NEVER sees the KEK — only serverHalf, encrypted.
  *
  * At unlock time:
  *   1. User completes OIDC flow → gets an ID token with `sub` claim.
- *   2. Client presents the ID token to the key-connector server.
+ *   2. Client presents the ID token (+ its `deviceId`) to the key-connector.
  *   3. Server verifies the ID token, decrypts and returns `serverHalf`.
  *   4. Client derives `deviceHalf` (same HKDF, same deviceSecret).
  *   5. Client reconstructs `KEK = serverHalf ⊕ deviceHalf`.
  *   6. Client derives DEKs from the keyring file using the reconstructed KEK.
+ *
+ * Token lifecycle (LIFF and friends)
+ * ──────────────────────────────────
+ * OIDC ID tokens are short-lived — LINE LIFF ID tokens expire after ~1 hour
+ * and LIFF has NO silent refresh. Two rules keep that livable:
+ *
+ *   - Expiry is checked CLIENT-SIDE, BEFORE any network call: an expired
+ *     token surfaces as the typed `OidcTokenError` from `enrollOidc`,
+ *     `unlockOidc`, `listOidcDevices`, and `revokeOidcDevice`. Apps map it
+ *     to a re-auth prompt (`liff.login()` on LINE).
+ *   - **An unlocked session survives token expiry.** The ID token is needed
+ *     exactly once — at serverHalf fetch (or PUT) time. The returned
+ *     `UnlockedKeyring` holds DEKs only; nothing in this package retains or
+ *     re-checks the token after unlock. Mid-session expiry never tears down
+ *     the session — only the NEXT connector call needs a fresh token.
+ *
+ * Multi-device enrollment — firm re-invite ONLY
+ * ─────────────────────────────────────────────
+ * deviceHalf is partition-local by design (LINE in-app WebView, external
+ * browser, and installed PWA all have isolated storage). A new partition or
+ * device therefore ALWAYS needs the key material once — and the ONLY way to
+ * deliver it is a fresh custodian (firm) invite: invite-seeded unlock →
+ * `enrollOidcFromInvite` → new deviceSecret + deviceId + serverHalf entry.
+ *
+ * Device-to-device handoff (QR / one-time code minted by an enrolled
+ * device) is deliberately NOT offered: a compromised client device could
+ * mint handoffs and silently escalate one device compromise into persistent
+ * multi-device access. Round-tripping through the firm makes every new
+ * partition an audit point, a rate-limit point, and a revocation point —
+ * client-device compromise cannot self-propagate. Enrollment REQUIRES an
+ * `UnlockedKeyring`, which only the invite and passphrase paths produce;
+ * an enrolled device holds DEKs but no primitive to mint one for a peer.
+ * Expired/consumed/revoked invites fail in `@noy-db/on-magic-link`'s
+ * `acceptInvite` (InviteExpiredError / InviteAlreadyAcceptedError /
+ * InviteRevokedError) before this package is ever reached.
  *
  * Security properties:
  *   - Compromise of the OIDC provider (stolen tokens): attacker has the
@@ -46,14 +88,53 @@
  *
  * Key-connector server contract
  * ──────────────────────────────
- * This package handles the CLIENT side only. The server must:
- *   1. Expose a `PUT /kek-fragment` endpoint that accepts:
- *      `{ idToken, encryptedServerHalf, iv }` and stores the decrypted
- *      serverHalf indexed by the `sub` from the verified ID token.
- *   2. Expose a `GET /kek-fragment` endpoint that accepts a Bearer ID token,
- *      verifies it, and returns the encrypted `{ serverHalf, iv }` for that `sub`.
- *   3. Rotate the encryption key used for serverHalf periodically, with
+ * This package handles the CLIENT side only. Entries are keyed by
+ * `(sub, deviceId)` — one serverHalf fragment per enrolled device. The
+ * server must:
+ *   1. Expose a `PUT /kek-fragment` endpoint (Bearer ID token) that accepts
+ *      `{ encryptedServerHalf, iv, deviceId? }` and stores the decrypted
+ *      serverHalf indexed by `(sub, deviceId)` where `sub` comes from the
+ *      VERIFIED ID token (never from the body).
+ *   2. Expose a `GET /kek-fragment?deviceId=<id>` endpoint (Bearer ID token)
+ *      that verifies the token and returns the encrypted
+ *      `{ encryptedServerHalf, iv }` for that `(sub, deviceId)`.
+ *   3. Expose a `GET /kek-fragment/devices` endpoint (Bearer ID token) that
+ *      returns `{ devices: [{ deviceId, createdAt? }] }` — every fragment
+ *      entry for the token's `sub`. Feeds the firm-side device-management UI.
+ *   4. Expose a `DELETE /kek-fragment?deviceId=<id>` endpoint (Bearer ID
+ *      token) that removes ONE `(sub, deviceId)` entry — individual device
+ *      revocation. Idempotent.
+ *   5. Rotate the encryption key used for serverHalf periodically, with
  *      re-encryption at login time (beyond NOYDB's scope).
+ *
+ * Backward compatibility: a v1 server that IGNORES `deviceId` still works —
+ * it degrades to a single entry per `sub` with last-write-wins semantics
+ * (enrolling a second device clobbers the first device's fragment; only the
+ * most recently enrolled partition can unlock). Clients built before the
+ * per-device contract send no `deviceId`; servers should treat that as the
+ * single-entry legacy key for the `sub`.
+ *
+ * Error taxonomy (client sees these as `KeyConnectorError.status`):
+ *   - `401` — ID-token verification failed (expired server-side, bad
+ *     signature, wrong `iss`/`aud`) → the app re-authenticates
+ *     (`liff.login()` on LINE) and retries.
+ *   - `404` — no fragment for this `(sub, deviceId)` → the device was
+ *     revoked or never enrolled. Recovery is a fresh FIRM re-invite +
+ *     `enrollOidcFromInvite`; there is no self-service or device-to-device
+ *     recovery path by design.
+ *   - `5xx` — server-side fault → retry with backoff; nothing is wrong with
+ *     the enrollment.
+ *
+ * LINE-specific server verification (LIFF ID tokens):
+ *   - Verify `iss === 'https://access.line.me'` and `alg === 'ES256'`.
+ *   - Verify `aud` equals YOUR LINE Login channel ID (LIFF ID tokens are
+ *     channel-scoped; `aud` is the numeric channel ID as a string).
+ *   - Fetch keys from the JWKS endpoint
+ *     `https://api.line.me/oauth2/v2.1/certs`, select by the token's `kid`,
+ *     and CACHE the JWKS (respect HTTP cache headers; re-fetch on unknown
+ *     `kid` to pick up rotation).
+ *   - Allow a small clock skew (±60 s is customary) when checking
+ *     `exp`/`iat` — LIFF tokens are minted on LINE's clock, not yours.
  *
  * Provider configuration
  * ──────────────────────
@@ -62,7 +143,7 @@
  * for common providers (LINE, Google, Apple).
  */
 
-import { bufferToBase64, base64ToBuffer } from '@noy-db/hub'
+import { bufferToBase64, base64ToBuffer, generateULID } from '@noy-db/hub'
 import { ValidationError } from '@noy-db/hub'
 import type { UnlockedKeyring, Role } from '@noy-db/hub'
 
@@ -91,9 +172,15 @@ export class OidcTokenError extends Error {
  * Thrown when the key-connector server returns an error response.
  *
  * The `status` field carries the HTTP status code when available — use it
- * to distinguish 401 Unauthorized (bad token, re-authenticate) from 404
- * (no key fragment stored for this sub, must re-enroll) and 5xx
- * (server-side error, retry).
+ * to distinguish 401 Unauthorized (token failed server-side verification —
+ * re-authenticate, e.g. `liff.login()` on LINE, and retry) from 404 (no key
+ * fragment stored for this `(sub, deviceId)` — the device was revoked or
+ * never enrolled; recovery is a fresh firm re-invite + enrollment, see
+ * `enrollOidcFromInvite`) and 5xx (server-side error, retry with backoff).
+ *
+ * A failed `fetch` itself (offline, DNS, CORS) rejects with the runtime's
+ * own `TypeError` — enrollment and device management are online-only
+ * ceremonies; callers should gate them on connectivity.
  */
 export class KeyConnectorError extends Error {
   readonly code = 'KEY_CONNECTOR_ERROR'
@@ -110,11 +197,13 @@ export class KeyConnectorError extends Error {
  * Thrown by `unlockOidc()` when the per-device secret for the OIDC subject
  * cannot be found in browser storage.
  *
- * The device secret is generated once at `enrollOidc()` time and stored in
+ * The device secret is generated once at enrollment time and stored in
  * IndexedDB/localStorage on the enrolling device — it is never transmitted.
  * This error means the device secret was cleared (storage wipe, private
- * browsing session, new device) and the user must re-enroll using their
- * passphrase.
+ * browsing session, new device/partition) and this partition must be
+ * enrolled afresh — via a new firm invite (`enrollOidcFromInvite`) or, where
+ * the user holds one, a passphrase-unlocked `enrollOidc`. There is no
+ * device-to-device recovery path by design.
  */
 export class OidcDeviceSecretNotFoundError extends Error {
   readonly code = 'OIDC_DEVICE_SECRET_NOT_FOUND'
@@ -122,7 +211,8 @@ export class OidcDeviceSecretNotFoundError extends Error {
     super(
       `No device secret found for OIDC subject "${sub}". ` +
       'The device secret is generated at enrollment and stored in browser storage. ' +
-      'Re-enroll on this device to restore OIDC unlock.',
+      'Request a fresh enrollment invite from the vault custodian (firm re-invite) ' +
+      'to enroll this device — enrolled devices cannot hand off credentials to it.',
     )
     this.name = 'OidcDeviceSecretNotFoundError'
   }
@@ -144,6 +234,13 @@ export interface OidcProviderConfig {
   readonly authorizationEndpoint?: string
   /** Token endpoint URL. If omitted, discovered from issuer's .well-known. */
   readonly tokenEndpoint?: string
+  /**
+   * JWKS endpoint URL for ID-token signature verification (performed by the
+   * KEY-CONNECTOR SERVER, never client-side — this package's checks are
+   * structural only). If omitted, discovered from the issuer's .well-known.
+   * LINE publishes ES256 keys at `https://api.line.me/oauth2/v2.1/certs`.
+   */
+  readonly jwksUri?: string
   /**
    * Base URL of the noy-db key-connector server.
    * Must expose `PUT /kek-fragment` and `GET /kek-fragment`.
@@ -169,6 +266,23 @@ export interface OidcEnrollment {
   readonly deviceKeyId: string
   /** Number of active enrollments for this sub (for key rotation auditing). */
   readonly enrollmentCount: number
+  /**
+   * Stable per-partition device id (ULID). Generated beside the device
+   * secret at enrollment, stored with it, and sent with every key-connector
+   * PUT/GET so the server can key fragments by `(sub, deviceId)`. Absent on
+   * enrollment records created before the per-device contract — unlock then
+   * falls back to the partition-stored device id, or omits `deviceId`
+   * entirely (legacy single-entry server contract).
+   */
+  readonly deviceId?: string
+}
+
+/** One per-device serverHalf entry, as listed by `listOidcDevices()`. */
+export interface OidcDeviceEntry {
+  /** The `(sub, deviceId)` key's device component. */
+  readonly deviceId: string
+  /** ISO timestamp of the entry's creation, when the server records it. */
+  readonly createdAt?: string
 }
 
 /** Minimal JWT claims we need from an OIDC ID token. */
@@ -197,6 +311,7 @@ export interface UnlockOidcOptions {
 // ─── Device secret management ─────────────────────────────────────────
 
 const DEVICE_SECRET_PREFIX = 'noydb:oidc:device-secret:'
+const DEVICE_ID_PREFIX = 'noydb:oidc:device-id:'
 
 function getDeviceSecret(sub: string, storage?: Storage): Uint8Array | null {
   const store = storage ?? (typeof localStorage !== 'undefined' ? localStorage : null)
@@ -210,6 +325,18 @@ function saveDeviceSecret(sub: string, secret: Uint8Array, storage?: Storage): v
   const store = storage ?? (typeof localStorage !== 'undefined' ? localStorage : null)
   if (!store) throw new ValidationError('localStorage is not available in this environment')
   store.setItem(DEVICE_SECRET_PREFIX + sub, bufferToBase64(secret))
+}
+
+function getStoredDeviceId(sub: string, storage?: Storage): string | null {
+  const store = storage ?? (typeof localStorage !== 'undefined' ? localStorage : null)
+  if (!store) return null
+  return store.getItem(DEVICE_ID_PREFIX + sub)
+}
+
+function saveDeviceId(sub: string, deviceId: string, storage?: Storage): void {
+  const store = storage ?? (typeof localStorage !== 'undefined' ? localStorage : null)
+  if (!store) throw new ValidationError('localStorage is not available in this environment')
+  store.setItem(DEVICE_ID_PREFIX + sub, deviceId)
 }
 
 // ─── HKDF device half derivation ──────────────────────────────────────
@@ -290,6 +417,7 @@ async function putServerHalf(
   idToken: string,
   serverHalfBase64: string,
   ivBase64: string,
+  deviceId?: string,
 ): Promise<void> {
   const resp = await fetch(`${keyConnectorUrl}/kek-fragment`, {
     method: 'PUT',
@@ -297,7 +425,11 @@ async function putServerHalf(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${idToken}`,
     },
-    body: JSON.stringify({ encryptedServerHalf: serverHalfBase64, iv: ivBase64 }),
+    body: JSON.stringify({
+      encryptedServerHalf: serverHalfBase64,
+      iv: ivBase64,
+      ...(deviceId !== undefined && { deviceId }),
+    }),
   })
   if (!resp.ok) {
     throw new KeyConnectorError(
@@ -310,12 +442,23 @@ async function putServerHalf(
 async function getServerHalf(
   keyConnectorUrl: string,
   idToken: string,
+  deviceId?: string,
 ): Promise<{ encryptedServerHalf: string; iv: string }> {
-  const resp = await fetch(`${keyConnectorUrl}/kek-fragment`, {
+  const query = deviceId !== undefined ? `?deviceId=${encodeURIComponent(deviceId)}` : ''
+  const resp = await fetch(`${keyConnectorUrl}/kek-fragment${query}`, {
     method: 'GET',
     headers: { Authorization: `Bearer ${idToken}` },
   })
   if (!resp.ok) {
+    if (resp.status === 404) {
+      throw new KeyConnectorError(
+        'Key connector GET failed: 404 — no key fragment stored for this subject/device. ' +
+        'The device was revoked or was never enrolled. Request a fresh enrollment invite ' +
+        'from the vault custodian (firm re-invite) and enroll this device again — ' +
+        'enrolled devices cannot hand off or restore credentials for another device.',
+        404,
+      )
+    }
     throw new KeyConnectorError(
       `Key connector GET failed: ${resp.status} ${resp.statusText}`,
       resp.status,
@@ -329,16 +472,23 @@ async function getServerHalf(
 /**
  * Enroll a device for OIDC unlock (client-side portion).
  *
- * Requires an unlocked keyring (user is already authenticated) and a valid
- * OIDC ID token. Derives the device half, XOR-splits the serialized keyring
- * payload, encrypts the server half with the ID token, and sends it to the
- * key-connector server.
+ * Requires an unlocked keyring and a valid OIDC ID token. HOW the keyring
+ * was unlocked is irrelevant — a passphrase session works, and so does an
+ * invite-seeded one (`@noy-db/on-magic-link`'s `acceptInvite` on a firm
+ * invite; the portal client never holds a passphrase). Only the keyring's
+ * DEKs/salt/identity are read; `keyring.kek` may be `null`.
+ *
+ * Derives the device half, XOR-splits the serialized keyring payload,
+ * encrypts the server half with the ID token, and sends it to the
+ * key-connector server. A fresh `deviceSecret` AND a fresh `deviceId` are
+ * generated for THIS partition — enrolling never reuses or transfers
+ * another device's material.
  *
  * Returns an `OidcEnrollment` that should be stored (e.g. in localStorage
  * or a noy-db collection) so `unlockOidc()` can look up the `sub` and
- * `deviceKeyId` later.
+ * `deviceId` later.
  *
- * @param keyring - The currently unlocked keyring.
+ * @param keyring - The currently unlocked keyring (passphrase- or invite-sourced).
  * @param vault - The vault to enroll for.
  * @param config - OIDC provider + key-connector configuration.
  * @param idToken - A valid OIDC ID token from the completed OIDC flow.
@@ -374,10 +524,12 @@ export async function enrollOidc(
   })
   const payloadBytes = new TextEncoder().encode(payloadJson)
 
-  // Generate a device secret and derive the device half
+  // Generate a device secret + stable per-partition device id, derive the device half
   const deviceSecret = globalThis.crypto.getRandomValues(new Uint8Array(32))
   const deviceKeyId = bufferToBase64(globalThis.crypto.getRandomValues(new Uint8Array(16)))
+  const deviceId = generateULID()
   saveDeviceSecret(claims.sub, deviceSecret, options.storage)
+  saveDeviceId(claims.sub, deviceId, options.storage)
 
   // Pad payload to the next 16-byte boundary to avoid leaking length
   const padLen = (16 - (payloadBytes.length % 16)) % 16
@@ -402,6 +554,7 @@ export async function enrollOidc(
     idToken,
     bufferToBase64(encryptedServerHalf),
     bufferToBase64(iv),
+    deviceId,
   )
 
   return {
@@ -412,15 +565,70 @@ export async function enrollOidc(
     enrolledAt: new Date().toISOString(),
     deviceKeyId,
     enrollmentCount: 1,
+    deviceId,
   }
+}
+
+/**
+ * Enroll THIS partition after an invite-seeded unlock — the second-device /
+ * second-partition (re-invite) ceremony.
+ *
+ * The flow: the firm mints a fresh single-use invite bound to the SAME
+ * keyring identity (`@noy-db/on-magic-link`'s `issueInvite` semantics —
+ * rebind, don't re-grant; no new principal, same slots/roles/user-envelope),
+ * the new partition accepts it (`acceptInvite` — expired / revoked /
+ * already-consumed invites fail THERE with its typed errors before this
+ * function is ever reached), and the resulting unlocked keyring is passed
+ * here. A fresh `deviceSecret` + `deviceId` are generated for this
+ * partition and a NEW `(sub, deviceId)` serverHalf entry is written —
+ * existing device entries are untouched (enrolling a new partition never
+ * auto-revokes old ones; revocation is a separate firm-side
+ * `revokeOidcDevice` call).
+ *
+ * This is deliberately the ONLY way to add a device: enrollment requires an
+ * `UnlockedKeyring`, which only the invite and passphrase paths produce.
+ * An enrolled device cannot mint one for a peer — no device-to-device
+ * handoff exists, so client-device compromise cannot self-propagate.
+ *
+ * Functionally identical to `enrollOidc` (which is keyring-source-agnostic);
+ * exported under the ceremony's own name so call sites document intent.
+ *
+ * @param keyring - The invite-derived unlocked keyring from `acceptInvite`.
+ * @param vault - The vault to enroll for.
+ * @param config - OIDC provider + key-connector configuration.
+ * @param idToken - A valid OIDC ID token from the completed OIDC flow.
+ * @param options - Optional storage override.
+ */
+export async function enrollOidcFromInvite(
+  keyring: UnlockedKeyring,
+  vault: string,
+  config: OidcProviderConfig,
+  idToken: string,
+  options: EnrollOidcOptions = {},
+): Promise<OidcEnrollment> {
+  return enrollOidc(keyring, vault, config, idToken, options)
 }
 
 /**
  * Unlock a vault using OIDC (client-side portion).
  *
- * Fetches the server half from the key-connector server, derives the device
- * half from the local device secret, XORs them to reconstruct the keyring
- * payload, and returns an UnlockedKeyring.
+ * Fetches the server half from the key-connector server (keyed by this
+ * partition's `deviceId`), derives the device half from the local device
+ * secret, XORs them to reconstruct the keyring payload, and returns an
+ * UnlockedKeyring.
+ *
+ * Token lifecycle: the ID token is used exactly ONCE — for the serverHalf
+ * fetch. An expired token fails fast with `OidcTokenError` BEFORE any
+ * network call (map it to re-auth, e.g. `liff.login()`). The returned
+ * session SURVIVES later token expiry: nothing retains or re-checks the
+ * token after unlock, so a LIFF token expiring ~1h into the session never
+ * tears the session down — only the next connector call needs a fresh one.
+ *
+ * A 404 from the connector means no fragment exists for this
+ * `(sub, deviceId)` — the device was revoked or never enrolled. It surfaces
+ * as `KeyConnectorError` (status 404) whose message points at the firm
+ * re-invite flow (`enrollOidcFromInvite`); there is no self-service or
+ * device-to-device recovery path.
  *
  * @param enrollment - The enrollment record from `enrollOidc()`.
  * @param config - OIDC provider + key-connector configuration.
@@ -445,8 +653,18 @@ export async function unlockOidc(
     throw new OidcDeviceSecretNotFoundError(sub)
   }
 
+  // Resolve this partition's device id: the enrollment record carries it;
+  // fall back to the partition-local stored copy. Both absent = legacy
+  // (pre-per-device) enrollment — the GET goes out without deviceId and a
+  // legacy single-entry server still resolves it by `sub` alone.
+  const deviceId = enrollment.deviceId ?? getStoredDeviceId(sub, options.storage) ?? undefined
+
   // Fetch the server half from the key-connector
-  const { encryptedServerHalf, iv: ivBase64 } = await getServerHalf(config.keyConnectorUrl, idToken)
+  const { encryptedServerHalf, iv: ivBase64 } = await getServerHalf(
+    config.keyConnectorUrl,
+    idToken,
+    deviceId,
+  )
 
   // Decrypt the server half using the ID token
   const tokenKey = await deriveKeyFromIdToken(idToken)
@@ -501,6 +719,77 @@ export async function unlockOidc(
   }
 }
 
+// ─── Device management ─────────────────────────────────────────────────
+
+/**
+ * List every per-device serverHalf entry the key-connector holds for the
+ * ID token's `sub` (`GET /kek-fragment/devices`).
+ *
+ * Feeds the firm-side device-management UI: show the user's enrolled
+ * partitions, then revoke stale ones individually via `revokeOidcDevice()`.
+ *
+ * @throws {OidcTokenError} when the ID token is expired (checked BEFORE any
+ *         network call — re-authenticate first).
+ * @throws {KeyConnectorError} on any non-2xx connector response (`status`
+ *         carries the HTTP code: 401 re-auth, 5xx retry).
+ */
+export async function listOidcDevices(
+  config: OidcProviderConfig,
+  idToken: string,
+): Promise<OidcDeviceEntry[]> {
+  if (isIdTokenExpired(idToken)) {
+    throw new OidcTokenError('ID token is expired. Complete a fresh OIDC flow before listing devices.')
+  }
+  const resp = await fetch(`${config.keyConnectorUrl}/kek-fragment/devices`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${idToken}` },
+  })
+  if (!resp.ok) {
+    throw new KeyConnectorError(
+      `Key connector device list failed: ${resp.status} ${resp.statusText}`,
+      resp.status,
+    )
+  }
+  const body = await resp.json() as { devices?: OidcDeviceEntry[] }
+  return body.devices ?? []
+}
+
+/**
+ * Revoke ONE per-device serverHalf entry for the ID token's `sub`
+ * (`DELETE /kek-fragment?deviceId=<id>`).
+ *
+ * After revocation, that partition's next `unlockOidc()` gets a 404 —
+ * mapped to a `KeyConnectorError` whose message directs the user to the
+ * firm re-invite flow. Other devices' entries are untouched: revocation is
+ * per-device, never account-wide.
+ *
+ * @throws {OidcTokenError} when the ID token is expired (checked BEFORE any
+ *         network call — re-authenticate first).
+ * @throws {KeyConnectorError} on any non-2xx connector response.
+ */
+export async function revokeOidcDevice(
+  config: OidcProviderConfig,
+  idToken: string,
+  deviceId: string,
+): Promise<void> {
+  if (isIdTokenExpired(idToken)) {
+    throw new OidcTokenError('ID token is expired. Complete a fresh OIDC flow before revoking a device.')
+  }
+  const resp = await fetch(
+    `${config.keyConnectorUrl}/kek-fragment?deviceId=${encodeURIComponent(deviceId)}`,
+    {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${idToken}` },
+    },
+  )
+  if (!resp.ok) {
+    throw new KeyConnectorError(
+      `Key connector device revoke failed: ${resp.status} ${resp.statusText}`,
+      resp.status,
+    )
+  }
+}
+
 // ─── Known provider configs ────────────────────────────────────────────
 
 /**
@@ -508,6 +797,18 @@ export async function unlockOidc(
  * Pass your client ID and key-connector URL to get a complete config.
  */
 export const knownProviders = {
+  /**
+   * LINE Login / LIFF.
+   *
+   * `clientId` is the LINE Login CHANNEL ID (numeric, as a string) — LIFF
+   * ID tokens are channel-scoped and carry it as their `aud` claim. Tokens
+   * are ES256-signed (`iss: 'https://access.line.me'`); the key-connector
+   * server verifies signatures against the JWKS at
+   * `https://api.line.me/oauth2/v2.1/certs` (see the contract block above
+   * for cache/skew guidance). LIFF ID tokens expire after ~1 hour with no
+   * silent refresh — expired tokens surface client-side as `OidcTokenError`
+   * before any network call; map that to `liff.login()`.
+   */
   line: (clientId: string, keyConnectorUrl: string): OidcProviderConfig => ({
     name: 'LINE',
     issuer: 'https://access.line.me',
@@ -515,6 +816,7 @@ export const knownProviders = {
     scopes: ['openid', 'profile', 'email'],
     authorizationEndpoint: 'https://access.line.me/oauth2/v2.1/authorize',
     tokenEndpoint: 'https://api.line.me/oauth2/v2.1/token',
+    jwksUri: 'https://api.line.me/oauth2/v2.1/certs',
     keyConnectorUrl,
   }),
   google: (clientId: string, keyConnectorUrl: string): OidcProviderConfig => ({


### PR DESCRIPTION
Closes #804. Closes #805. Milestone: LINE/LIFF client portal [api].

## What — the portal's identity bridge, hardened

**#804 (LINE/LIFF):**
- `knownProviders.line` completed (issuer, channel-`aud`, ES256, JWKS URI) and pinned by a structurally-real LIFF token fixture test.
- Token lifecycle: expiry → typed `OidcTokenError` before any network call; **an unlocked session survives token expiry** (the ID token is consumed exactly once, at serverHalf fetch) — verified no path re-checks it.
- **Invite-seeded enrollment is first-class**: the portal client never has a passphrase; enrollment takes any `UnlockedKeyring` (invite- or passphrase-sourced), documented + tested.
- Protocol block gains LINE-specific server verification notes (JWKS cache/kid rotation, `aud`=channel, ±60s skew) and aligns the 401/404/5xx prose with `KeyConnectorError` as shipped.

**#805 (second device — firm re-invite ONLY):**
- Key-connector contract: `(sub, deviceId)` fragment entries (ULID minted beside the deviceSecret), with documented last-write-wins degradation on deviceId-ignoring v1 servers.
- `enrollOidcFromInvite(keyring, vault, config, idToken)` — the rebind ceremony: same keyring identity, no new principal.
- `listOidcDevices` / `revokeOidcDevice` + two new contract endpoints (`GET /kek-fragment/devices`, `DELETE /kek-fragment?deviceId=`, idempotent).
- **No-self-propagation, asserted twice**: runtime (a fresh partition with a valid token + live server entries still fails closed before any fetch — enrollment requires an `UnlockedKeyring` only invite/passphrase paths produce) and a frozen export snapshot proving no handoff/mint primitive exists. Revoked-device unlock guidance points to the custodian re-invite, never a self-restore.

## Verification

on-oidc: **37 tests pass** (21 pre-existing + 8 LINE + 8 device), build (ESM+DTS), typecheck, lint clean · `check:architecture` ✓ · knip zero on-oidc findings · hub untouched. Changesets: 2× `@noy-db/on-oidc` minor.

Note: the auth-landscape doc rows for re-invite-only multi-device live in noy-db-docs (tracked there in noy-db-docs#121).
