### PR TITLE
fix(hub)!: refuse sensitive + crdt — silently unsealed (#850); #835 verified unreachable

### DIFF
--- a/packages/hub/__tests__/crdt-write-tail-divergence.test.ts
+++ b/packages/hub/__tests__/crdt-write-tail-divergence.test.ts
@@ -1,0 +1,120 @@
+/**
+ * #835 — verification of the suspected CRDT write-tail divergences.
+ *
+ * `_putInternal`'s CRDT branch re-implements the tail of the normal write
+ * path instead of sharing it, and a code review flagged three helpers the
+ * CRDT branch never calls: `_ensureClassifiedMarker`,
+ * `uniqueConstraints.check/upsert`, and `_toCacheableRecord`.
+ *
+ * These tests establish which of the three is actually reachable. Two are
+ * not — the config layer already refuses the combination that would need
+ * them — and this file pins that reasoning so the next reader doesn't have
+ * to re-derive it (or "fix" a non-bug).
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { memoryStore } from '../src/kernel/memory-store.js'
+import { withCrdt } from '../src/with-commit/crdt/index.js'
+import { withClassified } from '../src/via/classified/index.js'
+import { classified } from '../src/via/classified/presets.js'
+import { withIndexing } from '../src/with-lookup/indexing/index.js'
+
+interface Doc extends Record<string, unknown> { title?: string; email?: string }
+
+async function crdtDb(extra: Record<string, unknown> = {}) {
+  return createNoydb({
+    store: memoryStore(), user: 'alice', encrypt: false,
+    crdtStrategy: withCrdt(), ...extra,
+  })
+}
+
+describe('#835 — CRDT write-tail divergences: which are reachable?', () => {
+  /**
+   * NOT reachable. Guard R2 (`via/classified/guards.ts`) refuses
+   * digest-only/recoverable classified fields on a CRDT collection, with
+   * exactly this reasoning: merge paths bypass write enforcement, and "the
+   * CRDT put branch persists via encryptJsonString with no vdig backstop".
+   * So `vdigFields` can never be non-null on a CRDT collection, and
+   * `_ensureClassifiedMarker` early-returns on `vdigFields === null`.
+   */
+  it('classified digest-only + crdt is REFUSED at config time (so the missing marker is unreachable)', async () => {
+    const db = await crdtDb({ classifiedStrategy: withClassified() })
+    const vault = await db.openVault('acme')
+    expect(() =>
+      vault.collection<Doc>('docs', {
+        crdt: 'lww-map',
+        // `password` is a digest-only preset — the storage class R2 refuses.
+        classifiedFields: { title: classified.password() },
+      }),
+    ).toThrowError(/crdt mode|R2/)
+  })
+
+  /**
+   * Also NOT reachable, for a second reason: `toCacheRecord` only does work
+   * when the envelope carries `_sealed` slots, and the CRDT branch writes
+   * through `encryptJsonString`, which never produces them. With no vdig
+   * fields possible (above) and no `_sealed` present, `_toCacheableRecord`
+   * would be an identity function — caching `resolvedRecord` directly is
+   * equivalent, not a leak.
+   */
+  it('a CRDT envelope carries no _sealed slots (so the skipped cache-normalisation is a no-op)', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, user: 'alice', encrypt: false, crdtStrategy: withCrdt(),
+    })
+    const vault = await db.openVault('acme')
+    const docs = vault.collection<Doc>('docs', { crdt: 'lww-map' })
+    await docs.put('d1', { title: 'hello' })
+    const env = await store.get('acme', 'docs', 'd1')
+    expect(env).not.toBeNull()
+    expect(env?._sealed).toBeUndefined()
+  })
+
+  /**
+   * ALSO NOT reachable — and this was the one I expected to be a real gap.
+   * `resolveCollectionConfig` refuses a unique index on a CRDT collection
+   * outright (`UnsupportedIndexOptionError`: "crdt mode is incompatible with
+   * eager unique enforcement"), so `uniqueConstraints` is always null there
+   * and the un-called `check`/`upsert` cannot matter.
+   */
+  it('unique index + crdt is REFUSED at config time (so the missing check is unreachable)', async () => {
+    const db = await crdtDb({ indexStrategy: withIndexing() })
+    const vault = await db.openVault('acme')
+    expect(() =>
+      vault.collection<Doc>('docs', {
+        crdt: 'lww-map',
+        indexes: [{ fields: ['email'], unique: true }],
+      }),
+    ).toThrowError(/unique indexes are not supported on CRDT/)
+  })
+
+  /**
+   * The one REAL hole this investigation found — now closed (#850).
+   *
+   * `sensitive` promises each field its own `_sealed` slot under an
+   * HKDF-derived per-field key. The CRDT branch never seals, so the fields
+   * were silently stored in the ordinary encrypted body: no per-field key,
+   * no slot, no error. Verified empirically before the fix — a non-CRDT
+   * collection produced `_sealed: { secret: … }` while the CRDT one produced
+   * nothing. Refused at config time now, matching the embeddings / unique /
+   * R2 precedents.
+   */
+  it('sensitive + crdt is REFUSED at config time (#850 — it used to be silently ignored)', async () => {
+    const db = await crdtDb()
+    const vault = await db.openVault('acme')
+    expect(() =>
+      vault.collection<Doc>('docs-sealed', { crdt: 'lww-map', sensitive: ['title'] }),
+    ).toThrowError(/sensitive .* not supported on CRDT|bypasses per-field sealing/)
+  })
+
+  it('sensitive still seals normally on a NON-crdt collection (the control)', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'alice', secret: 'pw-835-control' })
+    const vault = await db.openVault('acme')
+    const plain = vault.collection<Doc>('plain', { sensitive: ['title'] })
+    await plain.put('p1', { title: 'secret-value' })
+    const env = await store.get('acme', 'plain', 'p1')
+    expect(env?._sealed).toBeDefined()
+    expect(Object.keys(env?._sealed ?? {})).toContain('title')
+  })
+})

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -928,6 +928,23 @@ export function resolveCollectionConfig<T>(opts: CollectionOpts<T>) {
     )
   }
 
