### PR TITLE
chore: release v0.4.0-pre.2

### DIFF
--- a/packages/as-aws-s3/CHANGELOG.md
+++ b/packages/as-aws-s3/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/as-aws-s3
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/as-aws-s3/package.json
+++ b/packages/as-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-aws-s3",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "AWS S3 object projection for noy-db — serve blob bytes directly from S3/CDN (presigned or public), outside the encrypted store",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-blob/CHANGELOG.md
+++ b/packages/as-blob/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/as-blob
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/as-blob/package.json
+++ b/packages/as-blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-blob",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Single-attachment plaintext export for noy-db — extracts one blob from BlobSet as native MIME bytes. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier, document sub-family).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-csv/CHANGELOG.md
+++ b/packages/as-csv/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/as-csv
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/as-csv/package.json
+++ b/packages/as-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-csv",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "CSV plaintext export for noy-db — decrypts records and formats as comma-separated values. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-json/CHANGELOG.md
+++ b/packages/as-json/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/as-json
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/as-json/package.json
+++ b/packages/as-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-json",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Structured JSON plaintext export for noy-db — decrypts records and emits one JSON document per vault. Gated by RFC #249 canExportPlaintext capability; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-ndjson/CHANGELOG.md
+++ b/packages/as-ndjson/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/as-ndjson
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/as-ndjson/package.json
+++ b/packages/as-ndjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-ndjson",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Newline-delimited JSON export for noy-db — streaming plaintext export suitable for data pipelines, warehouse ingestion, and jq pipelines. Gated by RFC #249 canExportPlaintext. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-noydb/CHANGELOG.md
+++ b/packages/as-noydb/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/as-noydb
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/as-noydb/package.json
+++ b/packages/as-noydb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-noydb",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Encrypted .noydb bundle export for noy-db — wraps writeNoydbBundle() with the RFC #249 canExportBundle authorization gate and ergonomic browser/node helpers. Sole member of the @noy-db/as-* encrypted tier — ciphertext in, ciphertext out.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-sql/CHANGELOG.md
+++ b/packages/as-sql/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/as-sql
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/as-sql/package.json
+++ b/packages/as-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-sql",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "SQL dump export for noy-db — decrypts records and emits dialect-aware CREATE TABLE + INSERT statements for postgres / mysql / sqlite. One-way migration helper. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xlsx/CHANGELOG.md
+++ b/packages/as-xlsx/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @noy-db/as-xlsx
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+  - @noy-db/as-zip@1.0.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/as-xlsx/package.json
+++ b/packages/as-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xlsx",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Excel spreadsheet plaintext export for noy-db — produces a real .xlsx (Office Open XML) from one or more collections. Multi-sheet, Unicode-safe via shared-strings table. Zero runtime deps beyond the workspace zip encoder. Gated by RFC #249 `canExportPlaintext` with format `'xlsx'`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xml/CHANGELOG.md
+++ b/packages/as-xml/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/as-xml
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/as-xml/package.json
+++ b/packages/as-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xml",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "XML plaintext export for noy-db — decrypts records and formats as XML with RFC-compliant entity escaping. For legacy systems, banking batch imports, SOAP endpoints, and accounting software that requires XML. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-zip/CHANGELOG.md
+++ b/packages/as-zip/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/as-zip
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/as-zip/package.json
+++ b/packages/as-zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-zip",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Composite record + blob archive export for noy-db — bundles a collection's records plus every attached blob into one zip. Zero dependencies (STORE-only zip encoder). Gated by the RFC #249 `canExportPlaintext` capability bit with format `'zip'`. Part of the @noy-db/as-* portable-artefact family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-aws-kms/CHANGELOG.md
+++ b/packages/at-aws-kms/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — at-aws-kms
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/at-aws-kms/package.json
+++ b/packages/at-aws-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-aws-kms",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "AWS KMS sealing key provider for noy-db managed-passphrase mode — seal/unseal via KMS Encrypt/Decrypt, with KMS access logs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-azure-keyvault/CHANGELOG.md
+++ b/packages/at-azure-keyvault/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — at-azure-keyvault
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/at-azure-keyvault/package.json
+++ b/packages/at-azure-keyvault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-azure-keyvault",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Azure Key Vault sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-env/CHANGELOG.md
+++ b/packages/at-env/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — at-env
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-env",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Env-var sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a key from process.env. Smallest production-shape provider; pair with Kubernetes Secrets / Heroku env / AWS Secrets Manager.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-gcp-kms/CHANGELOG.md
+++ b/packages/at-gcp-kms/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — at-gcp-kms
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/at-gcp-kms/package.json
+++ b/packages/at-gcp-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-gcp-kms",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Google Cloud KMS sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-macos-keychain/CHANGELOG.md
+++ b/packages/at-macos-keychain/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — at-macos-keychain
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/at-macos-keychain/package.json
+++ b/packages/at-macos-keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-macos-keychain",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "macOS Keychain sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a 32-byte key stored in the user's login Keychain. Desktop-app provider in the at-* family; pairs with Touch ID via Keychain Access UI.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/attestation/package.json
+++ b/packages/attestation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/attestation",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Pure, zero-dependency document-attestation primitive for noy-db — per-field salted commitments, Ed25519 sign/verify, QR credential codec, and revocation checks. Runs in Node and the browser; the offline verifier imports only this.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-peer/CHANGELOG.md
+++ b/packages/by-peer/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — by-peer
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/by-peer/package.json
+++ b/packages/by-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-peer",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "WebRTC peer-to-peer transport for noy-db — direct browser-to-browser channel with signaling-agnostic handshake",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-tabs/CHANGELOG.md
+++ b/packages/by-tabs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @noy-db/by-tabs
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+  - @noy-db/by-peer@1.0.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/by-tabs/package.json
+++ b/packages/by-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-tabs",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "BroadcastChannel multi-tab transport for noy-db — sync between tabs of the same browser without round-tripping the storage backend",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @noy-db/cli
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+  - @noy-db/to-meter@1.0.0-pre.2
+  - @noy-db/to-probe@1.0.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/cli",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Command-line tool for noy-db — inspect .noydb bundles without decrypting, verify integrity, validate config objects, scaffold topology profiles, and monitor a live vault's store metrics.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/create-noy-db/CHANGELOG.md
+++ b/packages/create-noy-db/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — create-noy-db
 
