### PR TITLE
feat(on-pin): device-trust unlock mode — "always open on this device" (#801)

### DIFF
--- a/packages/on-pin/README.md
+++ b/packages/on-pin/README.md
@@ -16,6 +16,45 @@ pnpm add @noy-db/hub @noy-db/on-pin
 
 Session-resume PIN quick-lock for noy-db — after a full passphrase unlock, a short-lived PIN (or a per-device biometric) re-unlocks the cached DEKs without re-typing the passphrase. PIN never replaces the passphrase; only resumes an already-unlocked session.
 
+## Device-trust mode — "always safe to open on this device"
+
+The package's second session-resume mode: the session DEKs are wrapped under a
+**non-extractable, device-bound `crypto.subtle` key** persisted in IndexedDB
+(as a CryptoKey *object*, via structured clone — its raw bits never exist in
+JS), so the vault reopens on this device with **no user factor at all**. No
+network, no prompt.
+
+```ts
+import { enrollDeviceTrust, resumeDeviceTrust } from '@noy-db/on-pin'
+
+// After a real-factor unlock (passphrase, invite, OIDC) — never cold:
+await enrollDeviceTrust(keyring, { vault: 'main', policy: await db.policy.getPolicy('main') })
+
+// On the next cold start of this device:
+const { keyring, resumeTier } = await resumeDeviceTrust('main')
+// resumeTier is 3 by default — pass it to checkGate as the session's activeTier.
+```
+
+**Threat model — read before enabling.** This is a deliberate, opt-in trade:
+
+- **The OS lock screen IS the factor.** Anyone holding the unlocked device
+  opens the vault. Intended for mobile/embedded contexts (LIFF → detached PWA,
+  kiosk, personal phone) where the device lock is accepted as the effective
+  user factor and repeated prompts kill the offline UX.
+- **Non-extractable key.** Malware must run *on the origin in the browser* to
+  use the key; it cannot exfiltrate the key material itself.
+- **Fail closed, never a lockout.** Storage eviction (browser data clear, iOS
+  ITP) surfaces as the typed `DeviceTrustNotFoundError` → fall back to a
+  real-factor unlock and re-enroll. The real factor always remains.
+- **Enrollment requires an already-unlocked session** — device-trust is never
+  a first-unlock factor.
+- **Policy-gated.** The vault owner/admin forbids or tier-bounds enrollment via
+  the `app:device-trust` gate; a resume yields a capped session tier (default
+  3, below the passphrase tier) so sensitive gated ops still need a real
+  factor.
+- **Revocation.** `clearDeviceTrust()` kills it locally; keyring-side DEK
+  rotation invalidates the cached wrapped DEKs cryptographically.
+
 ## Status
 
 **Pre-release** (`0.1.0-pre.1`). API may change before `1.0`.

--- a/packages/on-pin/__tests__/device-trust.test.ts
+++ b/packages/on-pin/__tests__/device-trust.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for the device-trust unlock mode (@noy-db/on-pin).
+ *
+ * Covers:
+ *   - enroll + resume round-trip (identity + functional DEKs, no factor)
+ *   - non-extractable invariant (key.extractable === false, export
+ *     refused, structured-clone persistence path preserves both)
+ *   - resume yields the capped session tier (default 3, below
+ *     passphrase; hub checkGate denies tier-1 gates under it)
+ *   - enrollment refuses a keyring with no DEKs (no unlocked session)
+ *   - revocation: local clear kills it; keyring-side DEK rotation
+ *     invalidates the cached DEKs (stale DEK fails AES-GCM auth)
+ *   - eviction simulation: storage cleared → typed fail-closed error
+ *     naming the re-enroll path
+ *   - policy gate: owner forbids / tier-bounds enrollment via
+ *     `app:device-trust`; unconfigured gate allows
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { UnlockedKeyring, VaultPolicy } from '@noy-db/hub'
+import { checkGate, PolicyDeniedError } from '@noy-db/hub'
+import {
+  enrollDeviceTrust,
+  resumeDeviceTrust,
+  clearDeviceTrust,
+  isDeviceTrustEnrolled,
+  DEVICE_TRUST_GATE,
+  DEVICE_TRUST_DEFAULT_RESUME_TIER,
+  DeviceTrustNotFoundError,
+  DeviceTrustEnrollmentError,
+  DeviceTrustInvalidError,
+  DeviceTrustStorageError,
+  type DeviceTrustStore,
+  type DeviceTrustResumeTier,
+} from '../src/index.js'
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+/**
+ * In-memory DeviceTrustStore that structured-clones on BOTH set and
+ * get — the same round-trip IndexedDB performs. This is what makes the
+ * "persist the CryptoKey OBJECT via structured clone" path real in
+ * tests: a non-extractable key must survive the clone still
+ * non-extractable and still usable.
+ */
+function memoryStore(): DeviceTrustStore & { clear(): void; dump(key: string): unknown } {
+  const map = new Map<string, unknown>()
+  return {
+    async get(key) {
+      const value = map.get(key)
+      return value === undefined ? undefined : structuredClone(value)
+    },
+    async set(key, value) {
+      map.set(key, structuredClone(value))
+    },
+    async delete(key) {
+      map.delete(key)
+    },
+    clear() {
+      map.clear()
+    },
+    dump(key: string) {
+      return map.get(key)
+    },
+  }
+}
+
+async function makeTestKeyring(): Promise<UnlockedKeyring> {
+  const dek1 = await crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true, // extractable — required for session-resume wrapping
+    ['encrypt', 'decrypt'],
+  )
+  const dek2 = await crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt'],
+  )
+  return {
+    userId: 'alice',
+    displayName: 'Alice',
+    role: 'owner',
+    permissions: { invoices: 'rw', clients: 'rw' },
+    deks: new Map([
+      ['invoices', dek1],
+      ['clients', dek2],
+    ]),
+    kek: null, // simulate post-unlock state
+    salt: new Uint8Array(32).fill(7),
+  }
+}
+
+async function encryptWithDek(dek: CryptoKey, plaintext: string): Promise<{ iv: Uint8Array; ct: ArrayBuffer }> {
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const ct = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    dek,
+    new TextEncoder().encode(plaintext),
+  )
+  return { iv, ct }
+}
+
+async function decryptWithDek(dek: CryptoKey, blob: { iv: Uint8Array; ct: ArrayBuffer }): Promise<string> {
+  const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: blob.iv }, dek, blob.ct)
+  return new TextDecoder().decode(plain)
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe('enrollDeviceTrust + resumeDeviceTrust — happy path', () => {
+  it('resumes with no factor at all and returns an equivalent keyring', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    await enrollDeviceTrust(keyring, { vault: 'main', store })
+
+    const { keyring: resumed } = await resumeDeviceTrust('main', { store })
+    expect(resumed.userId).toBe('alice')
+    expect(resumed.displayName).toBe('Alice')
+    expect(resumed.role).toBe('owner')
+    expect(resumed.permissions).toEqual({ invoices: 'rw', clients: 'rw' })
+    expect(resumed.deks.size).toBe(2)
+    // KEK is deliberately null on resumed keyrings (session-resume law).
+    expect(resumed.kek).toBeNull()
+  })
+
+  it('resumed DEKs actually decrypt data encrypted by the originals', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    const blob = await encryptWithDek(keyring.deks.get('invoices')!, 'hello, device')
+
+    await enrollDeviceTrust(keyring, { vault: 'main', store })
+    const { keyring: resumed } = await resumeDeviceTrust('main', { store })
+
+    await expect(decryptWithDek(resumed.deks.get('invoices')!, blob)).resolves.toBe('hello, device')
+  })
+
+  it('records enrollment state and reports isDeviceTrustEnrolled', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+
+    expect(await isDeviceTrustEnrolled('main', { store })).toBe(false)
+    const state = await enrollDeviceTrust(keyring, { vault: 'main', store })
+    expect(state._noydb_device_trust).toBe(1)
+    expect(state.vault).toBe('main')
+    expect(Date.parse(state.enrolledAt)).not.toBeNaN()
+    expect(await isDeviceTrustEnrolled('main', { store })).toBe(true)
+    // Records are per-vault.
+    expect(await isDeviceTrustEnrolled('other', { store })).toBe(false)
+  })
+})
+
+describe('non-extractable invariant', () => {
+  it('persists a non-extractable CryptoKey object whose bits cannot be exported', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    await enrollDeviceTrust(keyring, { vault: 'main', store })
+
+    const record = store.dump('noydb:device-trust:main') as { key: CryptoKey }
+    expect(record.key).toBeInstanceOf(CryptoKey)
+    expect(record.key.extractable).toBe(false)
+    await expect(crypto.subtle.exportKey('raw', record.key)).rejects.toThrow()
+  })
+
+  it('the key survives the structured-clone persistence path still non-extractable and still usable', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    await enrollDeviceTrust(keyring, { vault: 'main', store })
+
+    // memoryStore structured-clones on set AND get — the same
+    // round-trip IndexedDB performs. Two hops from the original.
+    const cloned = (await store.get('noydb:device-trust:main')) as { key: CryptoKey }
+    expect(cloned.key.extractable).toBe(false)
+    await expect(crypto.subtle.exportKey('raw', cloned.key)).rejects.toThrow()
+
+    // Usable: resume (which goes through store.get → clone) works.
+    const { keyring: resumed } = await resumeDeviceTrust('main', { store })
+    expect(resumed.deks.size).toBe(2)
+  })
+})
+
+describe('tier cap', () => {
+  it('resume yields the default capped tier — 3, below the passphrase tier', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    const state = await enrollDeviceTrust(keyring, { vault: 'main', store })
+    expect(state.resumeTier).toBe(DEVICE_TRUST_DEFAULT_RESUME_TIER)
+    expect(state.resumeTier).toBe(3)
+
+    const { resumeTier } = await resumeDeviceTrust('main', { store })
+    expect(resumeTier).toBe(3)
+  })
+
+  it('sensitive gated operations still require a real factor under the capped tier', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    await enrollDeviceTrust(keyring, { vault: 'main', store })
+    const { resumeTier } = await resumeDeviceTrust('main', { store })
+
+    // A tier-1-floor gate (e.g. rotate-passphrase) denies a device-trust session.
+    const policy: VaultPolicy = { gates: { 'rotate-passphrase': { minTier: 1 } } }
+    await expect(
+      checkGate(policy, 'rotate-passphrase', { activeTier: resumeTier }),
+    ).rejects.toBeInstanceOf(PolicyDeniedError)
+  })
+
+  it('honors a configured resumeTier of 2', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    await enrollDeviceTrust(keyring, { vault: 'main', store, resumeTier: 2 })
+    const { resumeTier } = await resumeDeviceTrust('main', { store })
+    expect(resumeTier).toBe(2)
+  })
+
+  it('refuses to claim the passphrase tier', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    await expect(
+      enrollDeviceTrust(keyring, { vault: 'main', store, resumeTier: 1 as unknown as DeviceTrustResumeTier }),
+    ).rejects.toBeInstanceOf(DeviceTrustEnrollmentError)
+  })
+})
+
+describe('enrollment requires an already-unlocked session', () => {
+  it('refuses a keyring with no DEKs', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    const cold: UnlockedKeyring = { ...keyring, deks: new Map() }
+    await expect(enrollDeviceTrust(cold, { vault: 'main', store })).rejects.toBeInstanceOf(
+      DeviceTrustEnrollmentError,
+    )
+    expect(await isDeviceTrustEnrolled('main', { store })).toBe(false)
+  })
+})
+
+describe('revocation', () => {
+  it('clearDeviceTrust deletes the record — resume fails closed', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    await enrollDeviceTrust(keyring, { vault: 'main', store })
+
+    await clearDeviceTrust('main', { store })
+    expect(await isDeviceTrustEnrolled('main', { store })).toBe(false)
+    await expect(resumeDeviceTrust('main', { store })).rejects.toBeInstanceOf(
+      DeviceTrustNotFoundError,
+    )
+    // Idempotent.
+    await expect(clearDeviceTrust('main', { store })).resolves.toBeUndefined()
+  })
+
+  it('keyring-side DEK rotation invalidates the cached blob — stale DEKs fail AES-GCM auth', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    await enrollDeviceTrust(keyring, { vault: 'main', store })
+
+    // Simulate the vault's rotate ceremony: a NEW DEK is minted for the
+    // collection and new records are encrypted under it.
+    const rotatedDek = await crypto.subtle.generateKey(
+      { name: 'AES-GCM', length: 256 },
+      true,
+      ['encrypt', 'decrypt'],
+    )
+    const freshRecord = await encryptWithDek(rotatedDek, 'post-rotation record')
+
+    // The device-trust blob still resumes (it is a local cache), but the
+    // stale DEK it yields cannot decrypt anything written after the
+    // rotation — the wrapped-DEKs cache is cryptographically dead.
+    const { keyring: resumed } = await resumeDeviceTrust('main', { store })
+    await expect(
+      decryptWithDek(resumed.deks.get('invoices')!, freshRecord),
+    ).rejects.toThrow()
+
+    // Re-enrolling from the fresh (rotated) session overwrites the record.
+    const rotatedKeyring: UnlockedKeyring = {
+      ...keyring,
+      deks: new Map([['invoices', rotatedDek]]),
+    }
+    await enrollDeviceTrust(rotatedKeyring, { vault: 'main', store })
+    const { keyring: reResumed } = await resumeDeviceTrust('main', { store })
+    await expect(
+      decryptWithDek(reResumed.deks.get('invoices')!, freshRecord),
+    ).resolves.toBe('post-rotation record')
+  })
+})
+
+describe('eviction tolerance — fail closed, never a lockout', () => {
+  it('storage cleared → DeviceTrustNotFoundError naming the re-enroll path', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    await enrollDeviceTrust(keyring, { vault: 'main', store })
+
+    // Simulate browser data clear / iOS ITP eviction.
+    store.clear()
+
+    const failure = await resumeDeviceTrust('main', { store }).then(
+      () => null,
+      (err: unknown) => err,
+    )
+    expect(failure).toBeInstanceOf(DeviceTrustNotFoundError)
+    const error = failure as DeviceTrustNotFoundError
+    expect(error.code).toBe('DEVICE_TRUST_NOT_FOUND')
+    // The error must direct the user to the real-factor unlock +
+    // re-enrollment path — eviction disables the mode, never the vault.
+    expect(error.message).toContain('real factor')
+    expect(error.message).toContain('enrollDeviceTrust')
+  })
+
+  it('a corrupt record fails closed with DeviceTrustInvalidError', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    const state = await enrollDeviceTrust(keyring, { vault: 'main', store })
+
+    // Tamper: replace the wrapped blob with garbage (key survives).
+    const record = store.dump('noydb:device-trust:main') as { key: CryptoKey }
+    await store.set('noydb:device-trust:main', {
+      key: record.key,
+      state: { ...state, wrappedKeyring: btoa('garbage') },
+    })
+    await expect(resumeDeviceTrust('main', { store })).rejects.toBeInstanceOf(
+      DeviceTrustInvalidError,
+    )
+  })
+
+  it('no store and no indexedDB → typed DeviceTrustStorageError', async () => {
+    const keyring = await makeTestKeyring()
+    if (typeof indexedDB === 'undefined') {
+      await expect(enrollDeviceTrust(keyring, { vault: 'main' })).rejects.toBeInstanceOf(
+        DeviceTrustStorageError,
+      )
+    } else {
+      // Environment provides IndexedDB — the default store engages
+      // instead; nothing to assert here.
+      expect(true).toBe(true)
+    }
+  })
+})
+
+describe('policy gate — app:device-trust', () => {
+  it('owner forbids the mode → enrollment refused with PolicyDeniedError', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    const policy: VaultPolicy = {
+      gates: { [DEVICE_TRUST_GATE]: { minTier: 3, enabled: false } },
+    }
+    await expect(
+      enrollDeviceTrust(keyring, { vault: 'main', store, policy }),
+    ).rejects.toBeInstanceOf(PolicyDeniedError)
+    expect(await isDeviceTrustEnrolled('main', { store })).toBe(false)
+  })
+
+  it('owner tier-bounds enrollment → a weaker session cannot enroll', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    // Only a full-passphrase (tier-1) session may enroll device-trust.
+    const policy: VaultPolicy = {
+      gates: { [DEVICE_TRUST_GATE]: { minTier: 1 } },
+    }
+    // A PIN-resumed (tier-3) session is refused…
+    await expect(
+      enrollDeviceTrust(keyring, { vault: 'main', store, policy, activeTier: 3 }),
+    ).rejects.toBeInstanceOf(PolicyDeniedError)
+    // …a tier-1 session passes.
+    await expect(
+      enrollDeviceTrust(keyring, { vault: 'main', store, policy, activeTier: 1 }),
+    ).resolves.toBeDefined()
+  })
+
+  it('unconfigured gate allows (opt-in default), as does omitting the policy', async () => {
+    const store = memoryStore()
+    const keyring = await makeTestKeyring()
+    // Policy present but gate unconfigured — app:* gates default-allow.
+    const policy: VaultPolicy = { gates: {} }
+    await expect(
+      enrollDeviceTrust(keyring, { vault: 'a', store, policy }),
+    ).resolves.toBeDefined()
+    // No policy passed at all.
+    await expect(
+      enrollDeviceTrust(keyring, { vault: 'b', store }),
+    ).resolves.toBeDefined()
+  })
+})

