### PR TITLE
fix(hub)!: vault() is cache-only — kills the drifted Vault constructors (#834)

### DIFF
--- a/packages/hub/__tests__/vault-accessor-single-construction.test.ts
+++ b/packages/hub/__tests__/vault-accessor-single-construction.test.ts
@@ -1,0 +1,107 @@
+/**
+ * #834 — `db.vault(name)` must never CONSTRUCT a Vault.
+ *
+ * It used to carry two fallback constructors (one plaintext, one encrypted)
+ * beside the canonical `#openVaultFresh`. The encrypted copy had silently
+ * drifted: it omitted six strategies (attestation, classified, portability,
+ * sealed-record, sequence, forget), so a vault reached that way threw
+ * `*NotEnabledError` for services the caller HAD configured. Both fallbacks
+ * also skipped the async init `openVault` performs (`_initGuards`,
+ * `_initDerivations`, `_initMaterializedViews`, `_initOverlayedViews`,
+ * `schemaFence.init()`) — unavoidably, since `vault()` is synchronous.
+ *
+ * The fix is structural: `vault()` returns a cached instance or throws.
+ * One construction path means the drift cannot recur.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { memoryStore } from '../src/kernel/memory-store.js'
+import { ValidationError } from '../src/kernel/errors.js'
+import { withAttestation } from '../src/with-audit/attestation/index.js'
+import { NO_ATTESTATION } from '../src/with-audit/attestation/strategy.js'
+import { withClassified } from '../src/via/classified/index.js'
+import { NO_CLASSIFIED } from '../src/port/with/classified-strategy.js'
+import { withPortability } from '../src/with-audit/portability/index.js'
+import { NO_PORTABILITY } from '../src/with-audit/portability/strategy.js'
+import { withSealedRecord } from '../src/with-audit/sealed-record/index.js'
+import { NO_SEALED_RECORD } from '../src/with-audit/sealed-record/strategy.js'
+import { withSequence } from '../src/with-commit/sequence/index.js'
+import { NO_SEQUENCE } from '../src/with-commit/sequence/strategy.js'
+import { NO_FORGET } from '../src/with-audit/forget/strategy.js'
+
+describe('#834 — vault() is cache-only, never a second construction path', () => {
+  it('throws with an actionable message when the vault was never opened (plaintext)', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'alice', encrypt: false })
+    expect(() => db.vault('acme')).toThrowError(ValidationError)
+    expect(() => db.vault('acme')).toThrowError(/openVault/)
+  })
+
+  it('throws when the vault was never opened (encrypted)', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'alice', secret: 'pw-834-encrypted' })
+    expect(() => db.vault('never-opened')).toThrowError(ValidationError)
+  })
+
+  it('throws again after lockVault evicts the instance', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'alice', secret: 'pw-834-lock' })
+    await db.openVault('acme')
+    expect(db.vault('acme')).toBeDefined()
+    await db.lockVault('acme')
+    expect(() => db.vault('acme')).toThrowError(ValidationError)
+  })
+
+  it('returns the very instance openVault produced (identity, not a copy)', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'alice', secret: 'pw-834-identity' })
+    const opened = await db.openVault('acme')
+    expect(db.vault('acme')).toBe(opened)
+  })
+
+  /**
+   * The #834 symptom itself. The six strategies below are exactly the ones
+   * the drifted constructor dropped; a vault missing one throws
+   * `*NotEnabledError` on first use. White-box on purpose — the invariant
+   * that broke was "the constructed vault carries the configured
+   * strategies", and the strategy fields are private.
+   */
+  it('carries every strategy the caller configured, incl. the six that used to drop', async () => {
+    const db = await createNoydb({
+      store: memoryStore(),
+      user: 'alice',
+      secret: 'pw-834-strategies',
+      attestationStrategy: withAttestation(),
+      classifiedStrategy: withClassified(),
+      portabilityStrategy: withPortability(),
+      sealedRecordStrategy: withSealedRecord(),
+      sequenceStrategy: withSequence(),
+      forgetStrategy: { subjects: { invoices: 'clientId' } },
+    })
+    await db.openVault('acme')
+    const v = db.vault('acme') as unknown as Record<string, unknown>
+    expect(v['attestationStrategy']).not.toBe(NO_ATTESTATION)
+    expect(v['classifiedStrategy']).not.toBe(NO_CLASSIFIED)
+    expect(v['portabilityStrategy']).not.toBe(NO_PORTABILITY)
+    expect(v['sealedRecordStrategy']).not.toBe(NO_SEALED_RECORD)
+    expect(v['sequenceStrategy']).not.toBe(NO_SEQUENCE)
+    expect(v['forgetStrategy']).not.toBe(NO_FORGET)
+    // Async init that only `openVault` can perform must have run.
+    expect((db.vault('acme')).schemaFence).toBeDefined()
+  })
+
+  /**
+   * The actual regression guard. This bug survived for as long as it did
+   * because nothing asserted the invariant it broke: exactly one
+   * `new Vault(...)` site in the file. A second one is how six strategies
+   * went missing.
+   */
+  it('noydb.ts constructs a Vault in exactly ONE place', () => {
+    const src = readFileSync(
+      fileURLToPath(new URL('../src/kernel/noydb.ts', import.meta.url)),
+      'utf8',
+    )
+    const withoutComments = src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1')
+    expect(withoutComments.match(/new Vault\(/g) ?? []).toHaveLength(1)
+  })
+})