+  // Guard (#850): `sensitive` promises each field its own `_sealed` slot under
+  // an HKDF-derived per-field key, but the CRDT branch of `_putInternal`
+  // persists through `encryptJsonString` and returns before any sealing runs —
+  // so the fields were silently stored in the ordinary body instead, with no
+  // error. Refuse, matching what embeddings / unique indexes / classified
+  // digest-only (R2) already do for the same underlying reason: the CRDT write
+  // path bypasses the pipeline these options are enforced by. Fail loud rather
+  // than deliver less encryption than the caller asked for.
+  if (opts.sensitive && opts.sensitive.length > 0 && opts.crdt) {
+    throw new Error(
+      `Collection "${opts.name}": sensitive (structural group-encryption) is not supported on ` +
+        `CRDT collections — the CRDT write path bypasses per-field sealing, so the fields would ` +
+        `be stored in the ordinary encrypted body with no \`_sealed\` slot and no per-field key. ` +
+        `Use a non-CRDT collection for sealed fields.`,
+    )
+  }
+
   // #724 I1 — a tiered collection that declares blobFields must opt into
   // perRecordKeys: legacy (non-perRecordKeys) blobs have no per-blob `_cek`,
   // so `rehomeForTier` cannot rewrap/re-put them under a tier DEK on


### PR DESCRIPTION
Closes #850. Closes #835 (verified — no fix needed there, see below).

## #835: all three suspected divergences are unreachable

The CRDT branch of `_putInternal` does skip `_ensureClassifiedMarker`, `uniqueConstraints.check/upsert` and `_toCacheableRecord` — but every combination that would need them is already refused at config time:

| Suspected gap | Why it can't be reached |
|---|---|
| missing classified marker | guard **R2** refuses digest-only/recoverable classified fields + `crdt` — its comment even names this reason: *"the CRDT put branch persists via encryptJsonString with no vdig backstop"*. With `vdigFields === null`, `_ensureClassifiedMarker` early-returns. |
| unique constraint not enforced | `resolveCollectionConfig` throws `UnsupportedIndexOptionError` for unique + `crdt`, so `uniqueConstraints` is always null. |
| cache not normalised | `toCacheRecord` only acts on `_sealed` slots, which `encryptJsonString` never produces — so it is an identity function on CRDT envelopes. |

**Five guard tests pin exactly this**, so if any of those refusals is ever relaxed, they fail and point at the write tail that must be fixed first. The "security-adjacent" concern I raised when filing #835 (vdig plaintext reaching the working-set cache) is **false** — R2 makes it impossible.

## #850: the real hole the investigation found

`sensitive: [...]` was **accepted on a CRDT collection and silently ignored**. Verified empirically with an identical declaration on both:

| Collection | `_sealed` slot |
|---|---|
| non-CRDT | **yes** — `_sealed: { secret: … }` |
| `crdt: 'lww-map'` | **no** |

Not a plaintext leak (the body stays AES-GCM-encrypted under the collection DEK — confirmed `_iv` present and the value absent from raw `_data`), but the caller requested per-field HKDF-derived sealing and received ordinary body encryption with no slot, no per-field key, and **no error**.

Now refused at construction, matching the three precedents above. Implementing sealing inside the CRDT branch is the alternative, but that is a much larger change for a combination with no known consumer, and a refusal can be relaxed later. Fail loud beats quietly encrypting less than was asked for.

## Verification

Full hub **530 files / 4565 tests** · typecheck · lint · build · bundle-check ✓ · `check:architecture` ✓. Nothing in the repo used `sensitive` + `crdt`. Changeset: `@noy-db/hub` minor.