--- a/packages/on-pin/src/device-trust.ts
+++ b/packages/on-pin/src/device-trust.ts
@@ -1,0 +1,456 @@
+/**
+ * **Device-trust unlock mode** — "always safe to open on this device."
+ *
+ * The session DEKs are wrapped under a **non-extractable, device-bound
+ * `crypto.subtle` key** and persisted in IndexedDB, so the vault reopens
+ * on this device with **no user factor at all**: load the CryptoKey +
+ * blob, unwrap, done. No network, no prompt.
+ *
+ * Sits beside PIN quick-lock in the session-resume family and shares its
+ * plumbing (`keyring-codec.ts`): same serialized-keyring payload, same
+ * AES-GCM wrap, same `kek: null` resumed keyring. The differences are
+ * the wrapping key (device-generated, not credential-derived) and the
+ * persistence (IndexedDB structured clone, not an in-memory state
+ * object).
+ *
+ * ## Threat model (read before enabling)
+ *
+ * - **The OS lock screen IS the factor.** Anyone holding the unlocked
+ *   device opens the vault. This is a deliberate, opt-in trade for
+ *   mobile/embedded contexts (LIFF → detached PWA, kiosk, personal
+ *   phone) where a repeated passphrase/PIN prompt kills the offline UX
+ *   and the device lock is accepted as the effective user factor.
+ * - **The key material cannot be exfiltrated.** The wrapping key is
+ *   generated with `extractable: false` and persisted as a CryptoKey
+ *   OBJECT via IndexedDB's structured clone — its raw bits never exist
+ *   in JS. Malware must run *on the origin in the browser* to use it;
+ *   it cannot steal the key itself.
+ * - **Storage eviction silently disables the mode** (browser data
+ *   clear, iOS ITP 7-day eviction). Resume then fails CLOSED with the
+ *   typed {@link DeviceTrustNotFoundError} — the caller falls back to a
+ *   real-factor unlock (passphrase, invite, OIDC) and may re-enroll.
+ *   Never a lockout: the real factor always remains.
+ * - **Enrollment requires an already-unlocked session** (session-resume
+ *   family law). Device-trust is NEVER a first-unlock factor — a cold
+ *   device with no prior unlock has nothing to wrap.
+ * - **Revocation.** Locally, {@link clearDeviceTrust} deletes the key +
+ *   blob — the mode is dead on this device. Keyring-side, the blob
+ *   caches raw DEK bytes, so standard slot revocation + DEK rotation
+ *   invalidate it: after the vault rotates its DEKs, the cached stale
+ *   DEKs fail AES-GCM authentication against any newly written record.
+ *
+ * ## Policy gate + tier cap
+ *
+ * - Enrollment is gated by the `app:device-trust` policy gate
+ *   ({@link DEVICE_TRUST_GATE}), evaluated with the hub's own
+ *   `checkGate` engine when the caller passes the vault policy. The
+ *   vault owner/admin forbids the mode by configuring
+ *   `gates: { 'app:device-trust': { enabled: false, minTier: 3 } }`, or
+ *   bounds it (e.g. `minTier: 1` = only a full-passphrase session may
+ *   enroll, `factors: [...]` = require a fresh proof at enrollment).
+ *   Unconfigured, the gate allows — matching the mode's opt-in design.
+ * - A device-trust resume yields a **capped session tier**
+ *   ({@link DeviceTrustState.resumeTier}) — default tier 3, the floor,
+ *   same as a PIN resume and always below the passphrase tier 1. Pass
+ *   it as `activeTier` to `checkGate` so sensitive gated operations
+ *   still require a real factor.
+ *
+ * @module
+ */
+
+import { checkGate } from '@noy-db/hub'
+import type {
+  UnlockedKeyring,
+  VaultPolicy,
+  GateName,
+  ActiveTier,
+  FactorProof,
+} from '@noy-db/hub'
+import {
+  serializeKeyring,
+  deserializeKeyring,
+  bytesToBase64,
+  base64ToBytes,
+} from './keyring-codec.js'
+
+// ─── Constants ──────────────────────────────────────────────────────────
+
+/**
+ * The policy gate evaluated at enrollment. Lives in the `app:*`
+ * namespace deliberately: enrollment is a purely client-local operation
+ * over DEKs the session already holds, so the gate is an owner-facing
+ * policy switch, not a cryptographic boundary — and an unconfigured
+ * `app:*` gate allows (built-in gates fail closed), which matches the
+ * opt-in default: the mode works until the owner forbids it.
+ */
+export const DEVICE_TRUST_GATE: GateName = 'app:device-trust'
+
+/**
+ * Session tier a device-trust resume may claim. Tier 1 (passphrase) is
+ * deliberately unrepresentable — a no-factor resume can never claim the
+ * full-unlock tier.
+ */
+export type DeviceTrustResumeTier = 2 | 3
+
+/**
+ * Default resume tier: 3, the floor — same tier as a PIN quick-resume
+ * and below the passphrase tier (1), so policy-gated sensitive
+ * operations still require a real factor.
+ */
+export const DEVICE_TRUST_DEFAULT_RESUME_TIER: DeviceTrustResumeTier = 3
+
+const RECORD_KEY_PREFIX = 'noydb:device-trust:'
+const DB_NAME = 'noydb-device-trust'
+const OBJECT_STORE = 'records'
+
+// ─── Errors ─────────────────────────────────────────────────────────────
+
+/**
+ * Thrown by `resumeDeviceTrust()` when no device-trust record exists for
+ * the vault in browser storage.
+ *
+ * The device key + wrapped-DEKs blob are created at enrollment and
+ * stored in IndexedDB on the enrolling device — they never leave it.
+ * This error means storage was evicted (browser data clear, iOS ITP
+ * eviction, private browsing) or the mode was never enrolled / was
+ * cleared. Fail closed into a real-factor unlock (passphrase, invite,
+ * OIDC), then re-enroll this device via `enrollDeviceTrust` — the real
+ * factor always remains, so this is never a lockout.
+ */
+export class DeviceTrustNotFoundError extends Error {
+  readonly code = 'DEVICE_TRUST_NOT_FOUND' as const
+  constructor(vault: string) {
+    super(
+      `No device-trust record found for vault "${vault}". ` +
+      'The device key and wrapped DEKs are created at enrollment and stored in browser storage; ' +
+      'they were evicted, cleared, or never enrolled on this device. ' +
+      'Unlock with a real factor (passphrase, invite, OIDC) and re-enroll via enrollDeviceTrust().',
+    )
+    this.name = 'DeviceTrustNotFoundError'
+  }
+}
+
+/** Thrown when device-trust enrollment fails (see message for cause). */
+export class DeviceTrustEnrollmentError extends Error {
+  readonly code = 'DEVICE_TRUST_ENROLLMENT_FAILED' as const
+  constructor(message = 'Device-trust enrollment failed.') {
+    super(message)
+    this.name = 'DeviceTrustEnrollmentError'
+  }
+}
+
+/**
+ * Thrown by `resumeDeviceTrust()` when a record exists but cannot be
+ * unwrapped (corrupt blob, key/blob mismatch after a partial storage
+ * wipe). Fail closed: unlock with a real factor and re-enroll.
+ */
+export class DeviceTrustInvalidError extends Error {
+  readonly code = 'DEVICE_TRUST_INVALID' as const
+  constructor(vault: string) {
+    super(
+      `Device-trust record for vault "${vault}" exists but could not be unwrapped ` +
+      '(corrupt or mismatched key/blob). ' +
+      'Unlock with a real factor (passphrase, invite, OIDC) and re-enroll via enrollDeviceTrust().',
+    )
+    this.name = 'DeviceTrustInvalidError'
+  }
+}
+
+/**
+ * Thrown when no `store` was supplied and the environment has no
+ * `indexedDB` (Node, some workers). Pass an explicit
+ * {@link DeviceTrustStore} implementation.
+ */
+export class DeviceTrustStorageError extends Error {
+  readonly code = 'DEVICE_TRUST_STORAGE_UNAVAILABLE' as const
+  constructor(message = 'IndexedDB is not available in this environment; pass an explicit DeviceTrustStore.') {
+    super(message)
+    this.name = 'DeviceTrustStorageError'
+  }
+}
+
+// ─── Types ──────────────────────────────────────────────────────────────
+
+/**
+ * Minimal async key-value storage for device-trust records. Values must
+ * survive a structured clone (they contain a non-extractable
+ * CryptoKey). The default is IndexedDB
+ * ({@link indexedDbDeviceTrustStore}); tests and non-browser hosts
+ * inject their own.
+ */
+export interface DeviceTrustStore {
+  get(key: string): Promise<unknown>
+  set(key: string, value: unknown): Promise<void>
+  delete(key: string): Promise<void>
+}
+
+/**
+ * Metadata persisted beside the device key. Unlike `PinResumeState`,
+ * this is NOT the caller's to hold — it lives in the store (there is
+ * nothing secret and nothing to keep in memory across a cold start).
+ */
+export interface DeviceTrustState {
+  /** Schema marker. */
+  readonly _noydb_device_trust: 1
+  /** Vault this record resumes. */
+  readonly vault: string
+  /** Base64 AES-GCM IV for `wrappedKeyring`. */
+  readonly iv: string
+  /** Base64 AES-GCM ciphertext — serialized keyring wrapped under the device key. */
+  readonly wrappedKeyring: string
+  /** ISO-8601 enrollment timestamp. */
+  readonly enrolledAt: string
+  /** Session tier a resume from this record yields. */
+  readonly resumeTier: DeviceTrustResumeTier
+}
+
+export interface EnrollDeviceTrustOptions {
+  /** Vault name — keys the device-trust record in storage. */
+  readonly vault: string
+  /** Storage override. Default: IndexedDB. */
+  readonly store?: DeviceTrustStore
+  /**
+   * The vault's policy document (`db.policy.getPolicy(vault)`). When
+   * present, the {@link DEVICE_TRUST_GATE} gate is checked and a denial
+   * throws the hub's `PolicyDeniedError`. When absent, no gate runs.
+   */
+  readonly policy?: VaultPolicy
+  /** Tier of the enrolling session, for the gate check. Default: 1 (fresh full unlock). */
+  readonly activeTier?: ActiveTier
+  /** Factor proofs presented to the gate, if its policy requires any. */
+  readonly factors?: ReadonlyArray<FactorProof>
+  /** Session tier a resume will yield. Default: {@link DEVICE_TRUST_DEFAULT_RESUME_TIER}. */
+  readonly resumeTier?: DeviceTrustResumeTier
+}
+
+export interface DeviceTrustStoreOptions {
+  /** Storage override. Default: IndexedDB. */
+  readonly store?: DeviceTrustStore
+}
+
+/** What `resumeDeviceTrust()` yields. */
+export interface DeviceTrustResumeResult {
+  /** The resumed session keyring (`kek: null`, like every session-resume). */
+  readonly keyring: UnlockedKeyring
+  /**
+   * The capped session tier recorded at enrollment. Pass as
+   * `activeTier` to `checkGate` so gated operations see the true
+   * (no-factor) strength of this session.
+   */
+  readonly resumeTier: DeviceTrustResumeTier
+}
+
+/** Shape of the single structured-clone record persisted per vault. */
+interface DeviceTrustRecord {
+  readonly key: CryptoKey
+  readonly state: DeviceTrustState
+}
+
+// ─── Implementation ─────────────────────────────────────────────────────
+
+/**
+ * Enroll device-trust for a vault against an already-unlocked keyring.
+ *
+ * Generates a fresh **non-extractable** AES-GCM device key
+ * (`crypto.subtle.generateKey(..., extractable: false, ...)`), wraps
+ * the session's serialized keyring under it, and persists the CryptoKey
+ * OBJECT + blob as one structured-clone record. Re-enrolling the same
+ * vault overwrites the previous record (fresh key, fresh blob).
+ *
+ * @throws {DeviceTrustEnrollmentError} when the keyring holds no DEKs
+ *         (not an unlocked session) or a DEK is not extractable.
+ * @throws `PolicyDeniedError` (hub) when `options.policy` forbids or
+ *         bounds the {@link DEVICE_TRUST_GATE} gate.
+ * @throws {DeviceTrustStorageError} when no store is available.
+ */
+export async function enrollDeviceTrust(
+  keyring: UnlockedKeyring,
+  options: EnrollDeviceTrustOptions,
+): Promise<DeviceTrustState> {
+  const resumeTier = options.resumeTier ?? DEVICE_TRUST_DEFAULT_RESUME_TIER
+  if (resumeTier !== 2 && resumeTier !== 3) {
+    throw new DeviceTrustEnrollmentError(
+      `Invalid resumeTier ${String(resumeTier)} — a device-trust resume may only claim tier 2 or 3, never the passphrase tier.`,
+    )
+  }
+  if (keyring.deks.size === 0) {
+    throw new DeviceTrustEnrollmentError(
+      'Keyring holds no DEKs — device-trust enrolls an already-unlocked session, never a cold one.',
+    )
+  }
+
+  if (options.policy) {
+    await checkGate(options.policy, DEVICE_TRUST_GATE, {
+      activeTier: options.activeTier ?? 1,
+      ...(options.factors !== undefined && { factors: options.factors }),
+    })
+  }
+
+  const store = resolveStore(options.store)
+
+  let serialized: Uint8Array
+  try {
+    serialized = await serializeKeyring(keyring)
+  } catch (err) {
+    throw new DeviceTrustEnrollmentError(
+      'Failed to serialize keyring — DEK not extractable. ' +
+      `Underlying error: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+
+  // The device key: non-extractable by construction. Its raw bits never
+  // exist in JS; it persists only as a structured-clone CryptoKey object.
+  const deviceKey = await crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  )
+
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: iv as BufferSource },
+    deviceKey,
+    serialized as BufferSource,
+  )
+
+  const state: DeviceTrustState = {
+    _noydb_device_trust: 1,
+    vault: options.vault,
+    iv: bytesToBase64(iv),
+    wrappedKeyring: bytesToBase64(new Uint8Array(ciphertext)),
+    enrolledAt: new Date().toISOString(),
+    resumeTier,
+  }
+
+  const record: DeviceTrustRecord = { key: deviceKey, state }
+  await store.set(recordKey(options.vault), record)
+  return state
+}
+
+/**
+ * Resume a session from this device's device-trust record. No network,
+ * no prompt: load the CryptoKey + blob from storage, unwrap, return the
+ * keyring (`kek: null`) with its capped {@link DeviceTrustResumeResult.resumeTier}.
+ *
+ * @throws {DeviceTrustNotFoundError} when no record exists (evicted /
+ *         cleared / never enrolled) — fail closed to a real-factor unlock.
+ * @throws {DeviceTrustInvalidError} when the record exists but cannot
+ *         be unwrapped.
+ * @throws {DeviceTrustStorageError} when no store is available.
+ */
+export async function resumeDeviceTrust(
+  vault: string,
+  options: DeviceTrustStoreOptions = {},
+): Promise<DeviceTrustResumeResult> {
+  const store = resolveStore(options.store)
+  const record = await store.get(recordKey(vault))
+  if (record === undefined || record === null) {
+    throw new DeviceTrustNotFoundError(vault)
+  }
+  if (!isDeviceTrustRecord(record)) {
+    throw new DeviceTrustInvalidError(vault)
+  }
+
+  let plaintext: ArrayBuffer
+  try {
+    plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: base64ToBytes(record.state.iv) as BufferSource },
+      record.key,
+      base64ToBytes(record.state.wrappedKeyring) as BufferSource,
+    )
+  } catch {
+    throw new DeviceTrustInvalidError(vault)
+  }
+
+  const keyring = await deserializeKeyring(new Uint8Array(plaintext))
+  return { keyring, resumeTier: record.state.resumeTier }
+}
+
+/**
+ * Local revocation: delete this device's device-trust record (key +
+ * blob). The mode is dead on this device until re-enrolled from a
+ * real-factor unlock. Idempotent.
+ */
+export async function clearDeviceTrust(
+  vault: string,
+  options: DeviceTrustStoreOptions = {},
+): Promise<void> {
+  const store = resolveStore(options.store)
+  await store.delete(recordKey(vault))
+}
+
+/** Whether a device-trust record exists for the vault on this device. */
+export async function isDeviceTrustEnrolled(
+  vault: string,
+  options: DeviceTrustStoreOptions = {},
+): Promise<boolean> {
+  const store = resolveStore(options.store)
+  const record = await store.get(recordKey(vault))
+  return isDeviceTrustRecord(record)
+}
+
+// ─── Default IndexedDB store ────────────────────────────────────────────
+
+/**
+ * The default {@link DeviceTrustStore}: one IndexedDB database
+ * (`noydb-device-trust`) with a single object store. IndexedDB's
+ * structured clone is what lets a non-extractable CryptoKey persist as
+ * an OBJECT — the key survives, its bits stay unreadable.
+ */
+export function indexedDbDeviceTrustStore(dbName: string = DB_NAME): DeviceTrustStore {
+  let dbPromise: Promise<IDBDatabase> | undefined
+
+  function open(): Promise<IDBDatabase> {
+    dbPromise ??= new Promise((resolve, reject) => {
+      const req = indexedDB.open(dbName, 1)
+      req.onupgradeneeded = () => {
+        req.result.createObjectStore(OBJECT_STORE)
+      }
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error ?? new Error('indexedDB.open failed'))
+    })
+    return dbPromise
+  }
+
+  async function run<T>(mode: IDBTransactionMode, op: (s: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+    const db = await open()
+    return new Promise<T>((resolve, reject) => {
+      const tx = db.transaction(OBJECT_STORE, mode)
+      const req = op(tx.objectStore(OBJECT_STORE))
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error ?? new Error('IndexedDB request failed'))
+    })
+  }
+
+  return {
+    get: (key) => run('readonly', (s) => s.get(key)),
+    set: async (key, value) => {
+      await run('readwrite', (s) => s.put(value, key))
+    },
+    delete: async (key) => {
+      await run('readwrite', (s) => s.delete(key))
+    },
+  }
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────
+
+function resolveStore(store: DeviceTrustStore | undefined): DeviceTrustStore {
+  if (store) return store
+  if (typeof indexedDB === 'undefined') {
+    throw new DeviceTrustStorageError()
+  }
+  return indexedDbDeviceTrustStore()
+}
+
+function recordKey(vault: string): string {
+  return RECORD_KEY_PREFIX + vault
+}
+
+function isDeviceTrustRecord(value: unknown): value is DeviceTrustRecord {
+  if (typeof value !== 'object' || value === null) return false
+  const record = value as { key?: unknown; state?: unknown }
+  if (typeof CryptoKey === 'undefined' || !(record.key instanceof CryptoKey)) return false
+  const state = record.state as { _noydb_device_trust?: unknown } | undefined
+  return typeof state === 'object' && state !== null && state._noydb_device_trust === 1
+}

--- a/packages/on-pin/src/index.ts
+++ b/packages/on-pin/src/index.ts
@@ -60,10 +60,45 @@
  * const keyring = await resumePin(state, { pin: '1234' })
  * ```
  *
+ * ## The second mode: device-trust
+ *
+ * This package also ships the **device-trust** session-resume mode
+ * ("always safe to open on this device") — the session DEKs wrapped
+ * under a non-extractable device-bound CryptoKey persisted in
+ * IndexedDB, so the vault reopens with no user factor at all. See
+ * `device-trust.ts` for the API (`enrollDeviceTrust` /
+ * `resumeDeviceTrust`) and its explicit threat model (the OS lock
+ * screen IS the factor).
+ *
  * @packageDocumentation
  */
 
-import type { Role, Permissions, UnlockedKeyring } from '@noy-db/hub'
+import type { UnlockedKeyring } from '@noy-db/hub'
+import { serializeKeyring, deserializeKeyring, bytesToBase64, base64ToBytes } from './keyring-codec.js'
+
+// ─── Device-trust mode (see device-trust.ts) ────────────────────────────
+
+export {
+  enrollDeviceTrust,
+  resumeDeviceTrust,
+  clearDeviceTrust,
+  isDeviceTrustEnrolled,
+  indexedDbDeviceTrustStore,
+  DEVICE_TRUST_GATE,
+  DEVICE_TRUST_DEFAULT_RESUME_TIER,
+  DeviceTrustNotFoundError,
+  DeviceTrustEnrollmentError,
+  DeviceTrustInvalidError,
+  DeviceTrustStorageError,
+} from './device-trust.js'
+export type {
+  DeviceTrustState,
+  DeviceTrustStore,
+  DeviceTrustResumeTier,
+  DeviceTrustResumeResult,
+  EnrollDeviceTrustOptions,
+  DeviceTrustStoreOptions,
+} from './device-trust.js'
 
 // ─── Constants ──────────────────────────────────────────────────────────
 
@@ -297,69 +332,5 @@ async function deriveWrappingKey(
   )
 }
 
-interface SerializedKeyring {
-  userId: string
-  displayName: string
-  role: Role
-  permissions: Permissions
-  salt: string
-  deks: Record<string, string>
-}
-
-async function serializeKeyring(k: UnlockedKeyring): Promise<Uint8Array> {
-  const deks: Record<string, string> = {}
-  for (const [collection, key] of k.deks) {
-    const raw = await crypto.subtle.exportKey('raw', key)
-    deks[collection] = bytesToBase64(new Uint8Array(raw))
-  }
-  const json: SerializedKeyring = {
-    userId: k.userId,
-    displayName: k.displayName,
-    role: k.role,
-    permissions: k.permissions,
-    salt: bytesToBase64(k.salt),
-    deks,
-  }
-  return new TextEncoder().encode(JSON.stringify(json))
-}
-
-async function deserializeKeyring(bytes: Uint8Array): Promise<UnlockedKeyring> {
-  const parsed = JSON.parse(new TextDecoder().decode(bytes)) as SerializedKeyring
-  const deks = new Map<string, CryptoKey>()
-  for (const [coll, b64] of Object.entries(parsed.deks)) {
-    const raw = base64ToBytes(b64)
-    const key = await crypto.subtle.importKey(
-      'raw',
-      raw as BufferSource,
-      { name: 'AES-GCM' },
-      true,
-      ['encrypt', 'decrypt'],
-    )
-    deks.set(coll, key)
-  }
-  return {
-    userId: parsed.userId,
-    displayName: parsed.displayName,
-    role: parsed.role,
-    permissions: parsed.permissions,
-    salt: base64ToBytes(parsed.salt),
-    deks,
-    // KEK is deliberately null — PIN-resume returns a keyring that can
-    // read/write but cannot open additional vaults or rotate keys.
-    kek: null,
-    authenticators: [],
-  }
-}
-
-function bytesToBase64(bytes: Uint8Array): string {
-  let s = ''
-  for (const b of bytes) s += String.fromCharCode(b)
-  return btoa(s)
-}
-
-function base64ToBytes(b64: string): Uint8Array {
-  const s = atob(b64)
-  const out = new Uint8Array(s.length)
-  for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i)
-  return out
-}
+// serializeKeyring / deserializeKeyring / base64 helpers live in
+// keyring-codec.ts — shared with the device-trust mode.

--- a/packages/on-pin/src/keyring-codec.ts
+++ b/packages/on-pin/src/keyring-codec.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared keyring (de)serialization plumbing for this package's two
+ * session-resume modes — PIN quick-lock (`index.ts`) and device-trust
+ * (`device-trust.ts`).
+ *
+ * Both modes cache the SAME payload: the unlocked session's identity
+ * fields + raw DEK bytes, JSON-serialized, then AES-GCM-encrypted under
+ * a mode-specific wrapping key (PIN-derived vs. device-bound). Neither
+ * ever carries the KEK — a resumed keyring always has `kek: null`.
+ *
+ * @internal
+ * @module
+ */
+
+import type { Role, Permissions, UnlockedKeyring } from '@noy-db/hub'
+
+interface SerializedKeyring {
+  userId: string
+  displayName: string
+  role: Role
+  permissions: Permissions
+  salt: string
+  deks: Record<string, string>
+}
+
+/**
+ * Serialize an unlocked keyring (identity fields + raw DEK bytes) to
+ * UTF-8 JSON bytes. Requires every DEK to be extractable
+ * (`crypto.subtle.exportKey('raw', dek)` — the hub mints DEKs this way).
+ */
+export async function serializeKeyring(k: UnlockedKeyring): Promise<Uint8Array> {
+  const deks: Record<string, string> = {}
+  for (const [collection, key] of k.deks) {
+    const raw = await crypto.subtle.exportKey('raw', key)
+    deks[collection] = bytesToBase64(new Uint8Array(raw))
+  }
+  const json: SerializedKeyring = {
+    userId: k.userId,
+    displayName: k.displayName,
+    role: k.role,
+    permissions: k.permissions,
+    salt: bytesToBase64(k.salt),
+    deks,
+  }
+  return new TextEncoder().encode(JSON.stringify(json))
+}
+
+/**
+ * Reverse of {@link serializeKeyring}. Re-imports each DEK as a
+ * functional AES-GCM key. The returned keyring has `kek: null` —
+ * session-resume never reconstructs the KEK (by design).
+ */
+export async function deserializeKeyring(bytes: Uint8Array): Promise<UnlockedKeyring> {
+  const parsed = JSON.parse(new TextDecoder().decode(bytes)) as SerializedKeyring
+  const deks = new Map<string, CryptoKey>()
+  for (const [coll, b64] of Object.entries(parsed.deks)) {
+    const raw = base64ToBytes(b64)
+    const key = await crypto.subtle.importKey(
+      'raw',
+      raw as BufferSource,
+      { name: 'AES-GCM' },
+      true,
+      ['encrypt', 'decrypt'],
+    )
+    deks.set(coll, key)
+  }
+  return {
+    userId: parsed.userId,
+    displayName: parsed.displayName,
+    role: parsed.role,
+    permissions: parsed.permissions,
+    salt: base64ToBytes(parsed.salt),
+    deks,
+    // KEK is deliberately null — session-resume returns a keyring that
+    // can read/write but cannot open additional vaults or rotate keys.
+    kek: null,
+    authenticators: [],
+  }
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let s = ''
+  for (const b of bytes) s += String.fromCharCode(b)
+  return btoa(s)
+}
+
+export function base64ToBytes(b64: string): Uint8Array {
+  const s = atob(b64)
+  const out = new Uint8Array(s.length)
+  for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i)
+  return out
+}