--- a/packages/hub/src/kernel/noydb.ts
+++ b/packages/hub/src/kernel/noydb.ts
@@ -698,89 +698,27 @@ export class Noydb {
     return comp
   }
 
-  /** Synchronous vault access (must call openVault first, or auto-opens). */
+  /**
+   * Synchronous access to an ALREADY-OPEN vault.
+   *
+   * Returns the instance `openVault()` produced, or throws — it never
+   * constructs. It used to fall back to building a Vault itself (once for
+   * plaintext, once for encrypted-with-cached-keyring), and those copies
+   * drifted from the real open path: the encrypted one silently omitted six
+   * strategies, so a vault reached this way threw `*NotEnabledError` for
+   * services the caller had configured (#834). Both fallbacks also skipped
+   * the async registry init and schema-fence snapshot that `openVault`
+   * performs, which a synchronous method cannot await. One construction
+   * path is the only way that divergence stays fixed.
+   */
   vault(name: string): Vault {
     const cached = this.vaultCache.get(name)
     if (cached) return cached
-
-    // For backwards compat: if not opened yet, create with cached keyring or plaintext
-    if (this.options.encrypt === false) {
-      const keyring = createPlaintextKeyring(this.options.user, this.options.debugPlaintext === true)
-      const comp = new Vault({
-        adapter: this.options.store,
-        name,
-        noydb: this,
-        keyring,
-        encrypted: false,
-        emitter: this.emitter,
-        historyConfig: this.options.history,
-      ...(this.options.blobStrategy !== undefined ? { blobStrategy: this.options.blobStrategy } : {}),
-      ...(this.options.objectStore !== undefined ? { objectStore: this.options.objectStore } : {}),
-      ...(this.options.archiveStrategy !== undefined ? { archiveStrategy: this.options.archiveStrategy } : {}),
-      ...(this.options.indexStrategy !== undefined ? { indexStrategy: this.options.indexStrategy } : {}),
-      ...(this.options.lazyStrategy !== undefined ? { lazyStrategy: this.options.lazyStrategy } : {}),
-      ...(this.options.aggregateStrategy !== undefined ? { aggregateStrategy: this.options.aggregateStrategy } : {}),
-      ...(this.options.crdtStrategy !== undefined ? { crdtStrategy: this.options.crdtStrategy } : {}),
-      ...(this.options.tiersStrategy !== undefined ? { tiersStrategy: this.options.tiersStrategy } : {}),
-      ...(this.options.searchStrategy !== undefined ? { searchStrategy: this.options.searchStrategy } : {}),
-      ...(this.options.cargoStrategy !== undefined ? { cargoStrategy: this.options.cargoStrategy } : {}),
-      ...(this.options.brokerStrategy !== undefined ? { brokerStrategy: this.options.brokerStrategy } : {}),
-      ...(this.options.consentStrategy !== undefined ? { consentStrategy: this.options.consentStrategy } : {}),
-      ...(this.options.periodsStrategy !== undefined ? { periodsStrategy: this.options.periodsStrategy } : {}),
-      ...(this.options.shadowStrategy !== undefined ? { shadowStrategy: this.options.shadowStrategy } : {}),
-      ...(this.options.historyStrategy !== undefined ? { historyStrategy: this.options.historyStrategy } : {}),
-      ...(this.options.i18nStrategy !== undefined ? { i18nStrategy: this.options.i18nStrategy } : {}),
-      ...(this.options.syncStrategy !== undefined ? { syncStrategy: this.options.syncStrategy } : {}),
-      ...(this.options.guardStrategies !== undefined ? { guardStrategies: this.options.guardStrategies } : {}),
-      ...(this.options.numbering !== undefined ? { numberingConfigs: this.options.numbering } : {}),
-      forgetStrategy: this.forgetStrategy,
-      ...(this.options.attestationStrategy !== undefined ? { attestationStrategy: this.options.attestationStrategy } : {}),
-      ...(this.options.classifiedStrategy !== undefined ? { classifiedStrategy: this.options.classifiedStrategy } : {}),
-      ...(this.options.sealedRecordStrategy !== undefined ? { sealedRecordStrategy: this.options.sealedRecordStrategy } : {}),
-      ...(this.options.portabilityStrategy !== undefined ? { portabilityStrategy: this.options.portabilityStrategy } : {}),
-      ...(this.options.sequenceStrategy !== undefined ? { sequenceStrategy: this.options.sequenceStrategy } : {}),
-      })
-      this.vaultCache.set(name, comp)
-      return comp
-    }
-
-    const keyring = this.keyringCache.get(name)
-    if (!keyring) {
-      throw new ValidationError(
-        `Vault "${name}" not opened. Use await db.openVault("${name}") first.`,
-      )
-    }
-
-    const comp = new Vault({
-      adapter: this.options.store,
-      name,
-      noydb: this,
-      keyring,
-      encrypted: true,
-      historyConfig: this.options.history,
-      ...(this.options.blobStrategy !== undefined ? { blobStrategy: this.options.blobStrategy } : {}),
-      ...(this.options.objectStore !== undefined ? { objectStore: this.options.objectStore } : {}),
-      ...(this.options.archiveStrategy !== undefined ? { archiveStrategy: this.options.archiveStrategy } : {}),
-      ...(this.options.indexStrategy !== undefined ? { indexStrategy: this.options.indexStrategy } : {}),
-      ...(this.options.lazyStrategy !== undefined ? { lazyStrategy: this.options.lazyStrategy } : {}),
-      ...(this.options.aggregateStrategy !== undefined ? { aggregateStrategy: this.options.aggregateStrategy } : {}),
-      ...(this.options.crdtStrategy !== undefined ? { crdtStrategy: this.options.crdtStrategy } : {}),
-      ...(this.options.tiersStrategy !== undefined ? { tiersStrategy: this.options.tiersStrategy } : {}),
-      ...(this.options.searchStrategy !== undefined ? { searchStrategy: this.options.searchStrategy } : {}),
-      ...(this.options.cargoStrategy !== undefined ? { cargoStrategy: this.options.cargoStrategy } : {}),
-      ...(this.options.brokerStrategy !== undefined ? { brokerStrategy: this.options.brokerStrategy } : {}),
-      ...(this.options.consentStrategy !== undefined ? { consentStrategy: this.options.consentStrategy } : {}),
-      ...(this.options.periodsStrategy !== undefined ? { periodsStrategy: this.options.periodsStrategy } : {}),
-      ...(this.options.shadowStrategy !== undefined ? { shadowStrategy: this.options.shadowStrategy } : {}),
-      ...(this.options.historyStrategy !== undefined ? { historyStrategy: this.options.historyStrategy } : {}),
-      ...(this.options.i18nStrategy !== undefined ? { i18nStrategy: this.options.i18nStrategy } : {}),
-      ...(this.options.syncStrategy !== undefined ? { syncStrategy: this.options.syncStrategy } : {}),
-      ...(this.options.guardStrategies !== undefined ? { guardStrategies: this.options.guardStrategies } : {}),
-      ...(this.options.numbering !== undefined ? { numberingConfigs: this.options.numbering } : {}),
-      emitter: this.emitter,
-    })
-    this.vaultCache.set(name, comp)
-    return comp
+    throw new ValidationError(
+      `Vault "${name}" is not open. Call \`await db.openVault("${name}")\` first — ` +
+        `vault() only returns an already-open vault, because opening involves ` +
+        `async work (registry init, schema fence) that a sync accessor cannot do.`,
+    )
   }
 
   /**

--- a/packages/hub/src/via/blob/active.ts
+++ b/packages/hub/src/via/blob/active.ts
@@ -60,7 +60,8 @@ export interface BlobsService extends BlobStrategy {
  * })
  *
  * // Now live — delegates to BlobSet.
- * await db.vault('acme').collection('invoices').blob('inv-1').put('receipt.pdf', bytes)
+ * const vault = await db.openVault('acme')
+ * await vault.collection('invoices').blob('inv-1').put('receipt.pdf', bytes)
  * ```
  */
 export function withBlobs(options: WithBlobsOptions = {}): BlobsService {

--- a/packages/hub/src/with-audit/forget/index.ts
+++ b/packages/hub/src/with-audit/forget/index.ts
@@ -11,7 +11,8 @@
  *   historyStrategy: withHistory(),               // ledger for the erasure proof
  *   forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
  * })
