### PR TITLE
feat(hub): blob offline pinning + mobile cache budget (#808)

### DIFF
--- a/docs/subsystems/via-blob.md
+++ b/docs/subsystems/via-blob.md
@@ -56,8 +56,103 @@ literal — every knob is optional (`{}` is a valid, no-op policy):
   `'none'` means no backlink.
 
 Run eviction with `vault.compact()`, which returns a `CompactionResult` — `evicted`, `records`,
-`collections`, `auditEntries`, `held`, and a per-collection `byCollection: Record<string, {
-records, evicted }>` breakdown (`packages/hub/src/with-shape/blobs/blob-compaction.ts`).
+`collections`, `auditEntries`, `held`, `pinned`, `budgetEvicted`, `budgetBytesFreed`, and a
+per-collection `byCollection: Record<string, { records, evicted }>` breakdown
+(`packages/hub/src/with-shape/blobs/blob-compaction.ts`).
+
+## Mobile blob strategy — offline pinning + cache budget (#808)
+
+On top of the on-demand read path, blobs carry a client-intent layer for
+mobile/offline consumers: **"keep this document offline"** per slot, plus a
+size-budgeted LRU for everything else.
+
+### Pin / unpin
+
+```ts
+const blob = scans.blob('s1')
+await blob.pin('image')            // eager download (call while online) + eviction exemption
+await blob.isPinned('image')       // → true
+await blob.unpin('image')          // back to the normal lifecycle
+```
+
+- **Eager download.** Pinning an unfetched slot fetches it immediately: an internal
+  blob's chunks are read once to prove they are locally available; an `external`
+  slot's bytes are fetched from the object store into a local encrypted side-cache.
+- **Eviction exemption.** A pinned slot is skipped by BOTH `vault.compact()` passes —
+  the `blobFields` policy pass (counted in `CompactionResult.pinned`) and the
+  `cacheBudget` LRU pass (not even counted toward the budget). `unpin()` returns the
+  slot to the normal lifecycle.
+- **Device-local, never synced.** Pin state lives in the `withBlobs()` **pin
+  registry**, never in the vault store — each device pins for itself. The default
+  registry is in-memory (pins last one app session); pass a durable, device-local
+  backend to keep them across restarts:
+
+```ts
+import { withBlobs, type BlobPinStore } from '@noy-db/hub/blobs'
+const blobStrategy = withBlobs({ pinStore: myIdbBackedPinStore }) // 4-method BlobPinStore
+```
+
+The hub itself ships only the in-memory default — it has no device-persistence
+layer of its own (persistence backends are the `to-*` family), so a production
+mobile/web app supplies an IndexedDB/SQLite-backed `BlobPinStore`.
+
+### Cache budget (LRU)
+
+```ts
+await vault.compact({ cacheBudget: { maxBytes: 50 * 1024 * 1024 } })
+```
+
+After the policy pass, a dedicated budget pass inside the SAME compaction run
+walks every collection's slots and evicts **oldest-access-first** until the
+locally-cached **unpinned** bytes fit `maxBytes`:
+
+- internal slots evict through the standard eviction writer (`delete()` + a
+  `'budget'`-reason audit entry) and count their uncompressed `size`;
+- `external` slots only drop their **device-local cached copy** (the object-store
+  copy is authoritative and untouched) and count `cachedBytes`;
+- pinned slots and `legalHold`/`retainUntil`-held slots are exempt and uncounted.
+
+LRU order comes from the device-local last-read stamp (`SlotInfo.lastAccessAt`,
+maintained by `get()`), falling back to `uploadedAt`. Results land in
+`CompactionResult.budgetEvicted` / `budgetBytesFreed`; `dryRun: true` previews.
+
+### Offline read taxonomy
+
+`get()` never hangs and never silently returns an empty file:
+
+| State | internal (chunked) | `external: true` |
+|---|---|---|
+| pinned | readable (chunks local, eviction-exempt) | readable (encrypted local copy) |
+| unpinned + cached | readable | readable (reads auto-populate the local cache) |
+| unpinned + cold + offline | `BlobOfflineError` (chunk absent from the local store) | `BlobOfflineError` (no local copy, object store unreachable) |
+
+`BlobOfflineError` (`code: 'BLOB_OFFLINE'`, fields `collection`/`recordId`/`slotName`,
+original network failure as `cause`) means "exists, just not here right now" — UIs
+render *available when online*. A genuinely absent slot stays `null`; a genuinely
+deleted external object (fetch succeeded, nothing there) stays `null` too.
+
+### External pins — encryption posture
+
+An `external: true` slot's object-store copy sits **outside the zero-knowledge
+envelope by design** (raw, servable). The local pinned/cached copy does NOT: it is
+AES-256-GCM-encrypted under the vault's `_blob` DEK through the same enclave path
+that encrypts blob chunks (`encryptBytesWithAAD`, AAD-bound to the registry row's
+key) before it touches the pin registry. A stolen device store therefore leaks
+nothing the vault store wouldn't; plaintext bytes never rest in the registry. On an
+unencrypted vault (`encrypt: false`) the copy is stored base64-plain, mirroring the
+envelope convention.
+
+### KPI counters
+
+```ts
+const blobStrategy = withBlobs()
+// … reads happen …
+blobStrategy.cacheStats() // → { hits, misses, bytesDownloaded }
+```
+
+Local reads (internal chunks, cached external copies) count as `hits`; object-store
+fetches count as `misses` and add to `bytesDownloaded` — the number a 4G-budget
+demo charts. Counters are per-`withBlobs()`-instance (per device), like the registry.
 
 ## Query posture — `queryable: 'none'`: a NEW refusal (not parity)
 

--- a/packages/hub/__tests__/blob-pinning.test.ts
+++ b/packages/hub/__tests__/blob-pinning.test.ts
@@ -1,0 +1,400 @@
+/**
+ * #808 — blob offline pinning + mobile cache budget.
+ *
+ * - `collection.blob(id).pin(slot)` / `unpin(slot)` / `isPinned(slot)`:
+ *   device-local pin registry (never written to the vault store), eager
+ *   download on pin, eviction exemption inside `vault.compact()`.
+ * - `vault.compact({ cacheBudget: { maxBytes } })`: LRU budget pass over
+ *   locally-cached UNPINNED blob bytes, routed through the existing
+ *   compaction eviction writer.
+ * - Offline read taxonomy: pinned → always readable; unpinned+cached →
+ *   readable; unpinned+cold+offline → typed `BlobOfflineError`.
+ * - External (`external: true`) pins hold a LOCAL ENCRYPTED copy in the
+ *   device-local side-cache (ciphertext, never plaintext).
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+import { ConflictError, BlobOfflineError, NotFoundError, ValidationError } from '../src/kernel/errors.js'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withBlobs, memoryBlobPinStore } from '../src/via/blob/index.js'
+import type { ObjectProjection } from '../src/with-shape/blobs/object-projection.js'
+import { memoryObjectProjection } from '../src/with-shape/blobs/object-projection.js'
+
+function makeStore(): NoydbStore & { raw: Map<string, Map<string, Map<string, EncryptedEnvelope>>> } {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function bucket(v: string, c: string) {
+    let m = store.get(v); if (!m) { m = new Map(); store.set(v, m) }
+    let b = m.get(c); if (!b) { b = new Map(); m.set(c, b) }
+    return b
+  }
+  return {
+    name: 'memory',
+    raw: store,
+    async get(v, c, id) { return bucket(v, c).get(id) ?? null },
+    async put(v, c, id, env, ev) { const b = bucket(v, c); const ex = b.get(id); if (ev !== undefined && (ex?._v ?? 0) !== ev) throw new ConflictError(ex?._v ?? 0); b.set(id, env) },
+    async delete(v, c, id) { bucket(v, c).delete(id) },
+    async list(v, c) { return [...bucket(v, c).keys()] },
+    async loadAll(v) { const m = store.get(v); const s: VaultSnapshot = {}; if (m) for (const [n, c] of m) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of c) r[id] = e; s[n] = r } return s },
+    async saveAll(v, data) { for (const [n, recs] of Object.entries(data)) { const b = bucket(v, n); for (const [id, e] of Object.entries(recs)) b.set(id, e) } },
+  }
+}
+
+/** ObjectProjection wrapper with a switchable offline mode (network failure). */
+function flakyProjection(): { projection: ObjectProjection; setOffline: (v: boolean) => void; inner: ObjectProjection } {
+  const inner = memoryObjectProjection()
+  let offline = false
+  const fail = (): never => { throw new Error('network unreachable (simulated offline)') }
+  const projection: ObjectProjection = {
+    name: 'flaky',
+    async putObject(k, b, o) { if (offline) fail(); return inner.putObject(k, b, o) },
+    async getObject(k) { if (offline) fail(); return inner.getObject(k) },
+    async deleteObject(k) { if (offline) fail(); return inner.deleteObject(k) },
+    async headObject(k) { if (offline) fail(); return inner.headObject(k) },
+    async objectUrl(k, o) { return inner.objectUrl(k, o) },
+    async putUrl(k, o) { return inner.putUrl(k, o) },
+    async listPrefix(p) { if (offline) fail(); return inner.listPrefix(p) },
+  }
+  return { projection, setOffline: (v) => { offline = v }, inner }
+}
+
+function payload(n: number, seed = 13): Uint8Array {
+  const b = new Uint8Array(n)
+  for (let i = 0; i < n; i++) b[i] = (i * seed) & 0xff
+  return b
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+const SECRET = 'passphrase-1234-long-enough'
+
+describe('#808 — pin surface', () => {
+  it('pin/unpin/isPinned round-trip on an internal slot', async () => {
+    const store = makeStore()
+    const db = await createNoydb({ store, user: 'op', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs')
+    await docs.put('d1', { id: 'd1' })
+    await docs.blob('d1').put('scan', payload(300))
+
+    expect(await docs.blob('d1').isPinned('scan')).toBe(false)
+    await docs.blob('d1').pin('scan')
+    expect(await docs.blob('d1').isPinned('scan')).toBe(true)
+
+    // list() surfaces the device-local pin flag
+    const slot = (await docs.blob('d1').list()).find((s) => s.name === 'scan')!
+    expect(slot.pinned).toBe(true)
+
+    await docs.blob('d1').unpin('scan')
+    expect(await docs.blob('d1').isPinned('scan')).toBe(false)
+  })
+
+  it('pin on a missing slot throws NotFoundError', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs')
+    await docs.put('d1', { id: 'd1' })
+    await expect(docs.blob('d1').pin('nope')).rejects.toThrow(NotFoundError)
+  })
+
+  it('pin refuses a slot name containing the reserved separator', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs')
+    await docs.put('d1', { id: 'd1' })
+    await expect(docs.blob('d1').pin('a::b')).rejects.toThrow(ValidationError)
+  })
+
+  it('unpin of a never-pinned slot is a no-op', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs')
+    await docs.put('d1', { id: 'd1' })
+    await docs.blob('d1').put('scan', payload(10))
+    await expect(docs.blob('d1').unpin('scan')).resolves.toBeUndefined()
+  })
+})
+
+describe('#808 — pin state is device-local, never synced', () => {
+  it('a fresh device (same store, new withBlobs()) sees no pins, and the vault store holds no pin state', async () => {
+    const store = makeStore()
+    const db1 = await createNoydb({ store, user: 'op', secret: SECRET, blobStrategy: withBlobs() })
+    const v1 = await db1.openVault('t')
+    const docs1 = v1.collection<{ id: string }>('docs')
+    await docs1.put('d1', { id: 'd1' })
+    await docs1.blob('d1').put('scan', payload(64))
+    await docs1.blob('d1').pin('scan')
+    expect(await docs1.blob('d1').isPinned('scan')).toBe(true)
+
+    // No collection in the shared vault store carries pin state.
+    const collections = [...(store.raw.get('t')?.keys() ?? [])]
+    expect(collections.some((c) => c.toLowerCase().includes('pin'))).toBe(false)
+
+    // A second device over the SAME store sees the slot but not the pin.
+    const db2 = await createNoydb({ store, user: 'op', secret: SECRET, blobStrategy: withBlobs() })
+    const v2 = await db2.openVault('t')
+    const docs2 = v2.collection<{ id: string }>('docs')
+    expect((await docs2.blob('d1').list()).find((s) => s.name === 'scan')).toBeDefined()
+    expect(await docs2.blob('d1').isPinned('scan')).toBe(false)
+  })
+})
+
+describe('#808 — pin survives compact, unpin restores lifecycle', () => {
+  it('a pinned slot is exempt from policy eviction; unpin makes it evictable again', async () => {
+    const store = makeStore()
+    const db = await createNoydb({ store, user: 'op', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const scans = vault.collection<{ id: string; status: string }>('scans', {
+      blobFields: { image: { evictWhen: (r) => r.status === 'done' } },
+    })
+    await scans.put('s1', { id: 's1', status: 'done' })
+    await scans.put('s2', { id: 's2', status: 'done' })
+    await scans.blob('s1').put('image', payload(100, 3))
+    await scans.blob('s2').put('image', payload(100, 5))
+    await scans.blob('s1').pin('image')
+
+    const r1 = await vault.compact()
+    expect(r1.evicted).toBe(1) // s2 only
+    expect(r1.pinned).toBe(1)  // s1 exempted
+    expect(await scans.blob('s1').list()).toHaveLength(1)
+    expect(await scans.blob('s2').list()).toHaveLength(0)
+    expect(await scans.blob('s1').get('image')).not.toBeNull()
+
+    await scans.blob('s1').unpin('image')
+    const r2 = await vault.compact()
+    expect(r2.evicted).toBe(1)
+    expect(r2.pinned).toBe(0)
+    expect(await scans.blob('s1').list()).toHaveLength(0)
+  })
+})
+
+describe('#808 — cache budget (LRU) via vault.compact', () => {
+  it('evicts oldest-accessed unpinned internal blobs until under budget', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs')
+    for (const id of ['r1', 'r2', 'r3']) {
+      await docs.put(id, { id })
+      await docs.blob(id).put('file', payload(1000, id.charCodeAt(1)))
+      await sleep(5)
+    }
+    // Touch r1 so it is the most recently accessed; r2 becomes the LRU victim.
+    await sleep(5)
+    await docs.blob('r1').get('file')
+
+    const result = await vault.compact({ cacheBudget: { maxBytes: 2000 } })
+    expect(result.budgetEvicted).toBe(1)
+    expect(result.budgetBytesFreed).toBe(1000)
+    expect(await docs.blob('r2').list()).toHaveLength(0) // oldest access evicted
+    expect(await docs.blob('r1').list()).toHaveLength(1)
+    expect(await docs.blob('r3').list()).toHaveLength(1)
+  })
+
+  it('pinned slots are exempt from the budget (not counted, never evicted)', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs')
+    for (const id of ['r1', 'r2']) {
+      await docs.put(id, { id })
+      await docs.blob(id).put('file', payload(1000, id.charCodeAt(1)))
+      await sleep(5)
+    }
+    await docs.blob('r1').pin('file') // r1 is oldest but pinned
+
+    const result = await vault.compact({ cacheBudget: { maxBytes: 1000 } })
+    // Unpinned bytes = 1000 (r2 only) → already at budget → nothing evicted.
+    expect(result.budgetEvicted).toBe(0)
+    expect(await docs.blob('r1').list()).toHaveLength(1)
+    expect(await docs.blob('r2').list()).toHaveLength(1)
+
+    // Shrink the budget: only the unpinned r2 may go.
+    const result2 = await vault.compact({ cacheBudget: { maxBytes: 500 } })
+    expect(result2.budgetEvicted).toBe(1)
+    expect(await docs.blob('r1').list()).toHaveLength(1)
+    expect(await docs.blob('r2').list()).toHaveLength(0)
+  })
+
+  it('budget evictions write audit entries with reason "budget"; dryRun only counts', async () => {
+    const store = makeStore()
+    const db = await createNoydb({ store, user: 'op', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs')
+    await docs.put('r1', { id: 'r1' })
+    await docs.blob('r1').put('file', payload(1000))
+
+    const dry = await vault.compact({ cacheBudget: { maxBytes: 0 }, dryRun: true })
+    expect(dry.budgetEvicted).toBe(1)
+    expect(await docs.blob('r1').list()).toHaveLength(1) // untouched
+
+    const wet = await vault.compact({ cacheBudget: { maxBytes: 0 } })
+    expect(wet.budgetEvicted).toBe(1)
+    expect(wet.auditEntries).toBe(1)
+    expect(await docs.blob('r1').list()).toHaveLength(0)
+    expect((await store.list('t', '_blob_eviction_audit')).length).toBe(1)
+  })
+
+  it('refuses a negative or non-finite maxBytes', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    await expect(vault.compact({ cacheBudget: { maxBytes: -1 } })).rejects.toThrow(ValidationError)
+    await expect(vault.compact({ cacheBudget: { maxBytes: Number.NaN } })).rejects.toThrow(ValidationError)
+  })
+
+  it('drops an unpinned external side-cache copy without touching the slot or the remote object', async () => {
+    const { projection, setOffline } = flakyProjection()
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: SECRET, objectStore: projection, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { video: { external: true } } })
+    await docs.put('d1', { id: 'd1' })
+    const bytes = payload(2048)
+    await docs.blob('d1').put('video', bytes)
+
+    await docs.blob('d1').pin('video')   // caches an encrypted local copy
+    await docs.blob('d1').unpin('video') // copy stays, now budget-managed
+
+    const result = await vault.compact({ cacheBudget: { maxBytes: 0 } })
+    expect(result.budgetEvicted).toBe(1)
+    expect(result.budgetBytesFreed).toBe(2048)
+
+    // Slot + remote object survive — only the local cached copy was dropped.
+    expect((await docs.blob('d1').list()).find((s) => s.name === 'video')).toBeDefined()
+    setOffline(true)
+    await expect(docs.blob('d1').get('video')).rejects.toThrow(BlobOfflineError)
+    setOffline(false)
+    expect(Buffer.from((await docs.blob('d1').get('video'))!).equals(Buffer.from(bytes))).toBe(true)
+  })
+})
+
+describe('#808 — offline read taxonomy', () => {
+  it('external: pinned → readable offline; cached → readable offline; cold → BlobOfflineError', async () => {
+    const { projection, setOffline } = flakyProjection()
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: SECRET, objectStore: projection, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', {
+      blobFields: { a: { external: true }, b: { external: true }, c: { external: true } },
+    })
+    await docs.put('d1', { id: 'd1' })
+    const bytesA = payload(400, 3)
+    const bytesB = payload(400, 5)
+    await docs.blob('d1').put('a', bytesA)
+    await docs.blob('d1').put('b', bytesB)
+    await docs.blob('d1').put('c', payload(400, 7))
+
+    await docs.blob('d1').pin('a')       // pinned
+    await docs.blob('d1').get('b')       // unpinned but cached by the read
+
+    setOffline(true)
+    expect(Buffer.from((await docs.blob('d1').get('a'))!).equals(Buffer.from(bytesA))).toBe(true)
+    expect(Buffer.from((await docs.blob('d1').get('b'))!).equals(Buffer.from(bytesB))).toBe(true)
+    const err = await docs.blob('d1').get('c').then(() => null, (e: unknown) => e)
+    expect(err).toBeInstanceOf(BlobOfflineError)
+    expect((err as BlobOfflineError).code).toBe('BLOB_OFFLINE')
+    expect((err as BlobOfflineError).collection).toBe('docs')
+    expect((err as BlobOfflineError).recordId).toBe('d1')
+    expect((err as BlobOfflineError).slotName).toBe('c')
+  })
+
+  it('external: a deleted remote object (online) is null, not BlobOfflineError', async () => {
+    const { projection, inner } = flakyProjection()
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: SECRET, objectStore: projection, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { a: { external: true } } })
+    await docs.put('d1', { id: 'd1' })
+    await docs.blob('d1').put('a', payload(64))
+    await inner.deleteObject('docs/d1/a')
+    expect(await docs.blob('d1').get('a')).toBeNull()
+  })
+
+  it('internal: locally-present chunks are readable; missing chunks surface BlobOfflineError', async () => {
+    const store = makeStore()
+    const db = await createNoydb({ store, user: 'op', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs')
+    await docs.put('d1', { id: 'd1' })
+    const bytes = payload(500)
+    await docs.blob('d1').put('file', bytes)
+    expect(Buffer.from((await docs.blob('d1').get('file'))!).equals(Buffer.from(bytes))).toBe(true)
+
+    // Simulate a cold local store (chunk not yet synced to this device).
+    for (const id of await store.list('t', '_blob_chunks')) {
+      await store.delete('t', '_blob_chunks', id)
+    }
+    await expect(docs.blob('d1').get('file')).rejects.toThrow(BlobOfflineError)
+  })
+})
+
+describe('#808 — external pin: local copy is encrypted', () => {
+  it('the side-cache holds ciphertext under the vault keys, never plaintext', async () => {
+    const pinStore = memoryBlobPinStore()
+    const { projection } = flakyProjection()
+    const db = await createNoydb({
+      store: makeStore(), user: 'op', secret: SECRET,
+      objectStore: projection, blobStrategy: withBlobs({ pinStore }),
+    })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { doc: { external: true } } })
+    await docs.put('d1', { id: 'd1' })
+    const plaintext = new TextEncoder().encode('TOP-SECRET-PAYLOAD-'.repeat(40))
+    await docs.blob('d1').put('doc', plaintext)
+    await docs.blob('d1').pin('doc')
+
+    const entries = await pinStore.entries('')
+    expect(entries.length).toBe(1)
+    const entry = entries[0]!.entry
+    expect(entry.pinned).toBe(true)
+    expect(entry.cachedBytes).toBe(plaintext.byteLength)
+    expect(entry.cipher).toBeDefined()
+    expect(entry.cipher!.iv).not.toBe('') // encrypted, not the plaintext-vault fallback
+
+    // Neither the base64 blob nor its decoded bytes contain the plaintext.
+    expect(entry.cipher!.data).not.toContain('TOP-SECRET-PAYLOAD-')
+    const decoded = Buffer.from(entry.cipher!.data, 'base64').toString('latin1')
+    expect(decoded).not.toContain('TOP-SECRET-PAYLOAD-')
+    expect(JSON.stringify(entries)).not.toContain('TOP-SECRET-PAYLOAD-')
+  })
+})
+
+describe('#808 — KPI counters', () => {
+  it('counts external hits/misses and bytes downloaded', async () => {
+    const strategy = withBlobs()
+    const { projection, setOffline } = flakyProjection()
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: SECRET, objectStore: projection, blobStrategy: strategy })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { a: { external: true } } })
+    await docs.put('d1', { id: 'd1' })
+    await docs.blob('d1').put('a', payload(700))
+
+    expect(strategy.cacheStats()).toEqual({ hits: 0, misses: 0, bytesDownloaded: 0 })
+
+    await docs.blob('d1').get('a') // cold → network fetch (miss) + auto-cache
+    let stats = strategy.cacheStats()
+    expect(stats.misses).toBe(1)
+    expect(stats.hits).toBe(0)
+    expect(stats.bytesDownloaded).toBe(700)
+
+    setOffline(true)
+    await docs.blob('d1').get('a') // cached → hit, no download
+    stats = strategy.cacheStats()
+    expect(stats.misses).toBe(1)
+    expect(stats.hits).toBe(1)
+    expect(stats.bytesDownloaded).toBe(700)
+  })
+
+  it('counts internal local reads as hits; pin() of an external slot counts its eager download', async () => {
+    const strategy = withBlobs()
+    const { projection } = flakyProjection()
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: SECRET, objectStore: projection, blobStrategy: strategy })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { ext: { external: true } } })
+    await docs.put('d1', { id: 'd1' })
+    await docs.blob('d1').put('file', payload(100))
+    await docs.blob('d1').put('ext', payload(900))
+
+    await docs.blob('d1').get('file')
+    expect(strategy.cacheStats().hits).toBe(1)
+
+    await docs.blob('d1').pin('ext') // eager download
+    const stats = strategy.cacheStats()
+    expect(stats.bytesDownloaded).toBe(900)
+    expect(stats.misses).toBe(1)
+  })
+})