### PR DESCRIPTION
Closes #801. Milestone: LINE/LIFF client portal [api].

## What

The portal's third offline re-open factor (beside PIN and biometric): **device-trust** — DEKs sealed under a non-extractable device-bound `CryptoKey`, re-opened with no user factor and no network.

- `enrollDeviceTrust` / `resumeDeviceTrust` / `clearDeviceTrust` / `isDeviceTrustEnrolled` + `indexedDbDeviceTrustStore` (names mirror the package's `enrollPin`/`resumePin` idiom).
- **Crypto**: AES-GCM 256 generated `extractable: false`; the CryptoKey OBJECT persists via structured clone (verified: stays non-extractable, `exportKey` refuses) — raw bits never exist in JS.
- **Session-resume law**: enrollment requires an unlocked session; never a first-unlock factor. Resume tier capped — default 3 (floor), 2 allowed, **1 unrepresentable at type level** + runtime guard.
- **Owner control**: `app:device-trust` policy gate — `app:*` default-allows when unconfigured (a new built-in gate would fail closed on every existing vault, inverting the issue's intended default); owner forbids/tier-bounds via persisted `_meta/policy`; denials are hub's typed `PolicyDeniedError`. **Hub untouched.**
- **Fail-closed eviction**: cleared storage → `DeviceTrustNotFoundError` naming the real-factor re-enroll path; corrupt record and no-storage cases typed separately. DEK rotation invalidates the sealed copy (AES-GCM auth failure) — tested.
- Threat model in README + module JSDoc: the OS lock screen IS the factor; opt-in trade; on-origin malware can use but never exfiltrate the key.
- Deviation from the issue sketch, justified in-code: hub's `WrappedDeksBlob` is PBKDF2-string-credential-bound and wraps only `{deks}` — device-trust instead reuses on-pin's own canonical keyring codec (now shared with PIN via the extracted `keyring-codec.ts`; PIN behavior byte-identical, all 9 pre-existing tests untouched).

## Verification

on-pin **27/27 tests** (18 new across 7 suites incl. non-extractable invariant, capped-tier gate checks, rotation invalidation, eviction taxonomy, policy-gate deny/bound/allow) · build · typecheck · lint · `check:architecture` ✓ · knip zero on-pin findings · hub untouched (no hub suite/bundle-check needed). Changeset: `@noy-db/on-pin` minor.

Docs: auth-landscape row lands via noy-db-docs#121 (already in its scope).