- * const result = await db.vault('main').forget('buyer-123')
+ * const vault = await db.openVault('main')
+ * const result = await vault.forget('buyer-123')
  * ```
  *
  * The erasure flow (`vault.forget`), the subject-index maintenance hooks, and

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -1173,7 +1173,11 @@ const KERNEL_SURFACE_BUDGET = {
   // beside it. All period-scope logic lives in with-party/team/
   // sync-period-scope.ts + sync.ts; windows resolve through the PUBLIC
   // Vault.listPeriods(), so vault.ts is untouched.
-  'packages/hub/src/kernel/noydb.ts': 2407,
+  'packages/hub/src/kernel/noydb.ts': 2345,
+  // Lowered 2407→2345 (#834 vault() cache-only, 2026-07-26): deleting the two drifted
+  // fallback Vault constructors from vault() removed ~80 lines of duplicated option block.
+  // A test now asserts noydb.ts contains exactly ONE `new Vault(` site — that invariant,
+  // not this ceiling, is what keeps the six-strategy drift from recurring.
   // Lowered 2420→2406 (#826/#798/#812 deprecation cut, 2026-07-26): removed the #799 cover delegators + option key, the dead auth/autoSync/syncInterval options, and the /bundle retirement fallout. Ratchets the #799 bumps back down as their comments promised.
 }
 


### PR DESCRIPTION
Closes #834.

## The bug

`db.vault(name)` carried **two fallback constructors** beside the canonical `#openVaultFresh`, and the encrypted one had drifted — it omitted six strategies: `attestationStrategy`, `classifiedStrategy`, `portabilityStrategy`, `sealedRecordStrategy`, `sequenceStrategy`, `forgetStrategy`. A vault reached that way threw `*NotEnabledError` **for services the caller had configured**, so the error actively misled: it told you to pass a strategy you already passed.

Both fallbacks also skipped the async work `openVault` does (`_initGuards`, `_initDerivations`, `_initMaterializedViews`, `_initOverlayedViews`, `schemaFence.init()`) — unavoidable, since `vault()` is synchronous. So the object they returned was structurally incomplete regardless of the strategy drift.

**Correction to the issue's diagnosis**: the trigger is *not* cache eviction. All three eviction points clear `keyringCache` as well, so the encrypted branch threw rather than constructing. The reachable path is *keyring-loaded-but-never-opened* — e.g. a `grant` before the first `openVault` populates the keyring cache, and `vault()` then builds the defective instance.

## The fix, and why not the one the issue proposed

The issue suggested extracting a shared `#vaultOptionsFrom` builder. That fixes the strategy drift but leaves (a) the async-init gap and (b) a second construction site free to drift again. Instead **`vault()` returns the cached instance or throws** with an actionable message. One construction path; divergence is no longer expressible.

Nothing in the repo relied on the auto-open — all 15 existing `vault()` callers already `openVault` first (full suite passes untouched). Two doc-comment examples were updated to show the open.

## The actual regression guard

A test asserts `noydb.ts` contains **exactly one** `new Vault(` site. This bug survived precisely because nothing asserted that invariant — a ceiling on file length doesn't catch a copy-paste that keeps the file the same size. Six tests total, and the two that matter were **confirmed to fail before the fix** (plaintext auto-open constructed instead of throwing; three construction sites found).

## Verification

Full hub **529 files / 4560 tests** · typecheck · lint · build · bundle-check ✓ · `check:architecture` ✓ with `noydb.ts` **2407→2345** (~80 duplicated lines deleted — a ratchet down, not a bump). Changeset: `@noy-db/hub` minor, breaking for the auto-open pattern.