--- a/packages/hub/__tests__/root-barrel-surface.golden.json
+++ b/packages/hub/__tests__/root-barrel-surface.golden.json
@@ -15,6 +15,7 @@
     "BackupCorruptedError",
     "BackupLedgerError",
     "BlobIntentPendingError",
+    "BlobOfflineError",
     "BlobSet",
     "BundleIntegrityError",
     "BundleSealMismatchError",

--- a/packages/hub/bundle-manifest.json
+++ b/packages/hub/bundle-manifest.json
@@ -25,8 +25,8 @@
       "gzippedBytes": 1036
     },
     "blobs": {
-      "minifiedBytes": 1612,
-      "gzippedBytes": 554
+      "minifiedBytes": 1692,
+      "gzippedBytes": 613
     },
     "analytics": {
       "minifiedBytes": 2420,

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -193,7 +193,7 @@ export {
   sweepBlobIntents,
 } from './with-shape/blobs/blob-intent.js'
 export type { BlobIntent, BlobIntentHold, BlobIntentResume } from './with-shape/blobs/blob-intent.js'
-export { BlobIntentPendingError } from './kernel/errors.js'
+export { BlobIntentPendingError, BlobOfflineError } from './kernel/errors.js'
 export { wrapPodStore, createPodStore, wrapBundleStore, createBundleStore } from './with-pod/pod-store.js'
 export type {
   WrappedPodNoydbStore,

--- a/packages/hub/src/kernel/errors.ts
+++ b/packages/hub/src/kernel/errors.ts
@@ -798,6 +798,37 @@ export class BlobIntentPendingError extends NoydbError {
 }
 
 /**
+ * Thrown by a blob content read when the bytes are not available locally and
+ * cannot be fetched right now (#808 offline read taxonomy) — an `external`
+ * slot with no local cached copy while the object store is unreachable, or an
+ * internal (chunked) blob whose chunk envelopes are absent from the local
+ * store (not yet synced to this device, or evicted). The content still exists
+ * at its authoritative home — retry when online/synced, or `pin()` the slot
+ * while online to keep it readable offline. Deliberately typed (never a hang,
+ * never a silent `null`) so UIs can render "available when online".
+ *
+ * `slotName` is `undefined` when the failing read was not slot-addressed
+ * (e.g. a published-version fetch resolving chunks by eTag).
+ */
+export class BlobOfflineError extends NoydbError {
+  readonly collection: string
+  readonly recordId: string
+  readonly slotName?: string
+  constructor(collection: string, recordId: string, slotName: string | undefined, detail: string, cause?: unknown) {
+    super(
+      'BLOB_OFFLINE',
+      `Blob content for ${slotName !== undefined ? `slot "${slotName}" on ` : ''}record "${recordId}" ` +
+        `(collection "${collection}") is not available locally: ${detail}`,
+    )
+    this.name = 'BlobOfflineError'
+    this.collection = collection
+    this.recordId = recordId
+    if (slotName !== undefined) this.slotName = slotName
+    if (cause !== undefined) this.cause = cause
+  }
+}
+
+/**
  * Thrown when an elevated-handle operation runs after the elevation's
  * TTL expired. Reads continue at the original tier; only writes
  * through the scoped handle flip to throwing once expired.

--- a/packages/hub/src/kernel/types.ts
+++ b/packages/hub/src/kernel/types.ts
@@ -2181,6 +2181,26 @@ export interface SlotRecord {
 export interface SlotInfo extends SlotRecord {
   /** The slot name (key in the record's slot map). */
   readonly name: string
+  /**
+   * DEVICE-LOCAL (#808): slot is pinned for offline on THIS device. Read from
+   * the `withBlobs()` pin registry at list time — never stored in (or synced
+   * through) the vault store; present only when `true`. Pinned slots are
+   * exempt from `vault.compact()` eviction and the cache-budget pass.
+   */
+  readonly pinned?: boolean
+  /**
+   * DEVICE-LOCAL (#808): ISO timestamp of the last local read of this slot on
+   * this device — the LRU input for `vault.compact({ cacheBudget })`. Absent
+   * when the slot was never read here (the budget pass falls back to
+   * `uploadedAt`).
+   */
+  readonly lastAccessAt?: string
+  /**
+   * DEVICE-LOCAL (#808): byte size of the local encrypted side-cache copy of
+   * an `external` slot on this device (see `BlobPinEntry.cipher`). Absent for
+   * internal slots and for external slots with no local copy.
+   */
+  readonly cachedBytes?: number
 }
 
 /**

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -1983,6 +1983,7 @@ export class Vault {
         const coll = this.collection(name)
         await coll.blob(id).delete(slotName)
       },
+      dropLocalCache: async (name: string, id: string, slotName: string) => this.collection(name).blob(id).dropLocalCache(slotName), // #808: budget pass drops device-local external cache copies
     }, options)
   }
 

--- a/packages/hub/src/via/blob/active.ts
+++ b/packages/hub/src/via/blob/active.ts
@@ -12,6 +12,32 @@
 
 import { BlobSet } from '../../with-shape/blobs/blob-set.js'
 import type { BlobStrategy } from '../../port/with/blob-strategy.js'
+import { createBlobPinCache } from '../../with-shape/blobs/blob-pinning.js'
+import type { BlobPinStore, BlobCacheStats } from '../../with-shape/blobs/blob-pinning.js'
+
+/** Options for {@link withBlobs} (#808). */
+export interface WithBlobsOptions {
+  /**
+   * Device-local backend for the offline-pin registry + external side-cache
+   * (`collection.blob(id).pin()`, the `cacheBudget` LRU stamps). Default:
+   * in-memory — pins then last one app session. Supply a durable,
+   * DEVICE-LOCAL store (IndexedDB-backed on the web; it must never sync) to
+   * keep pins across restarts. See `BlobPinStore`'s doc for the posture.
+   */
+  readonly pinStore?: BlobPinStore
+}
+
+/**
+ * The strategy `withBlobs()` returns — a `BlobStrategy` plus the device-local
+ * blob-cache KPI surface (#808).
+ */
+export interface BlobsService extends BlobStrategy {
+  /**
+   * Snapshot of this device's blob-cache KPI counters: local-read hits,
+   * network misses, and total bytes downloaded from the object store.
+   */
+  cacheStats(): BlobCacheStats
+}
 
 /**
  * Build a default `BlobStrategy` ready to pass into `createNoydb`.
@@ -19,6 +45,9 @@ import type { BlobStrategy } from '../../port/with/blob-strategy.js'
  * Named `withBlobs` (plugin-pattern canonical) rather than `blobs` to
  * avoid shadowing the very common local idiom
  * `const blobs = invoices.blob(id)` in user code.
+ *
+ * One `withBlobs()` instance owns one device-local pin registry + KPI
+ * counter set (#808) — treat it as "this device's" blob service.
  *
  * @example
  * ```ts
@@ -34,10 +63,14 @@ import type { BlobStrategy } from '../../port/with/blob-strategy.js'
  * await db.vault('acme').collection('invoices').blob('inv-1').put('receipt.pdf', bytes)
  * ```
  */
-export function withBlobs(): BlobStrategy {
+export function withBlobs(options: WithBlobsOptions = {}): BlobsService {
+  const pinCache = createBlobPinCache(options.pinStore)
   return {
     openSlot(args) {
-      return new BlobSet(args)
+      return new BlobSet({ ...args, pinCache })
+    },
+    cacheStats() {
+      return { ...pinCache.stats }
     },
   }
 }

--- a/packages/hub/src/via/blob/index.ts
+++ b/packages/hub/src/via/blob/index.ts
@@ -20,7 +20,13 @@
  */
 
 export { withBlobs } from './active.js'
+export type { WithBlobsOptions, BlobsService } from './active.js'
 export type { BlobStrategy, BlobStrategyOpenArgs } from '../../port/with/blob-strategy.js'
+
+// #808 — offline pinning + mobile cache budget.
+export { memoryBlobPinStore, blobPinKey } from '../../with-shape/blobs/blob-pinning.js'
+export type { BlobPinStore, BlobPinEntry, BlobCacheStats } from '../../with-shape/blobs/blob-pinning.js'
+export { BlobOfflineError } from '../../kernel/errors.js'
 
 export { memoryObjectProjection } from '../../with-shape/blobs/object-projection.js'
 export type {

--- a/packages/hub/src/with-shape/blobs/blob-compaction.ts
+++ b/packages/hub/src/with-shape/blobs/blob-compaction.ts
@@ -31,6 +31,7 @@
 
 import type { NoydbStore, EncryptedEnvelope, SlotInfo } from '../../kernel/types.js'
 import { NOYDB_FORMAT_VERSION } from '../../kernel/types.js'
+import { ValidationError } from '../../kernel/errors.js'
 import { encrypt, type EnclaveKey } from '../../kernel/enclave/index.js'
 
 // ─── Config types ───────────────────────────────────────────────────────
@@ -115,7 +116,8 @@ export interface BlobEvictionEntry {
   readonly recordId: string
   readonly slotName: string
   readonly blobHash: string
-  readonly reason: 'ttl' | 'predicate' | 'both'
+  /** `'budget'` — evicted by the #808 cache-budget LRU pass, not a policy. */
+  readonly reason: 'ttl' | 'predicate' | 'both' | 'budget'
   readonly evictedAt: string
   readonly actor: string
 }
@@ -123,19 +125,35 @@ export interface BlobEvictionEntry {
 // ─── Compaction result ──────────────────────────────────────────────────
 
 export interface CompactionResult {
-  /** Number of blob slots evicted across all collections. */
+  /** Number of blob slots evicted by the policy pass across all collections. */
   readonly evicted: number
   /** Number of records touched (iterated + policy checked). */
   readonly records: number
   /** Number of collections with `blobFields` configured. */
   readonly collections: number
-  /** Number of audit entries written. Equal to `evicted`. */
+  /**
+   * Number of audit entries written — one per policy eviction plus one per
+   * budget SLOT eviction (dropping a device-local cache copy writes none).
+   */
   readonly auditEntries: number
   /**
    * Number of slots that would have evicted (TTL/predicate triggered)
    * but were retained by a `legalHold` or `retainUntil` floor.
    */
   readonly held: number
+  /**
+   * #808: number of slots whose due policy eviction was skipped because they
+   * are pinned for offline on THIS device (pin state is device-local).
+   */
+  readonly pinned: number
+  /**
+   * #808: number of evictions performed by the `cacheBudget` LRU pass —
+   * internal slots evicted through the standard eviction writer plus
+   * device-local external cache copies dropped. 0 when no budget was given.
+   */
+  readonly budgetEvicted: number
+  /** #808: plaintext bytes freed by the `cacheBudget` LRU pass. */
+  readonly budgetBytesFreed: number
   /** Per-collection breakdown for diagnostics. */
   readonly byCollection: Record<string, { records: number; evicted: number }>
 }
@@ -156,6 +174,20 @@ export interface CompactRunOptions {
    * what would happen.
    */
   readonly dryRun?: boolean
+  /**
+   * #808 mobile cache budget: cap the locally-cached UNPINNED blob bytes.
+   * After the policy pass, a dedicated LRU pass walks every collection's
+   * slots (pinned slots and `legalHold`/`retainUntil`-held slots are exempt
+   * and uncounted) and evicts oldest-access-first — internal slots through
+   * the standard eviction writer (`deleteSlot` + a `'budget'` audit entry),
+   * external slots by dropping their device-local encrypted cache copy only
+   * (the object-store copy is authoritative and untouched) — until the
+   * remaining unpinned bytes fit `maxBytes`. Internal slots count their
+   * uncompressed `size`; external slots count `cachedBytes` (0 = nothing
+   * local, nothing to evict). LRU order comes from the device-local
+   * `lastAccessAt` stamp, falling back to `uploadedAt`.
+   */
+  readonly cacheBudget?: { readonly maxBytes: number }
 }
 
 export interface CompactionContext {
@@ -180,6 +212,13 @@ export interface CompactionContext {
   readonly listSlots: (collection: string, id: string) => Promise<SlotInfo[]>
   /** Delete a slot and decrement its blob's refCount. */
   readonly deleteSlot: (collection: string, id: string, slotName: string) => Promise<void>
+  /**
+   * #808: drop a slot's DEVICE-LOCAL cached copy (the encrypted external
+   * side-cache) without touching the slot or the object store. Returns the
+   * plaintext bytes freed. Optional — absent (or a 0 return) means external
+   * cache entries simply cannot be budget-evicted through this context.
+   */
+  readonly dropLocalCache?: (collection: string, id: string, slotName: string) => Promise<number>
 }
 
 export async function runCompaction(
@@ -189,6 +228,10 @@ export async function runCompaction(
   const now = options.now ?? new Date()
   const maxEvictions = options.maxEvictions ?? Infinity
   const dryRun = options.dryRun === true
+  if (options.cacheBudget !== undefined
+    && (!Number.isFinite(options.cacheBudget.maxBytes) || options.cacheBudget.maxBytes < 0)) {
+    throw new ValidationError('compact(): cacheBudget.maxBytes must be a non-negative finite number (#808)')
+  }
 
   const allCollections = await ctx.listCollections()
   const byCollection: Record<string, { records: number; evicted: number }> = {}
@@ -196,6 +239,7 @@ export async function runCompaction(
   let records = 0
   let auditEntries = 0
   let held = 0
+  let pinned = 0
   let collectionsWithPolicy = 0
 
   outer: for (const collectionName of allCollections) {
@@ -225,6 +269,15 @@ export async function runCompaction(
         const reason = evaluatePolicy(policy, record, slot, now)
         if (!reason) continue
 
+        // #808: device-local offline pin — an exemption inside this existing
+        // pass, exactly like a hold: counted, never evicted. `slot.pinned` is
+        // the device-local annotation `BlobSet.list()` stamps from the
+        // withBlobs() pin registry (never synced state).
+        if (slot.pinned === true) {
+          pinned += 1
+          continue
+        }
+
         // Retention floor: a legal hold or period-bound retainUntil
         // blocks an otherwise-due eviction. Counted, never evicted.
         if (isHeld(policy, record, now)) {
@@ -252,14 +305,128 @@ export async function runCompaction(
     }
   }
 
+  // #808: cache-budget LRU pass — runs AFTER the policy pass so a slot that
+  // just evicted no longer counts toward the budget. Reuses this module's own
+  // eviction writer (deleteSlot + audit), never a parallel one.
+  let budgetEvicted = 0
+  let budgetBytesFreed = 0
+  if (options.cacheBudget !== undefined) {
+    const pass = await runBudgetPass(ctx, options.cacheBudget.maxBytes, {
+      now, dryRun, remainingEvictions: maxEvictions - evicted,
+    })
+    budgetEvicted = pass.evicted
+    budgetBytesFreed = pass.bytesFreed
+    auditEntries += pass.auditEntries
+  }
+
   return {
     evicted,
     records,
     collections: collectionsWithPolicy,
     auditEntries,
     held,
+    pinned,
+    budgetEvicted,
+    budgetBytesFreed,
     byCollection,
   }
+}
+
+// ─── #808: cache-budget LRU pass ───────────────────────────────────────
+
+interface BudgetCandidate {
+  readonly collection: string
+  readonly recordId: string
+  readonly slotName: string
+  readonly eTag: string
+  readonly bytes: number
+  /** `'slot'` — internal blob, evicted via `deleteSlot`; `'cache'` — external device-local copy, dropped via `dropLocalCache`. */
+  readonly kind: 'slot' | 'cache'
+  readonly lastAccessMs: number
+}
+
+/**
+ * Enforce `cacheBudget.maxBytes` over the locally-cached UNPINNED blob bytes
+ * (see {@link CompactRunOptions.cacheBudget} for the full contract). Walks
+ * EVERY collection — unlike the policy pass, the budget is not gated on a
+ * declared `blobFields` config — but still honors a declared policy's
+ * `legalHold`/`retainUntil` floor where one exists.
+ */
+async function runBudgetPass(
+  ctx: CompactionContext,
+  maxBytes: number,
+  opts: { now: Date; dryRun: boolean; remainingEvictions: number },
+): Promise<{ evicted: number; bytesFreed: number; auditEntries: number }> {
+  const candidates: BudgetCandidate[] = []
+  let total = 0
+
+  for (const collectionName of await ctx.listCollections()) {
+    if (collectionName.startsWith('_')) continue
+    const config = ctx.getBlobFields(collectionName)
+    for (const recordId of await ctx.listRecords(collectionName)) {
+      const slots = await ctx.listSlots(collectionName, recordId).catch(() => [])
+      if (slots.length === 0) continue
+      // The record is only needed to evaluate a declared policy's retention
+      // floor — skip the decrypt entirely for policy-less collections.
+      const record = config
+        ? await ctx.getRecord<unknown>(collectionName, recordId).catch(() => null)
+        : null
+      for (const slot of slots) {
+        if (slot.pinned === true) continue // pinned: exempt AND uncounted (#808)
+        const policy = config?.[slot.name]
+        if (policy && record !== null && isHeld(policy, record, opts.now)) continue // floor blocks budget too
+        const lastAccessMs = Date.parse(slot.lastAccessAt ?? slot.uploadedAt) || 0
+        const isExternal = slot.external !== undefined
+        const bytes = isExternal ? slot.cachedBytes ?? 0 : slot.size
+        if (bytes <= 0) continue // external with no local copy: nothing cached to evict
+        total += bytes
+        candidates.push({
+          collection: collectionName, recordId, slotName: slot.name, eTag: slot.eTag,
+          bytes, kind: isExternal ? 'cache' : 'slot', lastAccessMs,
+        })
+      }
+    }
+  }
+
+  // Oldest access first; deterministic tiebreak so equal timestamps (common
+  // within one ms) never make the eviction order flap between runs.
+  candidates.sort((a, b) =>
+    a.lastAccessMs - b.lastAccessMs
+    || a.collection.localeCompare(b.collection)
+    || a.recordId.localeCompare(b.recordId)
+    || a.slotName.localeCompare(b.slotName))
+
+  let evicted = 0
+  let bytesFreed = 0
+  let auditEntries = 0
+  for (const c of candidates) {
+    if (total <= maxBytes || evicted >= opts.remainingEvictions) break
+    if (!opts.dryRun) {
+      if (c.kind === 'slot') {
+        await ctx.deleteSlot(c.collection, c.recordId, c.slotName)
+        await writeAuditEntry(ctx, {
+          id: generateEvictionId(c.collection, c.recordId, c.slotName),
+          collection: c.collection,
+          recordId: c.recordId,
+          slotName: c.slotName,
+          blobHash: c.eTag,
+          reason: 'budget',
+          evictedAt: opts.now.toISOString(),
+          actor: ctx.actor,
+        })
+        auditEntries += 1
+      } else {
+        // Device-local cache drop only — the slot (catalog) and the
+        // object-store copy are untouched, so no eviction audit entry.
+        await ctx.dropLocalCache?.(c.collection, c.recordId, c.slotName)
+      }
+    }
+    evicted += 1
+    bytesFreed += c.bytes
+    total -= c.bytes
+  }
+
+  return { evicted, bytesFreed, auditEntries }
 }
 
 /**

--- a/packages/hub/src/with-shape/blobs/blob-pinning.ts
+++ b/packages/hub/src/with-shape/blobs/blob-pinning.ts
@@ -1,0 +1,137 @@
+/**
+ * #808 — device-local blob pin registry + external side-cache + KPI counters.
+ *
+ * Pinning marks a blob slot "keep this available offline" **for this device
+ * only**. Pin state is intentionally NEVER written to the vault's
+ * `NoydbStore` — the vault store is the synced/shared substrate, and each
+ * device pins for itself. Instead, `withBlobs()` owns one {@link BlobPinCache}
+ * per strategy instance and threads it into every `BlobSet` it opens; the
+ * registry rows live in a pluggable {@link BlobPinStore}.
+ *
+ * The default backend is in-memory ({@link memoryBlobPinStore}) — the hub has
+ * NO device-persistence idiom of its own (it never touches IndexedDB or any
+ * Node fs API; persistence backends are the `to-*` package family), so a
+ * durable registry is supplied by the consumer:
+ * `withBlobs({ pinStore: myIdbBackedStore })`. The interface is four async
+ * methods, deliberately trivial to implement over IndexedDB / SQLite / a file.
+ *
+ * ## What a registry row holds
+ *
+ * One row per `{vault, collection, record, slot}` ({@link blobPinKey}):
+ *  - the pin flag + timestamps (LRU input for the cache-budget pass), and
+ *  - for `external: true` slots, the **local encrypted copy** of the object's
+ *    bytes ({@link BlobPinEntry.cipher}). The object-store copy of an external
+ *    blob lives OUTSIDE the zero-knowledge envelope by design; the local copy
+ *    does NOT — it is AES-256-GCM-encrypted under the vault's `_blob` DEK
+ *    through the same enclave path that encrypts blob chunks
+ *    (`encryptBytesWithAAD`, AAD-bound to the row's pin key), so a stolen
+ *    device store leaks nothing the vault store wouldn't.
+ *
+ * Internal (chunked) blobs never store bytes here — their ciphertext already
+ * lives in `_blob_chunks`; the registry only carries their pin flag and
+ * access times.
+ *
+ * @module
+ */
+
+/** One device-local registry row — see the module doc for the field posture. */
+export interface BlobPinEntry {
+  /** Slot is pinned for offline on THIS device. */
+  readonly pinned: boolean
+  /** ISO timestamp of the pin (absent when not pinned). */
+  readonly pinnedAt?: string
+  /** ISO timestamp of the last local read — LRU input for the budget pass. */
+  readonly lastAccessAt?: string
+  /** Plaintext byte length of the cached external copy (external slots only). */
+  readonly cachedBytes?: number
+  /**
+   * Encrypted local copy of an external slot's bytes: base64 IV + base64
+   * AES-256-GCM ciphertext under the vault's `_blob` DEK, AAD-bound to the
+   * row's {@link blobPinKey}. On an UNENCRYPTED vault (`encrypt: false`) the
+   * fallback mirrors the envelope convention: `iv === ''`, `data` = base64
+   * plaintext.
+   */
+  readonly cipher?: { readonly iv: string; readonly data: string }
+}
+
+/**
+ * Pluggable device-local backend for the pin registry (#808). Implementations
+ * MUST be device-local (never synced) — an IndexedDB- or file-backed store is
+ * the expected production shape; {@link memoryBlobPinStore} is the default.
+ */
+export interface BlobPinStore {
+  get(key: string): Promise<BlobPinEntry | null>
+  set(key: string, entry: BlobPinEntry): Promise<void>
+  delete(key: string): Promise<void>
+  /** All rows whose key starts with `prefix` (`''` = every row). */
+  entries(prefix: string): Promise<Array<{ key: string; entry: BlobPinEntry }>>
+}
+
+/**
+ * In-memory {@link BlobPinStore} — the default. Pin state then lasts for the
+ * strategy instance's lifetime (one app session); pass a durable store to
+ * `withBlobs({ pinStore })` to keep pins across restarts.
+ */
+export function memoryBlobPinStore(): BlobPinStore {
+  const rows = new Map<string, BlobPinEntry>()
+  return {
+    async get(key) {
+      return rows.get(key) ?? null
+    },
+    async set(key, entry) {
+      rows.set(key, entry)
+    },
+    async delete(key) {
+      rows.delete(key)
+    },
+    async entries(prefix) {
+      const out: Array<{ key: string; entry: BlobPinEntry }> = []
+      for (const [key, entry] of rows) {
+        if (key.startsWith(prefix)) out.push({ key, entry })
+      }
+      return out
+    },
+  }
+}
+
+/**
+ * Device-local blob-cache KPI counters (#808) — read via
+ * `withBlobs().cacheStats()`. "Local" reads (internal chunks, cached external
+ * copies) count as hits; network fetches from the object store count as
+ * misses and add to `bytesDownloaded` (the 4G-budget number).
+ */
+export interface BlobCacheStats {
+  readonly hits: number
+  readonly misses: number
+  readonly bytesDownloaded: number
+}
+
+/**
+ * The per-strategy bundle `withBlobs()` threads into every `BlobSet`: the
+ * registry backend plus the shared mutable KPI counters.
+ *
+ * @internal
+ */
+export interface BlobPinCache {
+  readonly store: BlobPinStore
+  readonly stats: { hits: number; misses: number; bytesDownloaded: number }
+}
+
+/** @internal */
+export function createBlobPinCache(store?: BlobPinStore): BlobPinCache {
+  return {
+    store: store ?? memoryBlobPinStore(),
+    stats: { hits: 0, misses: 0, bytesDownloaded: 0 },
+  }
+}
+
+/**
+ * Registry key for one slot's row: `{vault}::{collection}::{record}::{slot}`
+ * (the blobs' established `::` separator — record ids and slot names are
+ * already `::`-refused at the write surface, see `assertKeyPartSafe`).
+ * Omitting `slotName` yields the record's row PREFIX (for per-record scans).
+ */
+export function blobPinKey(vault: string, collection: string, recordId: string, slotName?: string): string {
+  const prefix = `${vault}::${collection}::${recordId}::`
+  return slotName === undefined ? prefix : prefix + slotName
+}

--- a/packages/hub/src/with-shape/blobs/blob-set.ts
+++ b/packages/hub/src/with-shape/blobs/blob-set.ts
@@ -25,7 +25,8 @@ import {
   sha256Hex,
   type EnclaveKey,
 } from '../../kernel/enclave/index.js'
-import { BlobIntentPendingError, ConflictError, NotFoundError, TamperedError, TierNotGrantedError, UnsupportedTierCompositionError, ValidationError } from '../../kernel/errors.js'
+import { BlobIntentPendingError, BlobOfflineError, ConflictError, NotFoundError, TamperedError, TierNotGrantedError, UnsupportedTierCompositionError, ValidationError } from '../../kernel/errors.js'
+import { blobPinKey, type BlobPinCache, type BlobPinEntry } from './blob-pinning.js'
 import { liveRecordIsElevated, liveRecordTier } from '../../kernel/tier-visibility.js'
 import { dekKey, assertTierAccess } from '../../with-party/team/tiers.js'
 import type { UnlockedKeyring } from '../../with-party/team/keyring.js'
@@ -188,6 +189,12 @@ export class BlobSet {
   private readonly blobFields: BlobFieldsConfig | undefined
   private readonly keyring: UnlockedKeyring | undefined
   /**
+   * Device-local pin registry + external side-cache + KPI counters (#808).
+   * Injected by `withBlobs()` (one shared instance per strategy — per
+   * "device"); absent on a direct construction that never threads one.
+   */
+  private readonly pinCache: BlobPinCache | undefined
+  /**
    * Set only on the cleared clone `atTier()` returns (#749) — never by
    * `openSlot`/`Collection.blob()`. Its presence is what makes a `BlobSet`
    * a cleared view: see `ownerRecordElevated()`/`ownerTier()`.
@@ -210,6 +217,7 @@ export class BlobSet {
     blobFields?: BlobFieldsConfig
     keyring?: UnlockedKeyring
     clearedTier?: number
+    pinCache?: BlobPinCache
   }) {
     this.store = opts.store
     this.vault = opts.vault
@@ -226,6 +234,7 @@ export class BlobSet {
     this.blobFields = opts.blobFields
     this.keyring = opts.keyring
     this.clearedTier = opts.clearedTier
+    this.pinCache = opts.pinCache
   }
 
   /**
@@ -401,6 +410,7 @@ export class BlobSet {
       ...(this.maxBlobBytes !== undefined ? { maxBlobBytes: this.maxBlobBytes } : {}),
       ...(this.objectStore !== undefined ? { objectStore: this.objectStore } : {}),
       ...(this.blobFields !== undefined ? { blobFields: this.blobFields } : {}),
+      ...(this.pinCache !== undefined ? { pinCache: this.pinCache } : {}),
     })
   }
 
@@ -1026,6 +1036,19 @@ export class BlobSet {
     retainedShared: string[]
     residue: string[]
   }> {
+    // #808: device-local hygiene — the record's registry rows (pins, access
+    // stamps, cached external copies) die with it. Best-effort and FIRST: a
+    // failing device-local store must never abort the erasure cascade, and
+    // dropping the encrypted cached copies before the shred means no local
+    // copy outlives the record even if the shred itself later degrades.
+    if (this.pinCache) {
+      try {
+        const rows = await this.pinCache.store.entries(blobPinKey(this.vault, this.collection, this.recordId))
+        for (const { key } of rows) await this.pinCache.store.delete(key)
+      } catch {
+        // Device-local only — never part of the erasure accounting.
+      }
+    }
     const tierArg = ownerTier ?? 0
     const intent = await this.resolveShredIntent(tierArg)
     if (!intent) return this.unmarkedShred(tierArg)
@@ -2097,8 +2120,14 @@ export class BlobSet {
     for (let i = 0; i < blob.chunkCount; i++) {
       const chunk = await this.readChunk(blob.eTag, i, blob.chunkCount, chunkKey)
       if (!chunk) {
-        throw new NotFoundError(
-          `Blob chunk ${i}/${blob.chunkCount} missing for eTag "${blob.eTag}" on record "${this.recordId}"`,
+        // #808 offline taxonomy: the index/slot row is present but the chunk
+        // bytes are not IN THIS STORE — a cold local copy (not yet synced to
+        // this device, or evicted), not a missing slot. Typed so UIs can
+        // render "available when online" instead of a silent empty file.
+        throw new BlobOfflineError(
+          this.collection, this.recordId, undefined,
+          `chunk ${i}/${blob.chunkCount} for eTag "${blob.eTag}" is absent from the local store — ` +
+            'content not yet synced to this device, or evicted (#808)',
         )
       }
       chunks.push(chunk)
@@ -2531,7 +2560,11 @@ export class BlobSet {
   /**
    * Fetch all bytes for the named slot.
    * Returns `null` if the slot does not exist.
-   * Throws `NotFoundError` if the index entry exists but a chunk is missing.
+   * Throws `BlobOfflineError` if the content is not available locally (#808):
+   * an internal blob whose chunk envelopes are absent from the local store, or
+   * an external slot with no local cached copy while the object store is
+   * unreachable. External reads populate the device-local encrypted
+   * side-cache, so a repeat read is served locally (see `pin()`).
    */
   async get(slotName: string): Promise<Uint8Array | null> {
     if (await this.ownerRecordElevated()) return null // #724: elevated ≡ invisible, mirrors get()
@@ -2540,10 +2573,7 @@ export class BlobSet {
     if (!slot) return null
 
     if (slot.external) {
-      if (!this.objectStore) {
-        throw new NotFoundError(`Blob slot "${slotName}" is external but no objectStore is configured`)
-      }
-      return this.objectStore.getObject(slot.external.key)
+      return this.readExternal(slotName, slot)
     }
 
     const result = await this.loadBlobObject(slot.eTag)
@@ -2558,7 +2588,9 @@ export class BlobSet {
     // OPENED the index envelope (`result.atTier` — #747), not the flat one,
     // so it must be resolved explicitly here.
     const blobDEK = this.encrypted ? await this.getDEK(dekKey(BLOB_COLLECTION, result.atTier)) : undefined
-    return this.fetchAllChunks(result.blob, blobDEK, this.flatFallbackVerifyETag(slot.eTag, result.atTier))
+    const bytes = await this.fetchAllChunks(result.blob, blobDEK, this.flatFallbackVerifyETag(slot.eTag, result.atTier))
+    await this.recordLocalHit(slotName) // #808: KPI + LRU access stamp
+    return bytes
   }
 
   /**
@@ -2691,16 +2723,36 @@ export class BlobSet {
   /**
    * List all slot entries for this record.
    * Returns metadata only — no chunk data is loaded.
+   *
+   * #808: when a pin registry is present (`withBlobs()`), each entry is
+   * annotated with this DEVICE's view — `pinned` / `lastAccessAt` /
+   * `cachedBytes` (see their `SlotInfo` doc comments). The annotations come
+   * from the device-local registry, never the vault store, and are what
+   * `vault.compact()`'s pin exemption + cache-budget LRU pass key off.
    */
   async list(): Promise<SlotInfo[]> {
     if (await this.ownerRecordElevated()) return [] // #724: elevated ≡ invisible, mirrors get()
     const { slots } = await this.loadSlots()
     // #746: `pendingRelease` is internal rehome-journal bookkeeping (see
     // `SlotRecord`'s doc comment) — never surfaced through the public API.
-    return Object.entries(slots).map(([name, slot]) => {
+    const infos = Object.entries(slots).map(([name, slot]) => {
       const pub: SlotRecord = { ...slot }
       delete (pub as { pendingRelease?: string }).pendingRelease
       return { name, ...pub }
+    })
+    if (!this.pinCache) return infos
+    const prefix = blobPinKey(this.vault, this.collection, this.recordId)
+    const rows = await this.pinCache.store.entries(prefix)
+    const byName = new Map(rows.map(({ key, entry }) => [key.slice(prefix.length), entry]))
+    return infos.map((info) => {
+      const entry = byName.get(info.name)
+      if (!entry) return info
+      return {
+        ...info,
+        ...(entry.pinned ? { pinned: true } : {}),
+        ...(entry.lastAccessAt !== undefined ? { lastAccessAt: entry.lastAccessAt } : {}),
+        ...(entry.cachedBytes !== undefined ? { cachedBytes: entry.cachedBytes } : {}),
+      }
     })
   }
 
@@ -2736,6 +2788,247 @@ export class BlobSet {
         // Best-effort — a missed decrement is reconciled by a later pass.
       })
     }
+
+    // #808: the slot is gone — drop its device-local registry row (pin flag /
+    // access stamp / cached external copy). Best-effort hygiene: a failing
+    // device-local store must not fail the vault-store delete that already
+    // landed above.
+    if (this.pinCache) {
+      await this.pinCache.store.delete(this.pinKeyFor(slotName)).catch(() => {})
+    }
+  }
+
+  // ─── Public API: Offline pinning + device-local cache (#808) ──────
+
+  /**
+   * Pin the named slot for offline availability ON THIS DEVICE.
+   *
+   * - Downloads eagerly (call while online): an internal blob's chunks are
+   *   fetched once to prove they are locally readable; an `external` slot's
+   *   bytes are fetched from the object store and kept in the device-local
+   *   side-cache, **encrypted** under the vault's `_blob` DEK via the same
+   *   enclave path as chunk encryption (the object-store copy sits outside
+   *   the ZK envelope by design; the local copy does not).
+   * - A pinned slot is EXEMPT from `vault.compact()` eviction — both the
+   *   `blobFields` policy pass and the `cacheBudget` LRU pass.
+   * - Pin state is device-local (never synced): it lives in the `withBlobs()`
+   *   pin registry, not in the vault store. Each device pins for itself.
+   *
+   * Throws `NotFoundError` for a missing slot and `BlobOfflineError` when the
+   * eager download cannot complete (offline).
+   */
+  async pin(slotName: string): Promise<void> {
+    this.assertKeyPartSafe(this.recordId, 'record id')
+    this.assertKeyPartSafe(slotName, 'slot name')
+    const pc = this.requirePinCache('pin')
+    // #724: elevated ≡ invisible — same posture as get(), surfaced as the
+    // not-found a caller without clearance would legitimately see.
+    if (await this.ownerRecordElevated()) {
+      throw new NotFoundError(`Slot "${slotName}" not found on record "${this.recordId}"`)
+    }
+    const { slots } = await this.loadSlots()
+    const slot = slots[slotName]
+    if (!slot) throw new NotFoundError(`Slot "${slotName}" not found on record "${this.recordId}"`)
+
+    const now = new Date().toISOString()
+    if (slot.external) {
+      // Eager download (or local cache hit) — readExternal caches the fetched
+      // bytes encrypted, so after this the registry row always carries the
+      // local copy; then flip its pin flag on.
+      const bytes = await this.readExternal(slotName, slot)
+      if (bytes === null) {
+        throw new NotFoundError(`External object for blob slot "${slotName}" is missing from the object store`)
+      }
+      const key = this.pinKeyFor(slotName)
+      const entry = await pc.store.get(key)
+      if (entry?.cipher) {
+        await pc.store.set(key, { ...entry, pinned: true, pinnedAt: entry.pinnedAt ?? now })
+      } else {
+        // Defensive: readExternal always caches on success when a registry is
+        // present — but never leave a pin without its local copy.
+        await this.cacheExternalCopy(slotName, bytes, { pin: true })
+      }
+      return
+    }
+
+    // Internal (chunked) blob: prove the content is locally readable NOW —
+    // a cold chunk surfaces BlobOfflineError here, not at first offline read.
+    const result = await this.loadBlobObject(slot.eTag)
+    if (!result) throw new NotFoundError(`BlobObject ${slot.eTag} not found`)
+    const blobDEK = this.encrypted ? await this.getDEK(dekKey(BLOB_COLLECTION, result.atTier)) : undefined
+    await this.fetchAllChunks(result.blob, blobDEK, this.flatFallbackVerifyETag(slot.eTag, result.atTier))
+    const key = this.pinKeyFor(slotName)
+    const prev = await pc.store.get(key)
+    await pc.store.set(key, { ...(prev ?? {}), pinned: true, pinnedAt: now, lastAccessAt: now })
+  }
+
+  /**
+   * Unpin the named slot on this device — it returns to the normal lifecycle:
+   * `blobFields` policy eviction applies again, and any local cached copy
+   * (external slots) stays but becomes budget-managed (`cacheBudget` LRU).
+   * A no-op when the slot is not pinned here.
+   */
+  async unpin(slotName: string): Promise<void> {
+    this.assertKeyPartSafe(slotName, 'slot name')
+    const pc = this.requirePinCache('unpin')
+    const key = this.pinKeyFor(slotName)
+    const entry = await pc.store.get(key)
+    if (!entry?.pinned) return
+    const rest = { ...entry, pinned: false }
+    delete (rest as { pinnedAt?: string }).pinnedAt
+    await pc.store.set(key, rest)
+  }
+
+  /** Whether the named slot is pinned for offline ON THIS DEVICE (#808). */
+  async isPinned(slotName: string): Promise<boolean> {
+    const pc = this.requirePinCache('isPinned')
+    const entry = await pc.store.get(this.pinKeyFor(slotName))
+    return entry?.pinned === true
+  }
+
+  /**
+   * Drop this slot's device-local cached copy (the encrypted external
+   * side-cache) WITHOUT touching the slot, the vault store, or the object
+   * store. Returns the plaintext bytes freed (0 when nothing was cached, the
+   * slot is pinned — pinned copies are exempt — or no registry is present).
+   * The cache-budget pass inside `vault.compact()` is the expected caller;
+   * the LRU access row itself is kept.
+   */
+  async dropLocalCache(slotName: string): Promise<number> {
+    const pc = this.pinCache
+    if (!pc) return 0
+    const key = this.pinKeyFor(slotName)
+    const entry = await pc.store.get(key)
+    if (!entry || entry.pinned || !entry.cipher) return 0
+    const freed = entry.cachedBytes ?? 0
+    const rest = { ...entry }
+    delete (rest as { cipher?: unknown }).cipher
+    delete (rest as { cachedBytes?: number }).cachedBytes
+    await pc.store.set(key, rest)
+    return freed
+  }
+
+  // ─── Internal: device-local pin registry plumbing (#808) ──────────
+
+  /** This slot's registry key — see {@link blobPinKey}. */
+  private pinKeyFor(slotName: string): string {
+    return blobPinKey(this.vault, this.collection, this.recordId, slotName)
+  }
+
+  /** AAD binding for a cached external copy: the row's own registry key. */
+  private pinCopyAAD(slotName: string): Uint8Array {
+    return new TextEncoder().encode(`pin:${this.pinKeyFor(slotName)}`)
+  }
+
+  private requirePinCache(op: string): BlobPinCache {
+    if (!this.pinCache) {
+      throw new ValidationError(
+        `BlobSet.${op}() requires the withBlobs() pin registry — this handle was constructed without one (#808)`,
+      )
+    }
+    return this.pinCache
+  }
+
+  /** KPI hit + LRU access stamp for a successful LOCAL read. No-op without a registry. */
+  private async recordLocalHit(slotName: string, prev?: BlobPinEntry | null): Promise<void> {
+    const pc = this.pinCache
+    if (!pc) return
+    pc.stats.hits += 1
+    const key = this.pinKeyFor(slotName)
+    const entry = prev ?? await pc.store.get(key)
+    await pc.store.set(key, { ...(entry ?? { pinned: false }), lastAccessAt: new Date().toISOString() })
+  }
+
+  /**
+   * Read an `external` slot (#808 taxonomy): local encrypted side-cache first
+   * (hit); else the object store (miss + `bytesDownloaded`), auto-caching the
+   * fetched bytes so the NEXT read — and any later offline read — is local.
+   * A network failure with no local copy is the typed `BlobOfflineError`;
+   * a genuinely absent object (fetch succeeded, nothing there) stays `null`.
+   */
+  private async readExternal(slotName: string, slot: SlotRecord): Promise<Uint8Array | null> {
+    const pc = this.pinCache
+    if (pc) {
+      const key = this.pinKeyFor(slotName)
+      const entry = await pc.store.get(key)
+      const cached = entry?.cipher ? await this.decryptCachedCopy(slotName, entry.cipher) : null
+      if (cached) {
+        await this.recordLocalHit(slotName, entry)
+        return cached
+      }
+    }
+
+    if (!this.objectStore) {
+      throw new NotFoundError(`Blob slot "${slotName}" is external but no objectStore is configured`)
+    }
+    let bytes: Uint8Array | null
+    try {
+      bytes = await this.objectStore.getObject(slot.external!.key)
+    } catch (err) {
+      throw new BlobOfflineError(
+        this.collection, this.recordId, slotName,
+        'no local cached copy and the object store is unreachable — pin() the slot while online to keep it readable offline (#808)',
+        err,
+      )
+    }
+    if (bytes === null) return null
+    if (pc) {
+      pc.stats.misses += 1
+      pc.stats.bytesDownloaded += bytes.byteLength
+      // Best-effort: a failing device-local cache write must not fail a read
+      // that already holds the bytes (e.g. a full IndexedDB quota). The next
+      // read simply fetches again.
+      await this.cacheExternalCopy(slotName, bytes).catch(() => {})
+    }
+    return bytes
+  }
+
+  /**
+   * Decrypt a cached external copy. `null` (treated as a cache miss → network
+   * refresh) when the vault keys can no longer open it — e.g. the copy was
+   * cached before the owning record moved tiers, so it is sealed under a DEK
+   * this handle no longer resolves. Genuine non-crypto failures propagate.
+   */
+  private async decryptCachedCopy(slotName: string, cipher: { iv: string; data: string }): Promise<Uint8Array | null> {
+    if (!this.encrypted) return base64ToBuffer(cipher.data)
+    const dek = await this.getDEK(dekKey(BLOB_COLLECTION, await this.ownerTier()))
+    try {
+      return await decryptBytesWithAAD(cipher.iv, cipher.data, dek, this.pinCopyAAD(slotName))
+    } catch (err) {
+      if (err instanceof TamperedError) return null
+      throw err
+    }
+  }
+
+  /**
+   * Write an external slot's bytes into the device-local side-cache —
+   * ENCRYPTED under the vault's `_blob` DEK (owner tier) via the enclave's
+   * AAD-bound path, mirroring chunk encryption; base64 plaintext with
+   * `iv: ''` only on an unencrypted vault (the envelope convention). A
+   * pre-existing pin flag survives the rewrite.
+   */
+  private async cacheExternalCopy(slotName: string, bytes: Uint8Array, opts?: { pin?: boolean }): Promise<void> {
+    const pc = this.pinCache
+    if (!pc) return
+    let cipher: { iv: string; data: string }
+    if (this.encrypted) {
+      const dek = await this.getDEK(dekKey(BLOB_COLLECTION, await this.ownerTier()))
+      const enc = await encryptBytesWithAAD(bytes, dek, this.pinCopyAAD(slotName))
+      cipher = { iv: enc.iv, data: enc.data }
+    } else {
+      cipher = { iv: '', data: bufferToBase64(bytes) }
+    }
+    const now = new Date().toISOString()
+    const key = this.pinKeyFor(slotName)
+    const prev = await pc.store.get(key)
+    const pinned = opts?.pin === true || prev?.pinned === true
+    await pc.store.set(key, {
+      pinned,
+      ...(pinned ? { pinnedAt: (opts?.pin === true ? now : prev?.pinnedAt) ?? now } : {}),
+      lastAccessAt: now,
+      cachedBytes: bytes.byteLength,
+      cipher,
+    })
   }
 
   /**

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -1032,7 +1032,11 @@ const KERNEL_SURFACE_BUDGET = {
   // getCover is the canonical method; getPublicEnvelope remains as a
   // @deprecated one-line delegator for one pre-release window, then this
   // ceiling ratchets back down with it.
-  'packages/hub/src/kernel/vault.ts': 3964,
+  // Bumped 3964→3965 (#808 blob pinning + cache budget): compact()'s
+  // CompactionContext gains ONE thin `dropLocalCache` closure line so the
+  // budget pass can drop device-local external cache copies; all the
+  // pin/budget machinery itself lives in with-shape/blobs/ behind withBlobs().
+  'packages/hub/src/kernel/vault.ts': 3965,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
Closes #808. Milestone: LINE/LIFF client portal [api].

## What

- **Pin surface** (behind `withBlobs()`): `pin`/`unpin`/`isPinned`/`dropLocalCache` per slot — pin downloads eagerly, exempts from compaction + budget eviction; unpin restores normal lifecycle.
- **Device-local by construction**: pluggable `BlobPinStore` + in-memory default (one per `withBlobs()` = one device); no pin state ever reaches the vault store (tested with a second instance seeing zero pins). Durable stores are consumer-supplied — hub keeps its no-device-persistence law.
- **Cache budget**: `vault.compact({ cacheBudget: { maxBytes } })` — LRU over unpinned cached bytes, reusing the existing eviction writer + audit trail (reason `'budget'`); `legalHold`/`retainUntil` floors beat the budget.
- **Offline taxonomy**: pinned → always local; unpinned+cached → local; cold+offline → new typed `BlobOfflineError` (root-barrel + golden consciously updated). Behavior note: the internal missing-chunk cell retyped from `NotFoundError` — called out in the changeset.
- **External-pin encryption posture**: pinned/cached external bytes AES-GCM under the `_blob` DEK via the existing enclave primitive (no new crypto surface), AAD-bound to the registry key; tests assert ciphertext-only; undecryptable cache degrades to miss+refresh. External unpinned reads auto-populate the cache (what makes the budget meaningful).
- **KPI**: `cacheStats()` → hits/misses/bytesDownloaded for the showcase's 4G chart.
- Docs: via-blob page gains the mobile strategy section + offline matrix + posture statement.

## Verification

17 new tests (TDD — passed on first implementation run) · full hub **529 files / 4558 tests** · typecheck · lint · build · `check:architecture` ✓ (vault ceiling 3964→3965, one closure line) · bundle-check ✓ — blobs scenario +59 B gz verified as feature weight (entry-chunk pin-cache factory; floor unchanged, leaks clean), baseline consciously hand-edited per the established procedure · knip zero new findings. Changeset: `@noy-db/hub` minor.