### PR TITLE
feat(in-pwa): new satellite — installable/offline shell (#803)

### DIFF
--- a/packages/in-pwa/LICENSE
+++ b/packages/in-pwa/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 vLannaAi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/in-pwa/README.md
+++ b/packages/in-pwa/README.md
@@ -1,0 +1,190 @@
+# @noy-db/in-pwa
+
+[![npm](https://img.shields.io/npm/v/%40noy-db/in-pwa.svg)](https://www.npmjs.com/package/@noy-db/in-pwa)
+
+> Installable/offline shell helpers for noy-db SPAs
+
+Part of [**`@noy-db/hub`**](https://www.npmjs.com/package/@noy-db/hub) — the zero-knowledge, offline-first, encrypted document store.
+
+## Install
+
+```bash
+pnpm add @noy-db/hub @noy-db/in-pwa
+```
+
+## The premise: the PWA starts empty
+
+An installed PWA lives in **its own storage partition**. On first open it holds no
+data: the app runs the online enrollment (unlock + re-invite via
+[`@noy-db/on-oidc`](https://github.com/vLannaAi/noy-db/tree/main/packages/on-oidc))
+and hydrates the vault from the firm cloud store into
+[`@noy-db/to-browser-idb`](https://github.com/vLannaAi/noy-db/tree/main/packages/to-browser-idb).
+From then on the installed app is the **offline-capable home of the vault**:
+offline boot = cached app shell (service worker) + local IndexedDB vault.
+
+This package is the browser-shell plumbing around that lifecycle. It holds **no
+keys** and sees **no plaintext** — every helper here operates on browser shell
+APIs or on opaque ciphertext-store presence, so it adds nothing to the threat
+model.
+
+## Persistence & eviction
+
+Eviction of the local vault is the top PWA risk. iOS ITP evicts all
+script-writable storage (IndexedDB included) of **non-installed** web content
+after ~7 days without interaction; installed home-screen apps are safer, and
+`navigator.storage.persist()` exempts an origin from best-effort eviction where
+granted. Two helpers cover the risk:
+
+### `requestPersistence()`
+
+```ts
+import { requestPersistence } from '@noy-db/in-pwa'
+
+const res = await requestPersistence()
+// { persisted: boolean, quota?: number, usage?: number,
+//   grantedBy: 'already' | 'granted' | 'denied' | 'unsupported' }
+```
+
+Wraps `navigator.storage.persist()` + `estimate()` with a clear grant/deny
+signal. **Never throws** — browsers without the Storage API resolve to
+`grantedBy: 'unsupported'`. Call it during enrollment; warn the user on
+`'denied'`.
+
+### `guardLocalVault()` — fail closed at boot
+
+If the partition *was* evicted, the app must never crash and never present a
+silent empty vault as truth. The guard probes the local store before the vault
+is opened and routes a missing vault into re-enrollment:
+
+```ts
+import { guardLocalVault } from '@noy-db/in-pwa'
+import { browserIdb } from '@noy-db/to-browser-idb'
+
+const store = browserIdb()
+const { healthy } = await guardLocalVault(store, 'firm', (why) => {
+  // why: { present: false, reason: 'empty' | 'probe-failed', cause? }
+  routeToReEnrollment()
+})
+if (healthy) {
+  /* open the vault normally */
+}
+```
+
+The probe (`probeLocalVault(store, vaultId)`) is **store-agnostic** — it speaks
+only the 6-method `NoydbStore` contract (`@noy-db/hub/to`), never
+`to-browser-idb` internals. It checks the vault's `_keyring` marker records
+first (every encrypted vault persists its owner keyring at creation — the same
+signal the hub uses for "vault provisioned"), then falls back to a `loadAll()`
+envelope scan for plaintext-mode vaults. A **broken store is treated exactly
+like a missing vault**: probe errors resolve to
+`{ present: false, reason: 'probe-failed' }` and trigger `onEvicted` — fail
+closed, never a throw from the probe path.
+
+## Install UX
+
+```ts
+import { captureInstallPrompt, getDisplayContext, isIosSafari } from '@noy-db/in-pwa'
+
+// Android/desktop Chromium: defer the browser prompt, re-fire it from your UI.
+const install = captureInstallPrompt() // call once at boot
+// later, on a user gesture:
+const outcome = await install.promptInstall() // 'accepted' | 'dismissed' | 'unavailable'
+
+getDisplayContext() // 'pwa' (standalone display-mode / iOS navigator.standalone) | 'browser'
+isIosSafari()       // true → show the "Add to Home Screen" share-sheet interstitial
+                    // (iOS never fires beforeinstallprompt)
+```
+
+The shared shell-context contract with `@noy-db/in-liff` is exported here as a
+plain string union (no runtime coupling):
+
+```ts
+export type AppShellContext = 'liff' | 'browser' | 'pwa'
+```
+
+## Online/offline transitions
+
+```ts
+import { watchOnline } from '@noy-db/in-pwa'
+
+const stop = watchOnline((online) => syncStrategy.setOnline(online))
+```
+
+Invokes the callback immediately with `navigator.onLine`, then on every
+`online`/`offline` event — shaped for feeding the sync engine's `isOnline`
+flag (reconnect replay of the dirty queue lives in `with-sync`; this package
+does not import it).
+
+## Service-worker recipe (copy, don't import)
+
+This package ships **no service-worker runtime** — the SW below is a recipe you
+copy into your app and version yourself.
+
+> **Hard rule: vault data NEVER goes in the SW cache.** The vault lives
+> encrypted in `to-browser-idb`; the service worker caches the **app shell
+> only** (HTML/JS/CSS/icons). A SW cache of vault responses would create a
+> second, unmanaged copy of ciphertext outside the store contract — and a
+> plaintext copy if you cached decrypted API responses. Don't.
+
+```js
+// sw.js — app-shell caching only. Bump SHELL_CACHE on every deploy.
+const SHELL_CACHE = 'app-shell-v1'
+const SHELL_ASSETS = ['/', '/index.html', '/assets/app.js', '/assets/app.css', '/icons/192.png']
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(SHELL_CACHE).then((cache) => cache.addAll(SHELL_ASSETS)))
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  // Drop caches from previous shell versions.
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) => Promise.all(keys.filter((k) => k !== SHELL_CACHE).map((k) => caches.delete(k))))
+      .then(() => self.clients.claim()),
+  )
+})
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url)
+  // App shell only: same-origin GET navigations and static assets.
+  // Everything else (sync traffic, APIs) passes straight to the network —
+  // vault data is never cached here.
+  if (event.request.method !== 'GET' || url.origin !== self.location.origin) return
+  event.respondWith(
+    caches.match(event.request).then((hit) => hit ?? fetch(event.request)),
+  )
+})
+```
+
+Offline boot then composes as: SW serves the cached shell → `guardLocalVault()`
+confirms the local vault is present → the app opens it from `to-browser-idb`
+with no network at all.
+
+## Detaching from LINE / re-enrollment
+
+Storage partitions are never transferable: LINE's WebView, the browser tab, and
+the installed PWA each have isolated storage, so moving the vault into the
+installed app is a **re-enroll + re-sync ceremony, never a data transfer** — the
+firm re-invites the device via the
+[`@noy-db/on-oidc`](https://github.com/vLannaAi/noy-db/tree/main/packages/on-oidc)
+unlock flow and the fresh partition hydrates from the firm cloud store, exactly
+like first enrollment. `guardLocalVault()`'s `onEvicted` hook is where that
+ceremony is (re-)entered.
+
+## Status
+
+**Pre-release** (`0.4.0-pre.1`). API may change before `1.0`.
+
+## Documentation
+
+See the [main repository](https://github.com/vLannaAi/noy-db#readme) for setup, examples, and the full subsystem catalog.
+
+- Source — [`packages/in-pwa`](https://github.com/vLannaAi/noy-db/tree/main/packages/in-pwa)
+- Issues — [github.com/vLannaAi/noy-db/issues](https://github.com/vLannaAi/noy-db/issues)
+- Spec — [`SPEC.md`](https://github.com/vLannaAi/noy-db-docs/blob/main/SPEC.md)
+
+## License
+
+[MIT](./LICENSE) © vLannaAi

--- a/packages/in-pwa/__tests__/browser-shell.test.ts
+++ b/packages/in-pwa/__tests__/browser-shell.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  requestPersistence,
+  captureInstallPrompt,
+  getDisplayContext,
+  isIosSafari,
+  watchOnline,
+} from '../src/index.js'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// ---------------------------------------------------------------------------
+// requestPersistence
+// ---------------------------------------------------------------------------
+
+interface StorageStub {
+  persist?: () => Promise<boolean>
+  persisted?: () => Promise<boolean>
+  estimate?: () => Promise<{ quota?: number; usage?: number }>
+}
+
+function stubStorage(storage: StorageStub | undefined): void {
+  vi.stubGlobal('navigator', storage === undefined ? {} : { storage })
+}
+
+describe('requestPersistence', () => {
+  it("'unsupported' when navigator.storage is absent — never throws", async () => {
+    stubStorage(undefined)
+    await expect(requestPersistence()).resolves.toEqual({
+      persisted: false,
+      grantedBy: 'unsupported',
+    })
+  })
+
+  it("'unsupported' when navigator itself is absent", async () => {
+    vi.stubGlobal('navigator', undefined)
+    await expect(requestPersistence()).resolves.toEqual({
+      persisted: false,
+      grantedBy: 'unsupported',
+    })
+  })
+
+  it("'already' when the origin was persistent before the call", async () => {
+    stubStorage({
+      persisted: async () => true,
+      persist: vi.fn(async () => true),
+      estimate: async () => ({ quota: 1000, usage: 10 }),
+    })
+    await expect(requestPersistence()).resolves.toEqual({
+      persisted: true,
+      grantedBy: 'already',
+      quota: 1000,
+      usage: 10,
+    })
+  })
+
+  it("'granted' when persist() succeeds", async () => {
+    stubStorage({
+      persisted: async () => false,
+      persist: async () => true,
+      estimate: async () => ({ quota: 500, usage: 5 }),
+    })
+    await expect(requestPersistence()).resolves.toEqual({
+      persisted: true,
+      grantedBy: 'granted',
+      quota: 500,
+      usage: 5,
+    })
+  })
+
+  it("'denied' when persist() is declined", async () => {
+    stubStorage({ persisted: async () => false, persist: async () => false })
+    await expect(requestPersistence()).resolves.toEqual({
+      persisted: false,
+      grantedBy: 'denied',
+    })
+  })
+
+  it("a throwing Storage API resolves to 'unsupported', never throws", async () => {
+    stubStorage({
+      persisted: async () => {
+        throw new Error('blocked')
+      },
+      persist: async () => {
+        throw new Error('blocked')
+      },
+    })
+    await expect(requestPersistence()).resolves.toEqual({
+      persisted: false,
+      grantedBy: 'unsupported',
+    })
+  })
+
+  it('a failing estimate() does not mask the persistence answer', async () => {
+    stubStorage({
+      persisted: async () => false,
+      persist: async () => true,
+      estimate: async () => {
+        throw new Error('nope')
+      },
+    })
+    await expect(requestPersistence()).resolves.toEqual({
+      persisted: true,
+      grantedBy: 'granted',
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// captureInstallPrompt
+// ---------------------------------------------------------------------------
+
+function makeBeforeInstallPromptEvent(outcome: 'accepted' | 'dismissed') {
+  const prompt = vi.fn(async () => {})
+  const event = Object.assign(new Event('beforeinstallprompt', { cancelable: true }), {
+    prompt,
+    userChoice: Promise.resolve({ outcome }),
+  })
+  return { event, prompt }
+}
+
+describe('captureInstallPrompt', () => {
+  it("resolves 'unavailable' when the event never fired (iOS / already installed)", async () => {
+    const handle = captureInstallPrompt(new EventTarget())
+    expect(handle.captured).toBe(false)
+    await expect(handle.promptInstall()).resolves.toBe('unavailable')
+  })
+
+  it('captures the event (suppressing the default mini-infobar) and re-fires it deferred', async () => {
+    const target = new EventTarget()
+    const handle = captureInstallPrompt(target)
+    const { event, prompt } = makeBeforeInstallPromptEvent('accepted')
+
+    target.dispatchEvent(event)
+    expect(handle.captured).toBe(true)
+    expect(event.defaultPrevented).toBe(true)
+    expect(prompt).not.toHaveBeenCalled() // deferred until promptInstall()
+
+    await expect(handle.promptInstall()).resolves.toBe('accepted')
+    expect(prompt).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports the dismissed outcome', async () => {
+    const target = new EventTarget()
+    const handle = captureInstallPrompt(target)
+    target.dispatchEvent(makeBeforeInstallPromptEvent('dismissed').event)
+    await expect(handle.promptInstall()).resolves.toBe('dismissed')
+  })
+
+  it("the deferred prompt is single-use: second call resolves 'unavailable'", async () => {
+    const target = new EventTarget()
+    const handle = captureInstallPrompt(target)
+    target.dispatchEvent(makeBeforeInstallPromptEvent('accepted').event)
+
+    await expect(handle.promptInstall()).resolves.toBe('accepted')
+    expect(handle.captured).toBe(false)
+    await expect(handle.promptInstall()).resolves.toBe('unavailable')
+  })
+
+  it('dispose() removes the listener and drops the captured prompt', async () => {
+    const target = new EventTarget()
+    const handle = captureInstallPrompt(target)
+    target.dispatchEvent(makeBeforeInstallPromptEvent('accepted').event)
+    expect(handle.captured).toBe(true)
+
+    handle.dispose()
+    expect(handle.captured).toBe(false)
+    await expect(handle.promptInstall()).resolves.toBe('unavailable')
+
+    // Events after dispose are no longer captured.
+    target.dispatchEvent(makeBeforeInstallPromptEvent('accepted').event)
+    expect(handle.captured).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getDisplayContext / isIosSafari
+// ---------------------------------------------------------------------------
+
+describe('getDisplayContext', () => {
+  it("'pwa' when the standalone display-mode media query matches", () => {
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      matches: query === '(display-mode: standalone)',
+    }))
+    vi.stubGlobal('navigator', {})
+    expect(getDisplayContext()).toBe('pwa')
+  })
+
+  it("'pwa' on iOS standalone (navigator.standalone) even without matchMedia", () => {
+    vi.stubGlobal('matchMedia', undefined)
+    vi.stubGlobal('navigator', { standalone: true })
+    expect(getDisplayContext()).toBe('pwa')
+  })
+
+  it("'browser' when neither signal is present", () => {
+    vi.stubGlobal('matchMedia', () => ({ matches: false }))
+    vi.stubGlobal('navigator', { standalone: false })
+    expect(getDisplayContext()).toBe('browser')
+  })
+
+  it("'browser' in hosts without matchMedia or navigator hints", () => {
+    vi.stubGlobal('matchMedia', undefined)
+    vi.stubGlobal('navigator', undefined)
+    expect(getDisplayContext()).toBe('browser')
+  })
+
+  it("'browser' when matchMedia throws", () => {
+    vi.stubGlobal('matchMedia', () => {
+      throw new Error('no media support')
+    })
+    vi.stubGlobal('navigator', {})
+    expect(getDisplayContext()).toBe('browser')
+  })
+})
+
+describe('isIosSafari', () => {
+  const IPHONE_SAFARI =
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1'
+  const IPHONE_CHROME =
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1'
+  const ANDROID_CHROME =
+    'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Mobile Safari/537.36'
+  const IPAD_AS_MAC =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15'
+
+  it('true on iPhone Safari', () => {
+    vi.stubGlobal('navigator', { userAgent: IPHONE_SAFARI })
+    expect(isIosSafari()).toBe(true)
+  })
+
+  it('true on iPadOS masquerading as macOS (MacIntel + touch)', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: IPAD_AS_MAC,
+      platform: 'MacIntel',
+      maxTouchPoints: 5,
+    })
+    expect(isIosSafari()).toBe(true)
+  })
+
+  it('false on iPhone Chrome (CriOS)', () => {
+    vi.stubGlobal('navigator', { userAgent: IPHONE_CHROME })
+    expect(isIosSafari()).toBe(false)
+  })
+
+  it('false on Android Chrome', () => {
+    vi.stubGlobal('navigator', { userAgent: ANDROID_CHROME })
+    expect(isIosSafari()).toBe(false)
+  })
+
+  it('false on real macOS Safari (no touch points)', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: IPAD_AS_MAC,
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+    })
+    expect(isIosSafari()).toBe(false)
+  })
+
+  it('false without a navigator', () => {
+    vi.stubGlobal('navigator', undefined)
+    expect(isIosSafari()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// watchOnline
+// ---------------------------------------------------------------------------
+
+describe('watchOnline', () => {
+  it('reports the initial navigator.onLine state immediately', () => {
+    vi.stubGlobal('navigator', { onLine: false })
+    const seen: boolean[] = []
+    const stop = watchOnline((online) => seen.push(online), new EventTarget())
+    expect(seen).toEqual([false])
+    stop()
+  })
+
+  it('fires on online/offline transitions and stops after unsubscribe', () => {
+    vi.stubGlobal('navigator', { onLine: true })
+    const target = new EventTarget()
+    const seen: boolean[] = []
+    const stop = watchOnline((online) => seen.push(online), target)
+
+    target.dispatchEvent(new Event('offline'))
+    target.dispatchEvent(new Event('online'))
+    expect(seen).toEqual([true, false, true])
+
+    stop()
+    target.dispatchEvent(new Event('offline'))
+    expect(seen).toEqual([true, false, true])
+  })
+
+  it('defaults to the global window target', () => {
+    const target = new EventTarget()
+    vi.stubGlobal('window', target)
+    vi.stubGlobal('navigator', { onLine: true })
+    const seen: boolean[] = []
+    const stop = watchOnline((online) => seen.push(online))
+
+    target.dispatchEvent(new Event('offline'))
+    expect(seen).toEqual([true, false])
+    stop()
+  })
+
+  it('assumes online with a no-op unsubscribe in hosts without window/events', () => {
+    vi.stubGlobal('window', undefined)
+    vi.stubGlobal('navigator', undefined)
+    const seen: boolean[] = []
+    const stop = watchOnline((online) => seen.push(online))
+    expect(seen).toEqual([true])
+    expect(() => stop()).not.toThrow()
+  })
+})

--- a/packages/in-pwa/__tests__/eviction-guard.test.ts
+++ b/packages/in-pwa/__tests__/eviction-guard.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { EncryptedEnvelope, NoydbStore, VaultSnapshot } from '@noy-db/hub'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { guardLocalVault, probeLocalVault } from '../src/index.js'
+
+/** Minimal hand-rolled store for shaping specific probe answers. */
+function stubStore(overrides: Partial<NoydbStore>): NoydbStore {
+  return {
+    name: 'stub',
+    async get() {
+      return null
+    },
+    async put() {},
+    async delete() {},
+    async list() {
+      return []
+    },
+    async loadAll() {
+      return {}
+    },
+    async saveAll() {},
+    ...overrides,
+  }
+}
+
+const fakeEnvelope = { _v: 1 } as unknown as EncryptedEnvelope
+
+describe('probeLocalVault', () => {
+  it('reports absent (empty) on a fresh store', async () => {
+    const presence = await probeLocalVault(memory(), 'firm')
+    expect(presence).toEqual({ present: false, reason: 'empty' })
+  })
+
+  it('is store-agnostic: finds a real vault via its _keyring marker on to-memory', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw' })
+    const vault = await db.openVault('firm')
+    await vault.collection<{ id: string }>('invoices').put('i1', { id: 'i1' })
+
+    const presence = await probeLocalVault(store, 'firm')
+    expect(presence).toEqual({ present: true, via: 'keyring' })
+
+    // A different vault id in the same store is still absent.
+    const other = await probeLocalVault(store, 'not-enrolled')
+    expect(other.present).toBe(false)
+  })
+
+  it('falls back to envelopes when no keyring exists (plaintext-mode vault)', async () => {
+    const store = stubStore({
+      async loadAll(): Promise<VaultSnapshot> {
+        return { invoices: { i1: fakeEnvelope } }
+      },
+    })
+    const presence = await probeLocalVault(store, 'firm')
+    expect(presence).toEqual({ present: true, via: 'envelopes' })
+  })
+
+  it('ignores collections with zero envelopes in the snapshot', async () => {
+    const store = stubStore({
+      async loadAll(): Promise<VaultSnapshot> {
+        return { invoices: {} }
+      },
+    })
+    const presence = await probeLocalVault(store, 'firm')
+    expect(presence).toEqual({ present: false, reason: 'empty' })
+  })
+
+  it('never throws: a broken store resolves to probe-failed with the cause', async () => {
+    const boom = new Error('idb gone')
+    const store = stubStore({
+      async list(): Promise<string[]> {
+        throw boom
+      },
+    })
+    const presence = await probeLocalVault(store, 'firm')
+    expect(presence).toEqual({ present: false, reason: 'probe-failed', cause: boom })
+  })
+})
+
+describe('guardLocalVault', () => {
+  it('fails closed on an empty store: onEvicted invoked, never reported healthy', async () => {
+    const onEvicted = vi.fn()
+    const result = await guardLocalVault(memory(), 'firm', onEvicted)
+
+    expect(result.healthy).toBe(false)
+    expect(result.presence).toEqual({ present: false, reason: 'empty' })
+    expect(onEvicted).toHaveBeenCalledTimes(1)
+    expect(onEvicted).toHaveBeenCalledWith({ present: false, reason: 'empty' })
+  })
+
+  it('awaits an async onEvicted handler before returning', async () => {
+    let settled = false
+    const result = await guardLocalVault(memory(), 'firm', async () => {
+      await new Promise((r) => setTimeout(r, 10))
+      settled = true
+    })
+    expect(settled).toBe(true)
+    expect(result.healthy).toBe(false)
+  })
+
+  it('fails closed on a broken store: probe-failed routes to onEvicted, no throw', async () => {
+    const boom = new Error('idb gone')
+    const store = stubStore({
+      async list(): Promise<string[]> {
+        throw boom
+      },
+      async loadAll(): Promise<VaultSnapshot> {
+        throw boom
+      },
+    })
+    const onEvicted = vi.fn()
+    const result = await guardLocalVault(store, 'firm', onEvicted)
+
+    expect(result.healthy).toBe(false)
+    expect(onEvicted).toHaveBeenCalledWith({ present: false, reason: 'probe-failed', cause: boom })
+  })
+
+  it('reports healthy on a populated vault and never calls onEvicted', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw' })
+    const vault = await db.openVault('firm')
+    await vault.collection<{ id: string }>('invoices').put('i1', { id: 'i1' })
+
+    const onEvicted = vi.fn()
+    const result = await guardLocalVault(store, 'firm', onEvicted)
+
+    expect(result.healthy).toBe(true)
+    expect(result.presence).toEqual({ present: true, via: 'keyring' })
+    expect(onEvicted).not.toHaveBeenCalled()
+  })
+})

--- a/packages/in-pwa/package.json
+++ b/packages/in-pwa/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@noy-db/in-pwa",
+  "version": "0.4.0-pre.1",
+  "description": "PWA shell helpers for noy-db — storage persistence with a clear grant/deny signal, fail-closed eviction guard for the local vault, install-prompt capture, display-mode context detection, online/offline watcher, and the app-shell service-worker recipe.",
+  "license": "MIT",
+  "author": "vLannaAi <vicio@lanna.ai>",
+  "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/in-pwa#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vLannaAi/noy-db.git",
+    "directory": "packages/in-pwa"
+  },
+  "bugs": {
+    "url": "https://github.com/vLannaAi/noy-db/issues"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@noy-db/hub": "workspace:*"
+  },
+  "devDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@noy-db/to-memory": "workspace:*"
+  },
+  "keywords": [
+    "noy-db",
+    "in-pwa",
+    "pwa",
+    "offline",
+    "persistence",
+    "service-worker"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  }
+}

--- a/packages/in-pwa/src/index.ts
+++ b/packages/in-pwa/src/index.ts
@@ -1,0 +1,352 @@
+/**
+ * **@noy-db/in-pwa** — installable/offline shell helpers for noy-db SPAs.
+ *
+ * The premise: **the PWA starts empty.** First open in its own storage
+ * partition runs online enrollment and hydrates from the firm cloud
+ * store; from then on the installed app is the offline-capable home of
+ * the vault (data in `to-browser-idb`, app shell in the SW cache — see
+ * the README recipe). This package ships the browser-shell plumbing
+ * around that lifecycle:
+ *
+ * - {@link requestPersistence} — `navigator.storage.persist()` +
+ *   `estimate()` with a clear grant/deny signal. Never throws.
+ * - {@link guardLocalVault} / {@link probeLocalVault} — detect a
+ *   wiped/missing local store at boot and **fail closed** into the
+ *   re-enrollment flow. Never a crash, never a silent empty vault
+ *   presented as truth.
+ * - {@link captureInstallPrompt}, {@link getDisplayContext},
+ *   {@link isIosSafari} — install UX helpers.
+ * - {@link watchOnline} — online/offline wiring shaped for the sync
+ *   engine's `isOnline` flag.
+ *
+ * No service worker runtime is shipped — the SW is a copy-able recipe
+ * in the README. This package holds no keys and sees no plaintext.
+ *
+ * @packageDocumentation
+ */
+
+import type { NoydbStore } from '@noy-db/hub'
+
+// ---------------------------------------------------------------------------
+// Shared app-shell context contract (also consumed/mirrored by @noy-db/in-liff)
+// ---------------------------------------------------------------------------
+
+/**
+ * The three shells one noy-db SPA can boot in. Shared contract with
+ * `@noy-db/in-liff` (which detects `'liff'`); this package's
+ * {@link getDisplayContext} distinguishes the other two. A plain string
+ * union — no runtime coupling between the packages.
+ */
+export type AppShellContext = 'liff' | 'browser' | 'pwa'
+
+// ---------------------------------------------------------------------------
+// Storage persistence
+// ---------------------------------------------------------------------------
+
+/** Result of {@link requestPersistence}. */
+export interface PersistenceResult {
+  /** True when the origin's storage is durable (not eviction-eligible). */
+  persisted: boolean
+  /** `navigator.storage.estimate().quota`, when the browser reports it. */
+  quota?: number
+  /** `navigator.storage.estimate().usage`, when the browser reports it. */
+  usage?: number
+  /**
+   * How the answer was reached:
+   * - `'already'` — the origin was persistent before this call.
+   * - `'granted'` — `persist()` was requested and the browser granted it.
+   * - `'denied'` — `persist()` was requested and the browser declined.
+   * - `'unsupported'` — no Storage API on this browser (or it errored).
+   */
+  grantedBy: 'already' | 'granted' | 'denied' | 'unsupported'
+}
+
+/**
+ * Ask the browser to mark this origin's storage as persistent and report
+ * quota/usage. Eviction of the local vault is the top PWA risk (iOS ITP
+ * evicts script-writable storage of non-installed web content after ~7
+ * days of disuse; installed home-screen apps are safer) — call this
+ * during enrollment and surface a warning UI on `'denied'`.
+ *
+ * Never throws: unsupported browsers resolve to
+ * `{ persisted: false, grantedBy: 'unsupported' }`.
+ */
+export async function requestPersistence(): Promise<PersistenceResult> {
+  const storage = (globalThis as { navigator?: { storage?: StorageManager } }).navigator?.storage
+  if (!storage || typeof storage.persist !== 'function') {
+    return { persisted: false, grantedBy: 'unsupported' }
+  }
+
+  let persisted = false
+  let grantedBy: PersistenceResult['grantedBy']
+  try {
+    const already = typeof storage.persisted === 'function' ? await storage.persisted() : false
+    if (already) {
+      persisted = true
+      grantedBy = 'already'
+    } else {
+      persisted = await storage.persist()
+      grantedBy = persisted ? 'granted' : 'denied'
+    }
+  } catch {
+    // A throwing Storage API is indistinguishable from an absent one
+    // for the caller's purposes — report unsupported, never throw.
+    return { persisted: false, grantedBy: 'unsupported' }
+  }
+
+  const result: PersistenceResult = { persisted, grantedBy }
+  if (typeof storage.estimate === 'function') {
+    try {
+      const est = await storage.estimate()
+      if (typeof est.quota === 'number') result.quota = est.quota
+      if (typeof est.usage === 'number') result.usage = est.usage
+    } catch {
+      // estimate() failing must not mask the persistence answer.
+    }
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Eviction guard
+// ---------------------------------------------------------------------------
+
+/** Outcome of {@link probeLocalVault}. */
+export type VaultPresence =
+  | {
+      present: true
+      /**
+       * What proved presence: `'keyring'` — the vault's `_keyring`
+       * marker records exist (every encrypted vault persists one at
+       * creation); `'envelopes'` — no keyring (plaintext-mode vault)
+       * but `loadAll()` returned at least one envelope.
+       */
+      via: 'keyring' | 'envelopes'
+    }
+  | {
+      present: false
+      /**
+       * `'empty'` — the store answered and holds nothing for this
+       * vault (wiped/evicted/never enrolled); `'probe-failed'` — the
+       * store itself errored. Both fail closed.
+       */
+      reason: 'empty' | 'probe-failed'
+      /** The underlying error when `reason` is `'probe-failed'`. */
+      cause?: unknown
+    }
+
+/**
+ * Cheap, store-agnostic probe: is a local vault actually present in
+ * `store`? Works against any `NoydbStore` (the 6-method contract from
+ * `@noy-db/hub/to`) — it never touches `to-browser-idb` internals.
+ *
+ * Presence check, in order:
+ * 1. `store.list(vaultId, '_keyring')` — an encrypted vault always
+ *    persists its owner keyring record at creation, so a non-empty
+ *    `_keyring` collection is the same marker the hub itself uses to
+ *    decide a vault is provisioned. One tiny `list()` call.
+ * 2. Fallback for plaintext-mode vaults (no keyring): `loadAll()` —
+ *    any envelope in any collection counts as present.
+ *
+ * Never throws — a store error resolves to
+ * `{ present: false, reason: 'probe-failed', cause }`.
+ */
+export async function probeLocalVault(store: NoydbStore, vaultId: string): Promise<VaultPresence> {
+  try {
+    const keyringIds = await store.list(vaultId, '_keyring')
+    if (keyringIds.length > 0) return { present: true, via: 'keyring' }
+
+    const snapshot = await store.loadAll(vaultId)
+    for (const records of Object.values(snapshot)) {
+      if (records && Object.keys(records).length > 0) {
+        return { present: true, via: 'envelopes' }
+      }
+    }
+    return { present: false, reason: 'empty' }
+  } catch (cause) {
+    return { present: false, reason: 'probe-failed', cause }
+  }
+}
+
+/** Result of {@link guardLocalVault}. */
+export interface GuardResult {
+  /** True iff the local vault is present. Never true on a failed probe. */
+  healthy: boolean
+  /** The underlying probe outcome. */
+  presence: VaultPresence
+}
+
+/**
+ * Boot-time eviction guard: probe the local store and **fail closed**
+ * into re-enrollment when the vault is gone.
+ *
+ * - Vault present → `{ healthy: true }`; `onEvicted` is not called.
+ * - Vault missing (wiped/evicted partition) **or the probe itself
+ *   failed** → `onEvicted` is invoked (and awaited) with the failure
+ *   detail, then `{ healthy: false }` is returned. A broken store is
+ *   treated exactly like a missing vault — the guard never presents an
+ *   empty or unreadable store as a healthy vault, and never throws
+ *   from the probe path.
+ *
+ * `onEvicted` is where the app routes to its re-enrollment flow (the
+ * online re-invite via `@noy-db/on-oidc`); errors thrown by the handler
+ * itself propagate to the caller.
+ */
+export async function guardLocalVault(
+  store: NoydbStore,
+  vaultId: string,
+  onEvicted: (presence: Extract<VaultPresence, { present: false }>) => void | Promise<void>,
+): Promise<GuardResult> {
+  const presence = await probeLocalVault(store, vaultId)
+  if (presence.present) return { healthy: true, presence }
+  await onEvicted(presence)
+  return { healthy: false, presence }
+}
+
+// ---------------------------------------------------------------------------
+// Install UX helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * The `beforeinstallprompt` event shape (Chromium-only, not in the DOM
+ * lib types).
+ */
+interface BeforeInstallPromptLike extends Event {
+  prompt(): Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
+/** Handle returned by {@link captureInstallPrompt}. */
+export interface CapturedInstallPrompt {
+  /** True once a `beforeinstallprompt` event has been captured (and not yet spent). */
+  readonly captured: boolean
+  /**
+   * Re-fire the deferred browser install prompt. Resolves to the user's
+   * choice, or `'unavailable'` when no event was captured (iOS, already
+   * installed, or the prompt was already spent — the browser fires it
+   * at most once per capture).
+   */
+  promptInstall(): Promise<'accepted' | 'dismissed' | 'unavailable'>
+  /** Remove the event listener and drop any captured prompt. */
+  dispose(): void
+}
+
+/**
+ * Capture the `beforeinstallprompt` event (Android/desktop Chromium) so
+ * the app can show its own install UI and re-fire the prompt on a user
+ * gesture. Call once at boot, before the browser fires the event.
+ *
+ * On browsers that never fire the event (iOS Safari — see
+ * {@link isIosSafari} for the add-to-home-screen interstitial decision)
+ * `promptInstall()` simply resolves `'unavailable'`.
+ */
+export function captureInstallPrompt(target?: EventTarget): CapturedInstallPrompt {
+  const t = target ?? (globalThis as { window?: EventTarget }).window
+  let deferred: BeforeInstallPromptLike | null = null
+
+  const listener = (event: Event): void => {
+    // Suppress the browser's own mini-infobar; the app re-fires the
+    // prompt from its install UI instead.
+    event.preventDefault()
+    deferred = event as BeforeInstallPromptLike
+  }
+  t?.addEventListener('beforeinstallprompt', listener)
+
+  return {
+    get captured() {
+      return deferred !== null
+    },
+    async promptInstall() {
+      const event = deferred
+      if (!event || typeof event.prompt !== 'function') return 'unavailable'
+      deferred = null // the deferred prompt is single-use
+      await event.prompt()
+      const choice = await event.userChoice
+      return choice.outcome
+    },
+    dispose() {
+      t?.removeEventListener('beforeinstallprompt', listener)
+      deferred = null
+    },
+  }
+}
+
+/**
+ * Which shell the app is currently displayed in: `'pwa'` when running
+ * standalone (installed — `display-mode: standalone` media query, or
+ * iOS `navigator.standalone`), else `'browser'`. The `'liff'` value of
+ * {@link AppShellContext} is detected by `@noy-db/in-liff`, not here.
+ */
+export function getDisplayContext(): Extract<AppShellContext, 'pwa' | 'browser'> {
+  const g = globalThis as {
+    matchMedia?: (query: string) => { matches: boolean }
+    navigator?: { standalone?: boolean }
+  }
+  try {
+    if (typeof g.matchMedia === 'function' && g.matchMedia('(display-mode: standalone)').matches) {
+      return 'pwa'
+    }
+  } catch {
+    // matchMedia throwing (non-browser host) means not standalone.
+  }
+  if (g.navigator?.standalone === true) return 'pwa'
+  return 'browser'
+}
+
+/**
+ * True on iOS Safari (including iPadOS masquerading as macOS), where
+ * `beforeinstallprompt` never fires and installing means the share-sheet
+ * "Add to Home Screen" flow — the signal for showing that interstitial.
+ * Third-party iOS browsers (Chrome/Firefox/Edge/Opera shells) return
+ * false.
+ */
+export function isIosSafari(): boolean {
+  const nav = (globalThis as {
+    navigator?: { userAgent?: string; platform?: string; maxTouchPoints?: number }
+  }).navigator
+  if (!nav) return false
+  const ua = nav.userAgent ?? ''
+  const iosDevice =
+    /iPad|iPhone|iPod/.test(ua) || (nav.platform === 'MacIntel' && (nav.maxTouchPoints ?? 0) > 1)
+  if (!iosDevice) return false
+  return /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS|OPiOS|OPT\//.test(ua)
+}
+
+// ---------------------------------------------------------------------------
+// Online/offline transitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Watch connectivity: invokes `callback` immediately with the current
+ * `navigator.onLine` state, then on every `online`/`offline` event.
+ * Returns an unsubscribe function.
+ *
+ * Shaped for feeding the sync engine's `isOnline` flag (this package
+ * deliberately does not import the sync engine):
+ *
+ * ```ts
+ * const stop = watchOnline((online) => syncStrategy.setOnline(online))
+ * ```
+ *
+ * In hosts without a `window`/events (or without `navigator.onLine`)
+ * the callback fires once with `true` (assume online) and the returned
+ * unsubscribe is a no-op.
+ */
+export function watchOnline(
+  callback: (online: boolean) => void,
+  target?: EventTarget,
+): () => void {
+  const g = globalThis as { window?: EventTarget; navigator?: { onLine?: boolean } }
+  const t = target ?? g.window
+  callback(g.navigator?.onLine ?? true)
+
+  if (!t || typeof t.addEventListener !== 'function') return () => {}
+  const onOnline = (): void => callback(true)
+  const onOffline = (): void => callback(false)
+  t.addEventListener('online', onOnline)
+  t.addEventListener('offline', onOffline)
+  return () => {
+    t.removeEventListener('online', onOnline)
+    t.removeEventListener('offline', onOffline)
+  }
+}

--- a/packages/in-pwa/tsconfig.json
+++ b/packages/in-pwa/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"]
+}

--- a/packages/in-pwa/tsup.config.ts
+++ b/packages/in-pwa/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+})

--- a/packages/in-pwa/vitest.config.ts
+++ b/packages/in-pwa/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'vitest/config'
+export default defineConfig({
+  test: { name: 'in-pwa', include: ['__tests__/**/*.test.ts'], environment: 'node', testTimeout: 15_000 },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,15 @@ importers:
         specifier: ^3.5.32
         version: 3.5.32(typescript@5.9.3)
 
+  packages/in-pwa:
+    devDependencies:
+      '@noy-db/hub':
+        specifier: workspace:*
+        version: link:../hub
+      '@noy-db/to-memory':
+        specifier: workspace:*
+        version: link:../to-memory
+
   packages/in-react:
     devDependencies:
       '@noy-db/hub':


### PR DESCRIPTION
Closes #803. Milestone: LINE/LIFF client portal [api].

## What

New `@noy-db/in-pwa` satellite — the portal's detached-mode shell helpers, built on the premise the issue pinned: **the PWA starts empty** and hydrates from the firm cloud after online enrollment.

- `requestPersistence()` — `navigator.storage.persist()`+`estimate()` with a four-state `grantedBy` signal; never throws (unsupported browsers report, not crash).
- **Eviction guard**: `probeLocalVault`/`guardLocalVault` — detects a wiped partition at boot and fails **closed** into re-enrollment; never a silent empty vault presented as truth, and a broken store counts as evicted. The probe reuses the hub's own `_keyring`-provisioning idiom (one `store.list` + envelope fallback) against the 6-method `NoydbStore` contract — store-agnostic, tested end-to-end against real `createNoydb` + to-memory.
- Install UX: `captureInstallPrompt` (deferred, single-use, never-throw `'unavailable'`), `getDisplayContext` (standalone media query + iOS `navigator.standalone`), `isIosSafari` for the interstitial decision.
- `watchOnline` — online/offline wiring shaped for the sync engine's `isOnline` flag, no sync import.
- Exports the shared `AppShellContext = 'liff' | 'browser' | 'pwa'` union — the context contract `in-liff` (#802) mirrors.
- SW = README **recipe only** (versioned shell cache, same-origin-GET-shell-only), with the hard rule stated: vault data never in SW cache. No SW runtime shipped.

Scaffolded from `in-zustand` (smallest full-shape in-*); zero root-config plumbing needed (workspace glob covers it — verified by grep).

## Verification

**36/36 tests** (persistence matrix, fail-closed eviction incl. broken-store, install prompt lifecycle, display-context 5-case matrix, iOS detection, watchOnline) · build (3.67 KB ESM) · typecheck · lint · `check:architecture` ✓ (peer-dep rule) · knip zero in-pwa findings. Changeset: `@noy-db/in-pwa` minor.