### PR TITLE
fix(hub): push symmetry for period summaries (#822)

### DIFF
--- a/packages/hub/__tests__/sync-period-scope.test.ts
+++ b/packages/hub/__tests__/sync-period-scope.test.ts
@@ -354,6 +354,55 @@ describe('period-scoped pull (#807)', () => {
     })
   })
 
+  describe('#822 — a closure made on a private-store authority PUSHES', () => {
+    it('closePeriod marks _periods dirty so push carries the summary to the shared store', async () => {
+      // The authority device here does NOT write straight to the shared
+      // store: it has its own local store and syncs. Before #822 the
+      // closure never left this device, because writeReserved bypasses
+      // Collection.put and so never marked the record dirty.
+      const remote = inlineMemory()
+      const authorityLocal = inlineMemory()
+      const authority = await createNoydb({
+        store: authorityLocal, sync: remote, user: 'server', encrypt: false,
+        syncStrategy: withSync(), periodsStrategy: withPeriods(),
+      })
+      const aVault = await authority.openVault(COMP)
+      await aVault.collection<Invoice>('invoices').put('inv-now', { amount: 42 })
+      await aVault.closePeriod({ name: 'HIST', endDate: '2026-03-31' })
+
+      await authority.push(COMP)
+
+      // The summary reached the shared store...
+      expect(await remote.get(COMP, '_periods', 'HIST')).not.toBeNull()
+
+      // ...so a second device sees the closure and can scope its pull by it.
+      const local = inlineMemory()
+      const db = await thinClient(local, remote)
+      const vault = await db.openVault(COMP)
+      await db.pull(COMP, { periods: { current: true } })
+      expect((await vault.listPeriods()).map((p) => p.name)).toEqual(['HIST'])
+    })
+
+    it('leaves the other reserved collections device-local', async () => {
+      // freezes / archives / target-purges are deliberately NOT pushed —
+      // see the writeReserved comment for why each stays put.
+      const remote = inlineMemory()
+      const authorityLocal = inlineMemory()
+      const authority = await createNoydb({
+        store: authorityLocal, sync: remote, user: 'server', encrypt: false,
+        syncStrategy: withSync(), periodsStrategy: withPeriods(),
+      })
+      const aVault = await authority.openVault(COMP)
+      await aVault.collection<Invoice>('invoices').put('inv-now', { amount: 1 })
+      await aVault.closePeriod({ name: 'HIST', endDate: '2026-03-31' })
+      await aVault.freezePeriod('HIST')
+      await authority.push(COMP)
+
+      expect(await remote.get(COMP, '_periods', 'HIST')).not.toBeNull()
+      expect(await remote.get(COMP, '_period_freezes', 'HIST')).toBeNull()
+    })
+  })
+
   describe('option validation', () => {
     it('rejects an unknown period name', async () => {
       const local = inlineMemory(); const remote = inlineMemory()

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -527,6 +527,8 @@ export class Vault {
       purgeDeleteMarkers: (before) => this._purgeDeleteMarkers(before),
       archiveRecords: (before) => this._archiveClosedPeriod(before),
       purgeTargets: (before) => this._purgePeriodTargets(before),
+      // #822: push symmetry for the period summaries — see writeReserved.
+      onDirty: this.onDirty,
     })
     this.linksEnforcer = new VaultLinks({
       refRegistry: this.refRegistry,

--- a/packages/hub/src/with-audit/periods/vault-facade.ts
+++ b/packages/hub/src/with-audit/periods/vault-facade.ts
@@ -55,6 +55,12 @@ export interface VaultPeriodsDeps {
   archiveRecords(before: string): Promise<number>
   /** #615: sweep delete markers off the vault's push-only sync targets. Bound to `vault._purgePeriodTargets`. */
   purgeTargets(before: string): Promise<readonly TargetPurgeCount[]>
+  /**
+   * #822: mark a reserved-collection write dirty so the sync engine pushes
+   * it. Bound to the vault's `onDirty` when sync is configured, `undefined`
+   * otherwise. Only `_periods` uses it — see `writeReserved`.
+   */
+  onDirty?: ((collection: string, id: string, action: 'put', version: number) => Promise<void>) | undefined
 }
 
 export class VaultPeriods {
@@ -438,6 +444,17 @@ export class VaultPeriods {
       }
     }
     await this.deps.adapter.put(this.deps.vault, collection, key, envelope)
+    // #822: the period summaries are vault-wide state — period-scoped pull
+    // (#807) treats `_periods` as always-sync precisely because it is the
+    // navigation index a thin client needs first. Pull symmetry without push
+    // symmetry meant a closure never left the device that made it. The other
+    // reserved collections deliberately stay local: freezes are marker-
+    // convergence state (#589/#590 territory), archives record a per-
+    // deployment hot→cold relocation, and target-purges describe the very
+    // targets they would be pushed to.
+    if (collection === PERIODS_COLLECTION && this.deps.onDirty) {
+      await this.deps.onDirty(collection, key, 'put', envelope._v)
+    }
     return envelope
   }
 

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -1037,7 +1037,12 @@ const KERNEL_SURFACE_BUDGET = {
   // CompactionContext gains ONE thin `dropLocalCache` closure line so the
   // budget pass can drop device-local external cache copies; all the
   // pin/budget machinery itself lives in with-shape/blobs/ behind withBlobs().
-  'packages/hub/src/kernel/vault.ts': 3960,
+  'packages/hub/src/kernel/vault.ts': 3962,
+  // Bumped 3960→3962 (#822 period-summary push symmetry, 2026-07-26): two lines wiring
+  // the vault's existing `onDirty` into VaultPeriods so `closePeriod` marks the `_periods`
+  // summary dirty and push carries it. The decision (which reserved collections push and
+  // why the other three deliberately do not) lives in `writeReserved`; the spine holds only
+  // the binding.
   // Lowered 3965→3959 (#826/#798/#812 deprecation cut, 2026-07-26): removed the #799 cover delegators + option key, the dead auth/autoSync/syncInterval options, and the /bundle retirement fallout. Ratchets the #799 bumps back down as their comments promised.
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy


### PR DESCRIPTION
Closes #822 — **the last open issue in the LINE/LIFF client portal milestone.**

## The bug

`closePeriod` persists `_periods` via `writeReserved`, which calls `adapter.put` directly and never reaches the `onDirty` hook that `Collection.put` fires. So a closure made on a device with its own local store (the normal portal topology) **never pushed** — other devices could not see it, and `{ current: true }` resolved against stale windows.

Period-scoped pull (#807) already exempts `_periods` from every filter because it is the navigation index a thin client needs first. Pull symmetry without push symmetry was the real defect — which is why this is a fix, not a feature.

## Scope: summaries only, deliberately

The other three reserved collections stay device-local, reasoned at the call site: **freezes** are marker-convergence state (#589/#590 territory — pushing them blind could re-arm a peer's marker purge), **archives** record a per-deployment hot→cold relocation, **target-purges** describe the very targets they would be pushed to.

## Verification

Two new tests, both **confirmed to fail without the fix** (temporarily reverted the wiring to check): a private-store authority's closure now reaches the shared store and a second device can scope its pull by it; and freezes stay local while summaries travel. Full hub **528 files / 4554 tests** · typecheck · lint · build · bundle-check ✓ · `check:architecture` ✓ with `vault.ts` 3960→3962 for the two binding lines (justified in the ratchet file). Changeset: `@noy-db/hub` patch.