+## 0.3.1-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+  - @noy-db/to-file@1.0.0-pre.2
+  - @noy-db/to-memory@1.0.0-pre.2
+
 ## 0.3.1-pre.1
 
 ### Patch Changes

--- a/packages/create-noy-db/package.json
+++ b/packages/create-noy-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-noy-db",
-  "version": "0.3.1-pre.1",
+  "version": "0.3.1-pre.2",
   "description": "Wizard + CLI tool for noy-db: scaffold a fresh Nuxt 4 + Pinia encrypted store, or add collections to an existing project. Invoke via `npm create noy-db`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog — hub
 
+## 0.4.0-pre.2
+
+### Minor Changes
+
+- Blobs: offline pinning + mobile cache budget (#808).
+
+  - `collection.blob(id).pin(slot)` / `unpin(slot)` / `isPinned(slot)`: pin a blob slot for
+    offline availability on THIS device. Pinning downloads eagerly (call while online) and
+    exempts the slot from `vault.compact()` eviction — both the `blobFields` policy pass
+    (reported via the new `CompactionResult.pinned` counter) and the new cache-budget pass.
+    Pin state is device-local and never synced: it lives in the `withBlobs()` pin registry
+    (`withBlobs({ pinStore })`, a pluggable 4-method `BlobPinStore`; in-memory default —
+    supply an IndexedDB/SQLite-backed store for durable pins).
+  - `vault.compact({ cacheBudget: { maxBytes } })`: LRU budget for locally-cached UNPINNED
+    blob bytes, run as a dedicated pass inside the existing compaction machinery. Internal
+    slots evict through the standard eviction writer (with a new `'budget'` audit reason);
+    `external` slots only drop their device-local cached copy (the object-store copy is
+    untouched). Pinned and `legalHold`/`retainUntil`-held slots are exempt. New
+    `CompactionResult.budgetEvicted` / `budgetBytesFreed`; LRU order from the device-local
+    `SlotInfo.lastAccessAt` stamp (fallback `uploadedAt`).
+  - Offline read taxonomy: new typed `BlobOfflineError` (`code: 'BLOB_OFFLINE'`) — an
+    `external` slot with no local copy while the object store is unreachable, or an internal
+    blob whose chunk envelopes are absent from the local store. BREAKING-ish detail (pre-1.0):
+    the internal missing-chunk case previously threw `NotFoundError`; it now throws
+    `BlobOfflineError`, since the content exists but is not locally available. External reads
+    now auto-populate the device-local encrypted side-cache, so a repeat read is served
+    locally (and offline).
+  - External pins are encrypted at rest locally: the object-store copy of an `external: true`
+    slot is outside the ZK envelope by design, but the local pinned/cached copy is
+    AES-256-GCM-encrypted under the vault's `_blob` DEK via the existing enclave path
+    (AAD-bound), so plaintext never rests in the pin registry.
+  - KPI counters for the 4G-budget demo: `withBlobs().cacheStats()` →
+    `{ hits, misses, bytesDownloaded }` (local reads hit; object-store fetches miss + count
+    bytes). `BlobSet.list()` now annotates `SlotInfo` with the device-local `pinned` /
+    `lastAccessAt` / `cachedBytes` view.
+
+- Complete the `/bundle` promotion (#812): the partition-transfer ops promoted onto `/cargo` in 0.4.0-pre.1 now ship with their own option/result types (`WalkClosureOptions`, `ClosureResult`, `DanglingRefNotice`, `ExtractPartitionResult`) — previously a caller could invoke `walkClosure()` from `/cargo` but could not name its options type. The **adopt half** of the transfer ceremony joins them (`adoptPartition`, `unsealDeks`, `createOwnerOnAdoptedPartition` + 6 option/result types): extraction without adoption was half the story. Transfer errors (`TransferSealError`, `AdoptionStateError`, `PartitionExtractionError`) land on `/cargo`, and the artifact/backup errors (`BundleIntegrityError`, `BundleSealMismatchError`, `PodVersionConflictError`, `BundleVersionConflictError`, `BackupLedgerError`, `BackupCorruptedError`) on `/pod`, so `instanceof` works from the subpath instead of the root barrel. Purely additive — `/bundle` still resolves everything it did, and its retirement follows in a later release. Also promotes `hasNoydbBundleMagic` onto `/pod` (#820) — it sat beside `NOYDB_BUNDLE_MAGIC` everywhere except the subpath, forcing klum's multi-bundle reader to keep a root-barrel import alive for one predicate.
+- **BREAKING (no migration shim).** Removes every deprecated `publicEnvelope` alias left by the cover rename (#799): the 6 type aliases, 10 value re-exports, `Noydb.setPublicEnvelope`/`getPublicEnvelope`, `Vault.getPublicEnvelope`, the `NoydbOptions.publicEnvelope` option key, and `readNoydbBundlePublicEnvelope`. Use `Cover`, `setCover`/`getCover`, `NoydbOptions.cover`, `readPodCover`. The deprecation window's only purpose was the klum-db migration, which shipped in klum-db 0.4.0-pre.1. **The wire format is unchanged and stays frozen**: the `_meta/public-envelope` record id, the `_noydb_public: 1` discriminator, and the pod-header `publicEnvelope` JSON key are untouched — existing vaults and bundles need no migration.
+- **BREAKING (no migration shim).** Removes three `NoydbOptions` fields that were declared but never read anywhere in the codebase, so setting them silently did nothing: `auth` (`'passphrase' | 'biometric'` — its JSDoc claimed a default that no code implemented; the real mechanisms are the `getKeyring` callback and the authenticator slots), `autoSync`, and `syncInterval` (both documented as superseded by `syncPolicy`, but no reader ever honored the stated precedence). Verified zero readers across every package before removal.
+- **BREAKING (no migration shim).** The `@noy-db/hub/bundle` subpath is removed, and with it the entire `src/legacy/` folder. Its surface has permanent homes: `.noydb` artifact ops on `@noy-db/hub/pod`, partition-transfer ops (extract **and** adopt) plus their option/result types and errors on `@noy-db/hub/cargo`. Nothing is orphaned — the promotion completed in #812/#820 before this cut. `/cargo`'s internal re-export floor moved from `src/legacy/kernel.ts` to `src/with-cargo/floor.ts` (unpublished either way). Consumers still on `/bundle`: import from `/pod` or `/cargo`; the symbol names are unchanged.
+
+### Patch Changes
+
+- `closePeriod` (and the other `_periods` summary writes) now mark the record dirty, so a closure made on a device with its own local store **pushes** to the shared store instead of staying put (#822). Period-scoped pull (#807) already treated `_periods` as always-sync — it is the navigation index a thin client needs first — so pull symmetry without push symmetry meant other devices could never see the closure. The other three reserved period collections stay device-local by design: freezes are marker-convergence state, archives record a per-deployment hot→cold relocation, and target-purges describe the very targets they would be pushed to.
+
 ## 0.4.0-pre.1
 
 ### Minor Changes

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/hub",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Zero-knowledge, offline-first, encrypted document store — core library with AES-256-GCM, PBKDF2, multi-user keyring, and sync engine",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-ai/CHANGELOG.md
+++ b/packages/in-ai/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/in-ai
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-ai/package.json
+++ b/packages/in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-ai",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "LLM function-calling adapter for noy-db — expose ACL-scoped collections as tool definitions, then dispatch tool calls back to the vault. Format-agnostic (OpenAI, Anthropic, Vercel AI SDK).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-devtools-tui/CHANGELOG.md
+++ b/packages/in-devtools-tui/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @noy-db/in-devtools-tui
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+  - @noy-db/in-devtools@1.0.0-pre.2
+  - @noy-db/to-meter@1.0.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-devtools-tui/package.json
+++ b/packages/in-devtools-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools-tui",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Interactive terminal inspector for a live noy-db (ink TUI over @noy-db/in-devtools).",
   "license": "MIT",
   "type": "module",

--- a/packages/in-devtools/CHANGELOG.md
+++ b/packages/in-devtools/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/in-devtools
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-devtools/package.json
+++ b/packages/in-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Framework-agnostic read-only inspector for a live noy-db — vaults, collections, schema, stats, records, and live writes.",
   "license": "MIT",
   "type": "module",

--- a/packages/in-liff/CHANGELOG.md
+++ b/packages/in-liff/CHANGELOG.md
@@ -1,0 +1,17 @@
+# @noy-db/in-liff
+
+## 0.4.0-pre.2
+
+### Minor Changes
+
+- New satellite `@noy-db/in-liff` — the LIFF shell binding for the LINE client portal (#802): `initLiffApp` (boot, login enforcement, three-shell detection, ID-token read, share-link deep-link ingestion), `getFreshIdToken` (client-side expiry detection, re-login or typed throw — an unlocked session survives token expiry), `openExternal` (the escape hatch, with the Android WebAPK / iOS manual-hop / LINE-WebView-isolation handoff matrix documented). The LIFF SDK is injected via the structural `LiffLike` interface — never a dependency; CI runs fully mocked.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2

--- a/packages/in-liff/package.json
+++ b/packages/in-liff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-liff",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "LIFF (LINE Front-end Framework) shell binding for noy-db — boot + shell context detection across LIFF/browser/PWA, LINE ID-token lifecycle with re-login on expiry, share-link deep-link ingestion, and the external-browser escape hatch with the platform handoff matrix.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nextjs/CHANGELOG.md
+++ b/packages/in-nextjs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @noy-db/in-nextjs
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+  - @noy-db/in-react@1.0.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-nextjs/package.json
+++ b/packages/in-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nextjs",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Next.js App Router helpers for noy-db — server components, route handlers, client hooks, and cookie-based session. Thin bridge that composes @noy-db/in-react with Next's cookies()/headers() APIs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nuxt/CHANGELOG.md
+++ b/packages/in-nuxt/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — in-nuxt
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+  - @noy-db/in-devtools@1.0.0-pre.2
+  - @noy-db/in-pinia@1.0.0-pre.2
+  - @noy-db/in-rest@1.0.0-pre.2
+  - @noy-db/in-vue@1.0.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-nuxt/package.json
+++ b/packages/in-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nuxt",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Nuxt 4 module for noy-db — auto-imports, SSR-safe runtime plugin, and the @noy-db/in-pinia bridge",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-pinia/CHANGELOG.md
+++ b/packages/in-pinia/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — in-pinia
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-pinia/package.json
+++ b/packages/in-pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-pinia",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Pinia integration for noy-db — defineNoydbStore() and the augmentation plugin for existing stores",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-pwa/CHANGELOG.md
+++ b/packages/in-pwa/CHANGELOG.md
@@ -1,0 +1,17 @@
+# @noy-db/in-pwa
+
+## 0.4.0-pre.2
+
+### Minor Changes
+
+- New satellite `@noy-db/in-pwa` — installable/offline shell helpers for noy-db SPAs (#803). The PWA starts empty: first open in its own storage partition runs online enrollment and hydrates from the firm cloud; from then on it is the offline-capable home of the vault. Ships `requestPersistence()` (`navigator.storage.persist()`/`estimate()` with a clear `'already' | 'granted' | 'denied' | 'unsupported'` signal, never throws), the fail-closed boot-time eviction guard `guardLocalVault()`/`probeLocalVault()` (store-agnostic `_keyring`-marker probe over the `@noy-db/hub/to` contract — a wiped or broken local store routes to re-enrollment, never a crash or a silent empty vault), install UX helpers (`captureInstallPrompt()` deferred `beforeinstallprompt`, `getDisplayContext()` `'pwa' | 'browser'`, `isIosSafari()` for the add-to-home-screen interstitial), the shared `AppShellContext = 'liff' | 'browser' | 'pwa'` union (contract with the upcoming `@noy-db/in-liff`), `watchOnline()` connectivity wiring for the sync engine's `isOnline` flag, and the documented app-shell-only service-worker recipe (vault data never in the SW cache). No SW runtime, no background sync/push, no framework bindings.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2

--- a/packages/in-pwa/package.json
+++ b/packages/in-pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-pwa",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "PWA shell helpers for noy-db — storage persistence with a clear grant/deny signal, fail-closed eviction guard for the local vault, install-prompt capture, display-mode context detection, online/offline watcher, and the app-shell service-worker recipe.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-react/CHANGELOG.md
+++ b/packages/in-react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/in-react
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-react/package.json
+++ b/packages/in-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-react",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "React hooks for noy-db — useNoydb, useVault, useCollection, useQuery, useSync. Uses useSyncExternalStore for reactive subscriptions. Zero deps beyond React.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-rest/CHANGELOG.md
+++ b/packages/in-rest/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/in-rest
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-rest/package.json
+++ b/packages/in-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-rest",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Framework-neutral REST API integration for noy-db — createRestHandler with Hono, Express, Fastify, and Nitro subpath adapters.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-solid/CHANGELOG.md
+++ b/packages/in-solid/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/in-solid
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-solid/package.json
+++ b/packages/in-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-solid",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "SolidJS signal primitives for noy-db — createCollectionSignal, createQuerySignal, createSyncSignal backed by noy-db change events.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-svelte/CHANGELOG.md
+++ b/packages/in-svelte/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/in-svelte
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-svelte/package.json
+++ b/packages/in-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-svelte",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Svelte stores for noy-db — collectionStore / queryStore / syncStore backed by noy-db change events. Works with Svelte 4 store contract and Svelte 5 runes (via $store subscription interop).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-query/CHANGELOG.md
+++ b/packages/in-tanstack-query/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/in-tanstack-query
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-tanstack-query/package.json
+++ b/packages/in-tanstack-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-query",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "TanStack Query adapter for noy-db — queryFn + mutationFn helpers that speak the Collection API, plus automatic invalidation from noy-db change events. Framework-agnostic (React / Vue / Solid / Svelte).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-table/CHANGELOG.md
+++ b/packages/in-tanstack-table/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/in-tanstack-table
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-tanstack-table/package.json
+++ b/packages/in-tanstack-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-table",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "TanStack Table bridge for noy-db — map Collection query state (sort, filter, pagination) into Table state and back, so a useSmartTable pattern drives the DB's query DSL without glue code.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-vue/CHANGELOG.md
+++ b/packages/in-vue/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — in-vue
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-vue/package.json
+++ b/packages/in-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-vue",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Vue 3 / Nuxt composables for noy-db — reactive useNoydb, useCollection, useSync, and biometric plugin",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-yjs/CHANGELOG.md
+++ b/packages/in-yjs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — in-yjs
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-yjs/package.json
+++ b/packages/in-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-yjs",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Yjs Y.Doc interop for noy-db — collaborative rich-text fields with encrypted-at-rest Yjs state",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-zustand/CHANGELOG.md
+++ b/packages/in-zustand/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/in-zustand
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/in-zustand/package.json
+++ b/packages/in-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-zustand",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Zustand adapter for noy-db — factory that mirrors defineNoydbStore for Zustand users, auto-syncs state from noy-db change events, and supports optimistic mutations.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-email-otp/CHANGELOG.md
+++ b/packages/on-email-otp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/on-email-otp
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/on-email-otp/package.json
+++ b/packages/on-email-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-email-otp",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Email OTP second factor for noy-db — generates time-boxed one-time codes, delivers via a user-supplied transport (SMTP / SES / Postmark / any fn), and verifies in constant time. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-magic-link/CHANGELOG.md
+++ b/packages/on-magic-link/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/on-magic-link
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/on-magic-link/package.json
+++ b/packages/on-magic-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-magic-link",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Magic-link unlock for noy-db — one-time URL that opens a vault in a viewer-scoped session without a passphrase. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-oidc/CHANGELOG.md
+++ b/packages/on-oidc/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — on-oidc
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Minor Changes

--- a/packages/on-oidc/package.json
+++ b/packages/on-oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-oidc",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "OAuth/OIDC bridge for noy-db — federated login (LINE, Google, Apple, Okta) with split-key key connector — server never sees plaintext",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-password/CHANGELOG.md
+++ b/packages/on-password/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/on-password
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/on-password/package.json
+++ b/packages/on-password/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-password",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Tier-2 password authenticator slot for noy-db. PBKDF2-SHA256 600K wraps the DEK set in its own keyring slot, distinct from the rarely-typed tier-1 phrase. Pair with @noy-db/on-email-otp or @noy-db/on-totp for the SaaS UX.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-pin/CHANGELOG.md
+++ b/packages/on-pin/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @noy-db/on-pin
 
+## 0.4.0-pre.2
+
+### Minor Changes
+
+- New **device-trust** unlock mode (#801) — "always safe to open on this device". The session DEKs are wrapped under a non-extractable, device-bound `crypto.subtle` AES-GCM key persisted in IndexedDB as a CryptoKey object (structured clone — raw bits never exist in JS), so the vault reopens on this device with no user factor at all: `enrollDeviceTrust()` (requires an already-unlocked session; gated by the owner-configurable `app:device-trust` policy gate) / `resumeDeviceTrust()` (yields the keyring plus a capped session tier, default 3 — below the passphrase tier) / `clearDeviceTrust()` / `isDeviceTrustEnrolled()`. Storage eviction fails closed with the typed `DeviceTrustNotFoundError` pointing at the real-factor re-enroll path — never a lockout. The OS lock screen IS the factor; the threat model is stated in the README and module docs.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/on-pin/package.json
+++ b/packages/on-pin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-pin",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Session-resume PIN quick-lock for noy-db — after a full passphrase unlock, a short-lived PIN (or a per-device biometric) re-unlocks the cached DEKs without re-typing the passphrase. PIN never replaces the passphrase; only resumes an already-unlocked session.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-recovery/CHANGELOG.md
+++ b/packages/on-recovery/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/on-recovery
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/on-recovery/package.json
+++ b/packages/on-recovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-recovery",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "One-time printable recovery codes for noy-db — last-resort vault unlock when the passphrase, passkey, and OIDC provider are all unavailable. Base32 + checksum codes, PBKDF2-derived wrapping keys, burn-on-use. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-shamir/package.json
+++ b/packages/on-shamir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-shamir",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "k-of-n Shamir Secret Sharing of the vault KEK for multi-party unlock. Any K of N shares recombines the key; fewer than K leaks zero bits. Composable — each share can be protected by any other on-* method. Zero runtime dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-threat/CHANGELOG.md
+++ b/packages/on-threat/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/on-threat
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/on-threat/package.json
+++ b/packages/on-threat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-threat",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Threat-response primitives for noy-db — multi-attempt lockout, duress-passphrase data destruction, duress-passphrase honeypot decoy. Pure stateful helpers; the caller coordinates keyring + audit-ledger integration. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-totp/CHANGELOG.md
+++ b/packages/on-totp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/on-totp
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/on-totp/package.json
+++ b/packages/on-totp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-totp",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "TOTP (RFC 6238) authenticator-app second factor for noy-db — generate secrets, otpauth:// provisioning URIs, and constant-time code verification. Zero dependencies (HMAC-SHA1 via Web Crypto). Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-webauthn/CHANGELOG.md
+++ b/packages/on-webauthn/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — on-webauthn
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/on-webauthn/package.json
+++ b/packages/on-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-webauthn",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "WebAuthn hardware-key keyrings for noy-db — Touch ID, Face ID, Windows Hello, YubiKey, FIDO2 passkeys",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-idb/CHANGELOG.md
+++ b/packages/to-browser-idb/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — to-browser-idb
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/to-browser-idb/package.json
+++ b/packages/to-browser-idb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-idb",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "IndexedDB adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-file/CHANGELOG.md
+++ b/packages/to-file/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — to-file
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/to-file/package.json
+++ b/packages/to-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-file",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "JSON file adapter for noy-db — encrypted document store on local disk, USB sticks, or network drives",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-memory/CHANGELOG.md
+++ b/packages/to-memory/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — to-memory
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/to-memory/package.json
+++ b/packages/to-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-memory",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "In-memory adapter for noy-db — ideal for testing, development, and ephemeral workloads",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-meter/CHANGELOG.md
+++ b/packages/to-meter/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/to-meter
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/to-meter/package.json
+++ b/packages/to-meter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-meter",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Pass-through meter for @noy-db/to-* stores — wraps any NoydbStore and records per-method latency percentiles, error rates, and byte counts on real traffic. Optional synthetic liveness probe emits degraded / restored events. No synthetic benchmarks (see @noy-db/to-probe for that) — this measures what your app is actually doing.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-probe/CHANGELOG.md
+++ b/packages/to-probe/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/to-probe
 
+## 0.4.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.4.0-pre.2
+
 ## 0.4.0-pre.1
 
 ### Patch Changes

--- a/packages/to-probe/package.json
+++ b/packages/to-probe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-probe",
-  "version": "0.4.0-pre.1",
+  "version": "0.4.0-pre.2",
   "description": "Diagnostic companion for the @noy-db/to-* store family — not itself a storage backend. Setup-time suitability test + topology check + runtime reliability monitor. Exercises the 6-method NoydbStore contract across five axes (write latency, CAS integrity, hydration cost, sync economics, network resilience) and produces a structured risk-scored report.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",


### PR DESCRIPTION
Version PR consuming the nine post-pre.1 changesets (lockstep 0.4.0-pre.2). **Two new packages debut on npm.**

## Features
- **`@noy-db/in-liff`** (new package) — LIFF shell binding: boot + three-shell detection, LINE token lifecycle, share-link deep-link ingestion, escape hatch (#802)
- **`@noy-db/in-pwa`** (new package) — installable/offline shell: persistence, fail-closed eviction guard, install UX, SW recipe (#803)
- **`@noy-db/on-pin`** — device-trust unlock mode, non-extractable device-bound key (#801)
- **hub/blobs** — offline pinning + mobile cache budget, `BlobOfflineError` (#808)
- **hub/cargo + /pod** — surface completion ahead of the retirement: adopt half, option/result types, error split, `hasNoydbBundleMagic` (#812, #820)
- **hub/periods** — push symmetry for period summaries (#822)

## Breaking (no migration shims — no production consumers)
- **`@noy-db/hub/bundle` subpath removed**, `src/legacy/` deleted entirely; use `/pod` and `/cargo` with the same symbol names (#812)
- **All `publicEnvelope` cover aliases removed** — use `Cover`, `setCover`/`getCover`, `NoydbOptions.cover`, `readPodCover`. **Wire format unchanged and frozen** (#826)
- **`NoydbOptions.auth`, `autoSync`, `syncInterval` removed** — declared but never read by any code (#798)

Also corrects the 49 `## 1.0.0-pre.2` CHANGELOG headings the changeset heuristic writes before the normalizer runs (fix tracked in #827).

After merge: `gh release create v0.4.0-pre.2 --target main --prerelease` → release.yml → npm `@next`.